### PR TITLE
NSA-2073 - allow invitation reactivation

### DIFF
--- a/src/app/users/getConfirmInvitationReactivate.js
+++ b/src/app/users/getConfirmInvitationReactivate.js
@@ -1,0 +1,9 @@
+const { sendResult } = require('./../../infrastructure/utils');
+
+const getConfirmInvitationReactivate = async (req, res) => {
+  sendResult(req, res, 'users/views/confirmInvitationReactivate', {
+    csrfToken: req.csrfToken(),
+  });
+};
+
+module.exports = getConfirmInvitationReactivate;

--- a/src/app/users/index.js
+++ b/src/app/users/index.js
@@ -19,6 +19,8 @@ const getConfirmInvitationDeactivate = require('./getConfirmInvitationDeactivate
 const postConfirmInvitationDeactivate = require('./postConfirmInvitationDeactivate');
 const getConfirmReactivate = require('./getConfirmReactivate');
 const postConfirmReactivate = require('./postConfirmReactivate');
+const getConfirmInvitationReactivate = require('./getConfirmInvitationReactivate');
+const postConfirmInvitationReactivate = require('./postConfirmInvitationReactivate');
 const getNewUser = require('./getNewUser');
 const postNewUser = require('./postNewUser');
 const getAssociateOrganisation = require('./getAssociateOrganisation');
@@ -107,6 +109,9 @@ const users = (csrf) => {
 
   router.get('/:uid/confirm-reactivation', csrf, asyncWrapper(getConfirmReactivate));
   router.post('/:uid/confirm-reactivation', csrf, asyncWrapper(postConfirmReactivate));
+
+  router.get('/:uid/confirm-invitation-reactivation', csrf, asyncWrapper(getConfirmInvitationReactivate));
+  router.post('/:uid/confirm-invitation-reactivation', csrf, asyncWrapper(postConfirmInvitationReactivate));
 
   router.post('/:uid/cancel-change-email', csrf, asyncWrapper(postCancelChangeEmail));
 

--- a/src/app/users/postConfirmInvitationReactivate.js
+++ b/src/app/users/postConfirmInvitationReactivate.js
@@ -1,0 +1,41 @@
+const logger = require('./../../infrastructure/logger');
+const { getUserDetails, getUserDetailsById, updateUserDetails, waitForIndexToUpdate } = require('./utils');
+const { reactivateInvite } = require('./../../infrastructure/directories');
+
+const updateUserIndex = async (uid, correlationId) => {
+  const user = await getUserDetailsById(uid, correlationId);
+  user.status.id = 1;
+  user.status.description = 'Reactivated Invitation';
+
+  await updateUserDetails(user, correlationId);
+
+  await waitForIndexToUpdate(uid, (updated) => updated.status.id === 1);
+};
+
+const postConfirmReactivate = async (req, res) => {
+  const user = await getUserDetails(req);
+
+  await reactivateInvite(user.id, req.body.reason, req.id);
+  await updateUserIndex(user.id, req.id);
+
+  logger.audit(`${req.user.email} (id: ${req.user.sub}) reactivated user invitation ${user.email} (id: ${user.id})`, {
+    type: 'support',
+    subType: 'user-edit',
+    userId: req.user.sub,
+    userEmail: req.user.email,
+    editedUser: user.id,
+    editedFields: [
+      {
+        name: 'status',
+        oldValue: user.status.id,
+        newValue: 1,
+      }
+    ],
+    reason: req.body.reason,
+  });
+
+  res.flash('info', 'The invitation has been reactivated');  
+  res.redirect('services');
+};
+
+module.exports = postConfirmReactivate;

--- a/src/app/users/views/confirmInvitationReactivate.ejs
+++ b/src/app/users/views/confirmInvitationReactivate.ejs
@@ -1,0 +1,19 @@
+<div class="row">
+    <div class="col-12">
+        <h1 class="heading-xlarge">
+            Confirm invitation reactivation
+        </h1>
+    </div>
+    <div class="col-12">
+        <form method="post" id="form-reactivate">
+            <input type="hidden" name="_csrf" value="<%= csrfToken %>"/>
+
+            <p>Please confirm you would like to reactivate the invitation.</p>
+
+            <div class="form-submit submit-buttons">
+                <button type="submit" class="button">Reactivate</button>
+                <a href="services" name="cancel" class="button button-secondary">Cancel</a>
+            </div>
+        </form>
+    </div>
+</div>

--- a/src/app/users/views/summaryPartial.ejs
+++ b/src/app/users/views/summaryPartial.ejs
@@ -13,6 +13,21 @@
     </div>
 </div>
 <% } %>
+<% if(locals.user.status.id === -2) { %>
+    <div class="row">
+        <div class="col-12">
+            <div class="notification">
+                <p>
+                    This account invitation was deactivated
+                    <% if(locals.user.status.changedOn) { %>
+                    on <%= locals.moment(locals.user.status.changedOn).format('DD MMM YYYY') %>.
+                    <% } %>
+                    <a href="confirm-invitation-reactivation" class="action">Reactivate invitation</a>
+                </p>
+            </div>
+        </div>
+    </div>
+    <% } %>
 <% if(locals.user.pendingEmail) { %>
 <div class="notification notification-information" tabindex="0">
     <h2>Pending email address change</h2>
@@ -69,17 +84,22 @@
                 <li><a href="web-service-sync">Send WS Sync</a></li>
             </ul>
         </aside>
-        <% } else if (locals.isInvitation && !locals.user.deactivated) { %>
+        <% } else if (locals.isInvitation) { %>
         <aside>
             <h2 class="heading-medium">Actions</h2>
             <ul class="list">
-                <li><a href="associate-organisation">Add organisation</a></li>
-                <% if (locals.organisations.length > 0) { %>
-                    <li><a href="select-organisation">Add services</a></li>
+                <% if (!locals.user.deactivated) { %>
+                    <li><a href="associate-organisation">Add organisation</a></li>
+                    <% if (locals.organisations.length > 0) { %>
+                        <li><a href="select-organisation">Add services</a></li>
+                    <% } %>
+                    <li><a href="edit-email">Change user's email address</a></li>
+                    <li><a href="confirm-invitation-deactivation">Deactivate user</a></li>
+                    <li><a href="resend-invitation"> Resend invitation email</a></li>
                 <% } %>
-                <li><a href="edit-email">Change user's email address</a></li>
-                <li><a href="confirm-invitation-deactivation">Deactivate user</a></li>
-                <li><a href="resend-invitation"> Resend invitation email</a></li>
+                <% if (locals.user.deactivated) { %>
+                    <li><a href="confirm-invitation-reactivation"> Reactivate user</a></li>
+                <% } %>
             </ul>
         </aside>
         <% } %>

--- a/src/app/users/views/summaryPartial.ejs
+++ b/src/app/users/views/summaryPartial.ejs
@@ -66,24 +66,38 @@
         </dl>
     </div>
     <div class="col-4">
-        <% if(!locals.isInvitation && !locals.user.deactivated) { %>
-        <aside>
-            <h2 class="heading-medium">Actions</h2>
-            <ul class="list">
-                <li><a href="associate-organisation">Add organisation</a></li>
-                <% if (locals.organisations.length > 0) { %>
-                    <li><a href="select-organisation">Add services</a></li>
-                <% } %>
-                <li><a href="edit-email">Change user's email address</a></li>
-                <% if(locals.user.status.id === 0) { %>
-                    <li><a href="confirm-reactivation">Reactivate user</a></li>
-                <% } else { %>
-                    <li><a href="confirm-deactivation">Deactivate user</a></li>
-                <% } %>
-                <li><a href="edit-profile">Edit user's details</a></li>
-                <li><a href="web-service-sync">Send WS Sync</a></li>
-            </ul>
-        </aside>
+        <% if(!locals.isInvitation) { %>
+            <aside>
+                <h2 class="heading-medium">Actions</h2>
+                <ul class="list">
+                    <li><a href="associate-organisation">Add organisation</a></li>
+                    <% if (locals.organisations.length > 0) { %>
+                        <li><a href="select-organisation">Add services</a></li>
+                    <% } %>
+                    <li><a href="edit-email">Change user's email address</a></li>
+                    <% if(locals.user.status.id === 0) { %>
+                        <li><a href="confirm-reactivation">Reactivate user</a></li>
+                    <% } else { %>
+                        <li><a href="confirm-deactivation">Deactivate user</a></li>
+                    <% } %>
+                    <li><a href="edit-profile">Edit user's details</a></li>
+                    <li><a href="web-service-sync">Send WS Sync</a></li>
+                </ul>
+            </aside>
+        <% } else if (locals.isInvitation && !locals.user.deactivated) { %>
+            <aside>
+                <h2 class="heading-medium">Actions</h2>
+                <ul class="list">
+                    <li><a href="associate-organisation">Add organisation</a></li>
+                    <% if (locals.organisations.length > 0) { %>
+                        <li><a href="select-organisation">Add services</a></li>
+                    <% } %>
+                    <li><a href="edit-email">Change user's email address</a></li>
+                    <li><a href="confirm-invitation-deactivation">Deactivate user</a></li>
+                    <li><a href="resend-invitation"> Resend invitation email</a></li>
+                </ul>
+            </aside>
+        <% } %>
     </div>
 </div>
 

--- a/src/app/users/views/summaryPartial.ejs
+++ b/src/app/users/views/summaryPartial.ejs
@@ -66,7 +66,7 @@
         </dl>
     </div>
     <div class="col-4">
-        <% if(!locals.isInvitation) { %>
+        <% if(!locals.isInvitation && !locals.user.deactivated) { %>
         <aside>
             <h2 class="heading-medium">Actions</h2>
             <ul class="list">
@@ -84,25 +84,6 @@
                 <li><a href="web-service-sync">Send WS Sync</a></li>
             </ul>
         </aside>
-        <% } else if (locals.isInvitation) { %>
-        <aside>
-            <h2 class="heading-medium">Actions</h2>
-            <ul class="list">
-                <% if (!locals.user.deactivated) { %>
-                    <li><a href="associate-organisation">Add organisation</a></li>
-                    <% if (locals.organisations.length > 0) { %>
-                        <li><a href="select-organisation">Add services</a></li>
-                    <% } %>
-                    <li><a href="edit-email">Change user's email address</a></li>
-                    <li><a href="confirm-invitation-deactivation">Deactivate user</a></li>
-                    <li><a href="resend-invitation"> Resend invitation email</a></li>
-                <% } %>
-                <% if (locals.user.deactivated) { %>
-                    <li><a href="confirm-invitation-reactivation"> Reactivate user</a></li>
-                <% } %>
-            </ul>
-        </aside>
-        <% } %>
     </div>
 </div>
 

--- a/src/infrastructure/config/schema.js
+++ b/src/infrastructure/config/schema.js
@@ -111,6 +111,7 @@ const schedulesSchema = new SimpleSchema({
 
 const togglesSchema = new SimpleSchema({
   useGenericAddUser: Boolean,
+  canReactivateInvitations: Boolean,
 });
 
 const notificationsSchema = new SimpleSchema({

--- a/src/infrastructure/config/schema.js
+++ b/src/infrastructure/config/schema.js
@@ -111,7 +111,6 @@ const schedulesSchema = new SimpleSchema({
 
 const togglesSchema = new SimpleSchema({
   useGenericAddUser: Boolean,
-  canReactivateInvitations: Boolean,
 });
 
 const notificationsSchema = new SimpleSchema({

--- a/src/infrastructure/directories/api.js
+++ b/src/infrastructure/directories/api.js
@@ -264,7 +264,7 @@ const reactivateInvite = async (id, reason, correlationId) => {
       },
       body: {
         reason: reason,
-        deactivated: true,
+        deactivated: false,
       },
       json: true,
     });

--- a/src/infrastructure/directories/api.js
+++ b/src/infrastructure/directories/api.js
@@ -252,6 +252,27 @@ const deactivateInvite = async (id, reason, correlationId) => {
   }
 };
 
+const reactivateInvite = async (id, reason, correlationId) => {
+  try {
+    const token = await jwtStrategy(config.directories.service).getBearerToken();
+    await rp({
+      method: 'PATCH',
+      uri: `${config.directories.service.url}/invitations/${id.replace('inv-', '')}`,
+      headers: {
+        authorization: `bearer ${token}`,
+        'x-correlation-id': correlationId,
+      },
+      body: {
+        reason: reason,
+        deactivated: true,
+      },
+      json: true,
+    });
+  } catch (e) {
+    console.log(e);
+  }
+};
+
 const createInvite = async (givenName, familyName, email, digipassSerialNumber, clientId, redirectUri, correlationId, overrides) => {
   const token = await jwtStrategy(config.directories.service).getBearerToken();
 
@@ -522,6 +543,7 @@ module.exports = {
   createInvite,
   updateInvite,
   deactivateInvite,
+  reactivateInvite,
   createUserDevice,
   deleteUserDevice,
   createChangeEmailCode,

--- a/src/infrastructure/directories/static.js
+++ b/src/infrastructure/directories/static.js
@@ -91,6 +91,10 @@ const deactivateInvite = async (inviteId, reason, correlationId) => {
   return Promise.resolve(uuid());
 };
 
+const reactivateInvite = async (inviteId, reason, correlationId) => {
+  return Promise.resolve(uuid());
+};
+
 const createUserDevice = async () => {
   return Promise.resolve();
 };
@@ -132,6 +136,7 @@ module.exports = {
   createInvite,
   updateInvite,
   deactivateInvite,
+  reactivateInvite,
   createUserDevice,
   createChangeEmailCode,
   getChangeEmailCode,

--- a/test/app/syncViews/syncUsersView.syncDiffUsersView.test.js
+++ b/test/app/syncViews/syncUsersView.syncDiffUsersView.test.js
@@ -135,7 +135,7 @@ const testData = {
       user1: {
         lastLogin: new Date(2018, 7, 6),
         lastStatusChange: undefined,
-        loginsInPast12Months: [{ timestamp: new Date(2018, 7, 4) }, { timestamp: new Date(2018, 7, 5) }, { timestamp: new Date(2018, 7, 6) }]
+        loginsInPast12Months: [{ timestamp: new Date(2019, 7, 4) }, { timestamp: new Date(2019, 7, 5) }, { timestamp: new Date(2019, 7, 6) }]
       },
     },
   },

--- a/test/app/syncViews/syncUsersView.syncFullUsersView.test.js
+++ b/test/app/syncViews/syncUsersView.syncFullUsersView.test.js
@@ -95,7 +95,7 @@ const testData = {
       user1: {
         lastLogin: new Date(2018, 7, 6),
         lastStatusChange: undefined,
-        loginsInPast12Months: [{timestamp:new Date(2018, 7, 4)},{timestamp:new Date(2018, 7, 5)},{timestamp:new Date(2018, 7, 6)}]
+        loginsInPast12Months: [{timestamp:new Date(2019, 7, 4)},{timestamp:new Date(2019, 7, 5)},{timestamp:new Date(2019, 7, 6)}]
       },
     },
   },

--- a/test/app/users/getConfirmInvitationReactivate.test.js
+++ b/test/app/users/getConfirmInvitationReactivate.test.js
@@ -1,0 +1,41 @@
+const get = require('./../../../src/app/users/getConfirmInvitationReactivate');
+
+describe('When processing a get for a user invitation reactivate request', () => {
+  let req;
+  let res;
+
+  beforeEach(() => {
+    req = {
+      method: 'GET',
+      params: {
+        uid: '123-456-789',
+      },
+      csrfToken: () => {
+        return 'token';
+      },
+      accepts: () => {
+        return ['text/html'];
+      },
+    };
+
+    res = {
+      render: jest.fn(),
+    };
+
+  });
+
+  test('then it should render the userDevice view', async () => {
+    await get(req, res);
+
+    expect(res.render.mock.calls[0][0]).toBe('users/views/confirmInvitationReactivate');
+  });
+
+  test('then it should include csrf token', async () => {
+    await get(req, res);
+
+    expect(res.render.mock.calls[0][1]).toMatchObject({
+      csrfToken: 'token',
+    });
+  });
+
+});

--- a/test/app/users/postConfirmInvitationReactivate.test.js
+++ b/test/app/users/postConfirmInvitationReactivate.test.js
@@ -35,6 +35,13 @@ describe('When processing a post for a user invitation reactivate request', () =
     updateUserDetails.mockReset();
   });
 
+  it('then the user is redirected to the services page', async () => {
+    await post(req, res);
+
+    expect(res.redirect.mock.calls).toHaveLength(1);
+    expect(res.redirect.mock.calls[0][0]).toBe('services');
+  });
+
   test('then it updates the user setting the status to reactivated', async () => {
     await post(req, res);
 

--- a/test/app/users/postConfirmInvitationReactivate.test.js
+++ b/test/app/users/postConfirmInvitationReactivate.test.js
@@ -1,0 +1,72 @@
+jest.mock('./../../../src/infrastructure/config', () => require('./../../utils').configMockFactory({}));
+jest.mock('./../../../src/infrastructure/directories');
+jest.mock('./../../../src/app/users/utils');
+jest.mock('./../../../src/infrastructure/logger', () => require('./../../utils').loggerMockFactory());
+
+const { getRequestMock } = require('./../../utils');
+const post = require('./../../../src/app/users/postConfirmInvitationReactivate');
+const { getUserDetails, getUserDetailsById, updateUserDetails } = require('./../../../src/app/users/utils');
+const logger = require('./../../../src/infrastructure/logger');
+const { reactivateInvite } = require('./../../../src/infrastructure/directories');
+
+describe('When processing a post for a user invitation reactivate request', () => {
+  const expectedUserId = 'uid-user-1';
+
+  let req;
+  let res;
+
+  beforeEach(() => {
+    req = getRequestMock({
+      body: {
+        reason: 'reactivate the invitation',
+      },
+    });
+
+    res = {
+      redirect: jest.fn(),
+      flash: jest.fn(),
+    };
+
+
+    getUserDetails.mockReset().mockReturnValue({ id: expectedUserId, status: { id: 1 } });
+
+    getUserDetailsById.mockReset().mockReturnValue({ id: expectedUserId, status: { id: 1 } });
+
+    updateUserDetails.mockReset();
+  });
+
+  test('then it updates the user setting the status to reactivated', async () => {
+    await post(req, res);
+
+    expect(reactivateInvite.mock.calls).toHaveLength(1);
+    expect(reactivateInvite.mock.calls[0][0]).toBe(expectedUserId);
+    expect(reactivateInvite.mock.calls[0][1]).toBe('reactivate the invitation');
+    expect(reactivateInvite.mock.calls[0][2]).toBe(req.id);
+  });
+
+  test('then the user index is updated', async () => {
+    await post(req, res);
+
+    expect(updateUserDetails.mock.calls).toHaveLength(1);
+    expect(updateUserDetails.mock.calls[0][0]).toMatchObject({
+      status: {
+        id: 1,
+        description: 'Reactivated Invitation',
+      }
+    })
+  });
+
+  it('then the event is audited', async () => {
+    await post(req, res);
+
+    expect(logger.audit.mock.calls).toHaveLength(1);
+  });
+
+  it('then a flash message is shown to the user', async () => {
+    await post(req, res);
+
+    expect(res.flash.mock.calls).toHaveLength(1);
+    expect(res.flash.mock.calls[0][0]).toBe('info');
+    expect(res.flash.mock.calls[0][1]).toBe('The invitation has been reactivated')
+  });
+});

--- a/test/infrastructure/directories/api.reactivateInvite.test.js
+++ b/test/infrastructure/directories/api.reactivateInvite.test.js
@@ -1,0 +1,78 @@
+jest.mock('login.dfe.request-promise-retry');
+jest.mock('login.dfe.jwt-strategies');
+jest.mock('./../../../src/infrastructure/config', () => require('./../../utils').configMockFactory({
+  directories: {
+    type: 'api',
+    service: {
+      url: 'http://directories.test',
+    },
+  },
+}));
+
+const rp = jest.fn();
+const requestPromise = require('login.dfe.request-promise-retry');
+requestPromise.defaults.mockReturnValue(rp);
+
+const jwtStrategy = require('login.dfe.jwt-strategies');
+const { reactivateInvite } = require('./../../../src/infrastructure/directories/api');
+
+const correlationId = 'abc123';
+const invitationId = 'invite1';
+const reason = 'invite deactivated by mistake';
+
+describe('when reactivating an invite from the directories api', () => {
+  beforeEach(() => {
+    rp.mockReset();
+    rp.mockImplementation(() => {
+
+    });
+
+    jwtStrategy.mockReset();
+    jwtStrategy.mockImplementation(() => {
+      return {
+        getBearerToken: jest.fn().mockReturnValue('token'),
+      };
+    })
+  });
+
+  it('then it should call invitations resource with invitation id', async () => {
+    await reactivateInvite(invitationId, reason, correlationId);
+
+    expect(rp.mock.calls).toHaveLength(1);
+    expect(rp.mock.calls[0][0]).toMatchObject({
+      method: 'PATCH',
+      uri: 'http://directories.test/invitations/invite1',
+    });
+  });
+
+  it('then the reason for reactivate is in the body', async () => {
+    await reactivateInvite(invitationId, reason, correlationId);
+
+    expect(rp.mock.calls[0][0]).toMatchObject({
+      body: {
+        reason: 'invite deactivated by mistake',
+        deactivated: true,
+      },
+    });
+  });
+
+  it('then it should use the token from jwt strategy as bearer token', async () => {
+    await reactivateInvite(invitationId, reason, correlationId);
+
+    expect(rp.mock.calls[0][0]).toMatchObject({
+      headers: {
+        authorization: 'bearer token',
+      },
+    });
+  });
+
+  it('then it should include the correlation id', async () => {
+    await reactivateInvite(invitationId, reason, correlationId);
+
+    expect(rp.mock.calls[0][0]).toMatchObject({
+      headers: {
+        'x-correlation-id': correlationId,
+      },
+    });
+  });
+});

--- a/test/infrastructure/directories/api.reactivateInvite.test.js
+++ b/test/infrastructure/directories/api.reactivateInvite.test.js
@@ -51,7 +51,7 @@ describe('when reactivating an invite from the directories api', () => {
     expect(rp.mock.calls[0][0]).toMatchObject({
       body: {
         reason: 'invite deactivated by mistake',
-        deactivated: true,
+        deactivated: false,
       },
     });
   });


### PR DESCRIPTION
Changes:
- Users that have been deactivated before accepting an invite can now be reactivated
- Warning banner added to profile summary of users with status === -2 (Deactivated Invitation)
- Actions menu also has a link to reactivate the invitation
- New API method added to directories client for handling reactivations.
