### PR TITLE
NSA-1549- add org back button bug

### DIFF
--- a/src/app/users/views/associateOrganisation.ejs
+++ b/src/app/users/views/associateOrganisation.ejs
@@ -1,4 +1,8 @@
+<% if (canSkip) { %>
 <a href="new-user" class="link-back">Back</a>
+<% } else { %>
+<a href="organisations" class="link-back">Back</a>
+<% } %>
 <div class="grid-row">
     <div class="col-8">
         <h1 class="heading-xlarge">


### PR DESCRIPTION
Fixed bug that caused an error when in support trying to add an org to existing user and pressing the back button due to this page being used in 2 instances.