### PR TITLE
NSA-1831 - Check JWT expiry when validation session expiry

### DIFF
--- a/src/infrastructure/oidc/index.js
+++ b/src/infrastructure/oidc/index.js
@@ -30,12 +30,12 @@ const getPassportStrategy = async () => {
   });
 };
 
-const hasJwtExpired = async (exp) => {
+const hasJwtExpired = (exp) => {
   if (!exp) {
     return true;
   }
 
-  const expires = new Date(Date.UTC(1970, 0, 1) + (user.exp * 1000)).getTime();
+  const expires = new Date(Date.UTC(1970, 0, 1) + (exp * 1000)).getTime();
   const now = Date.now();
   return expires < now;
 };

--- a/src/infrastructure/oidc/index.js
+++ b/src/infrastructure/oidc/index.js
@@ -73,13 +73,20 @@ const init = async (app) => {
         return res.redirect('/');
       }
 
-      const supportClaims = await getUserSupportClaims(user.sub);
+      const userDetails = {
+        sub: user.sub,
+        email: user.email,
+        exp: user.exp,
+        id_token: user.id_token,
+      };
+
+      const supportClaims = await getUserSupportClaims(userDetails.sub);
       if (!supportClaims || !supportClaims.isSupportUser) {
         if (!req.session.redirectUrl.toLowerCase().endsWith('signout')) {
           return res.redirect('/not-authorised');
         }
       } else {
-        Object.assign(user, supportClaims);
+        Object.assign(userDetails, supportClaims);
       }
 
       if (req.session.redirectUrl) {
@@ -87,7 +94,7 @@ const init = async (app) => {
         req.session.redirectUrl = null;
       }
 
-      return req.logIn(user, (loginErr) => {
+      return req.logIn(userDetails, (loginErr) => {
         if (loginErr) {
           logger.error(`Login error in auth callback - ${loginErr}`);
           return next(loginErr);


### PR DESCRIPTION
Will enforce the hard expiry that is defined in the original JWT login. This is currently whatever OIDC sends (an hour at present I believe). This feels OK when working with a sliding 30 minute window of the session cookie itself.

I have also noticed that we store the whole JWT data in the user details, but only ever use sub, email and now exp. We could probably remove the rest of the data in the original login to make the cookie a bit more light weight.