### PR TITLE
Feature/nsa 6389 name wrapping users list

### DIFF
--- a/src/app/organisations/views/_organisationSummary.ejs
+++ b/src/app/organisations/views/_organisationSummary.ejs
@@ -9,7 +9,7 @@
 <% } %>
 <div class="row">
     <div class="col-8">
-        <h1 class="heading-xlarge">
+        <h1 class="heading-xlarge breakable">
             <span class="heading-secondary"><%= organisation.category.name %></span>
             <%= organisation.name %>
         </h1>

--- a/src/app/organisations/views/_organisationSummary.ejs
+++ b/src/app/organisations/views/_organisationSummary.ejs
@@ -9,7 +9,7 @@
 <% } %>
 <div class="row">
     <div class="col-8">
-        <h1 class="heading-xlarge breakable">
+        <h1 class="heading-xlarge heading-breakable">
             <span class="heading-secondary"><%= organisation.category.name %></span>
             <%= organisation.name %>
         </h1>

--- a/src/app/organisations/views/search.ejs
+++ b/src/app/organisations/views/search.ejs
@@ -155,7 +155,7 @@ const paginationModel = {
                     <% } %>
                     <% for (let i = 0; i < locals.organisations.length; i++) { %>
                         <tr>
-                            <td><a href="/organisations/<%= organisations[i].id %>/"><%= organisations[i].name %></a></td>
+                            <td class="breakable"><a href="/organisations/<%= organisations[i].id %>/"><%= organisations[i].name %></a></td>
                             <td><%= organisations[i].category ? organisations[i].category.name : '' %></td>
                             <td><%= organisations[i].urn %></td>
                             <td><%= organisations[i].uid %></td>

--- a/src/app/organisations/views/users.ejs
+++ b/src/app/organisations/views/users.ejs
@@ -29,16 +29,16 @@ const paginationModel = {
             <%users.forEach((user) => {%>
                 <tr>
                     <td class="breakable"><a href="/users/<%=user.id%>"><%=user.name%></a></td>
-                    <td><%=user.email%></td>
-                    <td><%=user.organisation.role.description%></td>
-                    <td>
+                    <td class="breakable"><%=user.email%></td>
+                    <td class="breakable"><%=user.organisation.role.description%></td>
+                    <td class="breakable">
                         <% if (user.lastLogin) {%>
                             <%=locals.moment(user.lastLogin).fromNow()%>
                         <% } else {%>
                             Never
                         <% } %>
                     </td>
-                    <td><%=user.status.description%></td>
+                    <td class="breakable"><%=user.status.description%></td>
                 </tr>
             <%})%>
             </tbody>

--- a/src/app/organisations/views/users.ejs
+++ b/src/app/organisations/views/users.ejs
@@ -28,7 +28,7 @@ const paginationModel = {
             <tbody>
             <%users.forEach((user) => {%>
                 <tr>
-                    <td><a href="/users/<%=user.id%>"><%=user.name%></a></td>
+                    <td class="breakable"><a href="/users/<%=user.id%>"><%=user.name%></a></td>
                     <td><%=user.email%></td>
                     <td><%=user.organisation.role.description%></td>
                     <td>

--- a/src/app/sharedViews/layout.ejs
+++ b/src/app/sharedViews/layout.ejs
@@ -10,7 +10,6 @@
     <link rel="stylesheet" href="<%= locals.urls.assets %>/css/govuk/fonts.css?version=<%= locals.assets.version %>">
     <link rel="stylesheet" href="<%= locals.urls.assets %>/css/govuk/govuk-template.css?version=<%= locals.assets.version %>">
     <link rel="stylesheet" href="<%= locals.urls.assets %>/css/screen.css?version=<%= locals.assets.version %>">
-    <link rel="stylesheet" href="<%= locals.urls.assets %>/gds-upgrade/css/screen.css?version=<%= locals.assets.version %>">
 
     <link rel="shortcut icon" href="<%= locals.urls.assets %>/images/favicon.ico" type="image/x-icon"/>
 

--- a/src/app/users/views/audit.ejs
+++ b/src/app/users/views/audit.ejs
@@ -51,5 +51,5 @@
             <% } %>
             </tbody>
         </table>
+        <%- include('../../sharedViews/pagination', paginationModel); %>
     </div>
-<%- include('../../sharedViews/pagination', paginationModel); %>

--- a/src/app/users/views/audit.ejs
+++ b/src/app/users/views/audit.ejs
@@ -24,28 +24,32 @@
 %>
 
 <%- include('../../sharedViews/pagination', paginationModel); %>
-
-<div class="col-12 text-break"> 
-	<div class="row data border-bottom-black-2px">
-		<div class="col-2 text-smaller-right-padding-5px">Date</div>
-		<div class="col-3 text-smaller-right-padding-5px">Event</div>
-		<div class="col-1 text-smaller-right-padding-5px">Service</div>
-		<div class="col-2 text-smaller-right-padding-5px">Organisation</div>
-		<div class="col-1 text-smaller-right-padding-5px">Result</div>
-		<div class="col-3 text-smaller-right-padding-5px">User</div>
-	</div>		
-	
-	<% for(let a = 0;a < locals.audits.length; a++) { %>
-	<% const audit = locals.audits[a]; %>
-		<div class="row data border-bottom-gray-1px">
-			<div class="col-2 text-smaller-right-padding-5px"><%= locals.moment(audit.timestamp).format('DD/MMM/YYYY HH:mm:ss') %></div>
-			<div class="col-3 text-smaller-right-padding-5px"><%= audit.event.description %>&nbsp;</div>
-			<div class="col-1 text-smaller-right-padding-5px"><%= audit.service ? audit.service.name : '' %>&nbsp;</div>
-			<div class="col-2 text-smaller-right-padding-5px"><%= audit.organisation ? audit.organisation.name: '' %>&nbsp;</div>
-			<div class="col-1 text-smaller-right-padding-5px"><%= audit.result ? 'Success' : 'Failure' %></div>
-			<div class="col-3 text-smaller-right-padding-5px"><%= audit.user ? audit.user.name : '' %>&nbsp;</div>
-		</div>
-	<% } %>
-</div>
-
+<div class="row">
+    <div class="col-12">
+        <table class="data">
+            <thead>
+                <tr>
+                    <th scope="col" class="cwp-20">Date</th>
+                    <th scope="col" class="cwp-30">Event</th>
+                    <th scope="col" class="cwp-15">Service</th>
+                    <th scope="col" class="cwp-10">Organisation</th>
+                    <th scope="col" class="cwp-10">Result</th>
+                    <th scope="col" class="cwp-15">User</th>
+                </tr>
+            </thead>
+            <tbody>
+            <% for(let a = 0;a < locals.audits.length; a++) { %>
+            <% const audit = locals.audits[a]; %>
+                <tr>
+                    <td><%= locals.moment(audit.timestamp).format('DD/MMM/YYYY HH:mm:ss') %></td>
+                    <td class="breakable"><%= audit.event.description %></td>
+                    <td class="breakable"><%= audit.service ? audit.service.name : '' %></td>
+                    <td class="breakable"><%= audit.organisation ? audit.organisation.name: '' %></td>
+                    <td class="breakable"><%= audit.result ? 'Success' : 'Failure' %></td>
+                    <td class="breakable"><%= audit.user ? audit.user.name : '' %></td>
+                </tr>
+            <% } %>
+            </tbody>
+        </table>
+    </div>
 <%- include('../../sharedViews/pagination', paginationModel); %>

--- a/src/app/users/views/search.ejs
+++ b/src/app/users/views/search.ejs
@@ -244,7 +244,7 @@ if (services && services.length > 0) {
             <% } %>
             <% for (let i = 0; i < locals.users.length; i++) { %>
             <tr>
-                <td><a href="/users/<%= users[i].id %>/"><%= users[i].name %></a></td>
+                <td><a class="breakable" href="/users/<%= users[i].id %>/"><%= users[i].name %></a></td>
 
                 <td><span class="breakable"><%= users[i].email %></span></td>
                 <td>

--- a/src/app/users/views/services.ejs
+++ b/src/app/users/views/services.ejs
@@ -61,7 +61,7 @@
 <%}%>
 
 <% if (!hasServices) { %>
-<div class="empty-state text-break">
+<div class="empty-state">
     <p><%= user.name %> is not associated with any services</p>
 </div>
 <% } %>

--- a/src/app/users/views/summaryPartial.ejs
+++ b/src/app/users/views/summaryPartial.ejs
@@ -52,7 +52,7 @@
 
 <div class="row">
     <div class="col-8">
-        <h1 class="heading-xlarge breakable">
+        <h1 class="heading-xlarge heading-breakable">
             <span class="heading-secondary"><%= user.email %></span>
             <%= user.name %>
         </h1>

--- a/src/app/users/views/summaryPartial.ejs
+++ b/src/app/users/views/summaryPartial.ejs
@@ -52,7 +52,7 @@
 
 <div class="row">
     <div class="col-8">
-        <h1 class="heading-xlarge text-break">
+        <h1 class="heading-xlarge breakable">
             <span class="heading-secondary"><%= user.email %></span>
             <%= user.name %>
         </h1>


### PR DESCRIPTION
Jira ticket:  NSA-6389
- reverted to pre-GDS CSS version (GDS-upgrade isn't compatible right now and it breaks some UI components as notifications font size)
- reverted changes to the users Audit table that came when added the GDS-upgrade CSS stylesheet
- wrapped Audit table column using pre GDS CSS stylesheet
- Wrapped long headings in users/organisations pages
- Wrapped long user names in Users page
- wrapped long names/email addresses in the users table for an organisation 
- wrapped long organisation names in the organisation search 
- fixed the UI for notification when selecting a Deactivated/Invitation deactivated user