### PR TITLE
[NSA-7489] User/Organisation Search bug fixes

### DIFF
--- a/DevOps/pipeline/azure-pipeline.yml
+++ b/DevOps/pipeline/azure-pipeline.yml
@@ -103,9 +103,9 @@ stages:
 
     - template:  pipeline/eslint.yml@devopsTemplates
 
-    # - template:  pipeline/dependencyCheck.yml@devopsTemplates
-    #   parameters:
-    #     npmInstCmd: 'install --force --json --no-package-lock'
+    - template:  pipeline/dependencyCheck.yml@devopsTemplates
+      parameters:
+        npmInstCmd: 'install --force --json --no-package-lock'
 
     - template: pipeline/build.yml@devopsTemplates
       parameters:

--- a/DevOps/pipeline/azure-pipeline.yml
+++ b/DevOps/pipeline/azure-pipeline.yml
@@ -103,9 +103,9 @@ stages:
 
     - template:  pipeline/eslint.yml@devopsTemplates
 
-    - template:  pipeline/dependencyCheck.yml@devopsTemplates
-      parameters:
-        npmInstCmd: 'install --force --json --no-package-lock'
+    # - template:  pipeline/dependencyCheck.yml@devopsTemplates
+    #   parameters:
+    #     npmInstCmd: 'install --force --json --no-package-lock'
 
     - template: pipeline/build.yml@devopsTemplates
       parameters:

--- a/src/app/organisations/organisationUsers.js
+++ b/src/app/organisations/organisationUsers.js
@@ -33,6 +33,7 @@ const render = async (req, res, dataSource) => {
 
 const get = async (req, res) => {
   req.session.params = {
+    ...req.session.params,
     ...req.query,
     redirectedFromSearchResult: true
   }

--- a/src/app/organisations/organisationUsers.js
+++ b/src/app/organisations/organisationUsers.js
@@ -35,7 +35,6 @@ const get = async (req, res) => {
   req.session.params = {
     ...req.session.params,
     ...req.query,
-    searchType: 'organisations',
   };
 
   // Check if it's possible to re-populate search with the current params.

--- a/src/app/organisations/organisationUsers.js
+++ b/src/app/organisations/organisationUsers.js
@@ -33,8 +33,8 @@ const render = async (req, res, dataSource) => {
 
 const get = async (req, res) => {
   req.session.params = {
-    ...req.query, 
-    redirectedFromSearch: true
+    ...req.query,
+    redirectedFromSearchResult: true
   }
   return render(req, res, req.query);
 };

--- a/src/app/organisations/organisationUsers.js
+++ b/src/app/organisations/organisationUsers.js
@@ -34,7 +34,7 @@ const render = async (req, res, dataSource) => {
 const get = async (req, res) => {
   req.session.params = {
     ...req.query, 
-    redirectedFromOrganisations: true
+    redirectedFromSearch: true
   }
   return render(req, res, req.query);
 };

--- a/src/app/organisations/organisationUsers.js
+++ b/src/app/organisations/organisationUsers.js
@@ -35,7 +35,8 @@ const get = async (req, res) => {
   req.session.params = {
     ...req.session.params,
     ...req.query,
-    redirectedFromSearchResult: true
+    redirectedFromSearchResult: true,
+    searchType: 'organisations',
   }
   return render(req, res, req.query);
 };

--- a/src/app/organisations/organisationUsers.js
+++ b/src/app/organisations/organisationUsers.js
@@ -35,9 +35,19 @@ const get = async (req, res) => {
   req.session.params = {
     ...req.session.params,
     ...req.query,
-    redirectedFromSearchResult: true,
     searchType: 'organisations',
+  };
+
+  // Check if it's possible to re-populate search with the current params.
+  if (
+    req.session.params.showFilters === 'true'
+    || (typeof req.session.params.criteria !== "undefined" && req.session.params.criteria !== '')
+  ) {
+    req.session.params.redirectedFromSearchResult = true;
+  } else {
+    req.session.params.redirectedFromSearchResult = false;
   }
+
   return render(req, res, req.query);
 };
 const post = async (req, res) => {

--- a/src/app/organisations/organisationUsers.js
+++ b/src/app/organisations/organisationUsers.js
@@ -48,6 +48,12 @@ const get = async (req, res) => {
     req.session.params.redirectedFromSearchResult = false;
   }
 
+  // If searchType isn't set or equal to users, set it to organisations.
+  // This allows us to avoid populating org search after going from user's profile straight to an org user list.
+  if (req.session.params.searchType !== 'users') {
+    req.session.params.searchType = 'organisations';
+  }
+
   return render(req, res, req.query);
 };
 const post = async (req, res) => {

--- a/src/app/organisations/search.js
+++ b/src/app/organisations/search.js
@@ -59,9 +59,8 @@ const search = async (req) => {
 
   if (req.session.params && Object.keys(inputSource).length === 0) {
     inputSource = {
-      ...req.session.params,
-      page: req.session.params.currentPage
-    }
+      ...req.session.params
+    };
   }
 
   let criteria = inputSource.criteria ? inputSource.criteria.trim() : '';

--- a/src/app/organisations/search.js
+++ b/src/app/organisations/search.js
@@ -141,7 +141,10 @@ const doSearchAndBuildModel = async (req) => {
 };
 
 const get = async (req, res) => {
-  if (!req.session.params?.redirectedFromSearchResult && req.session.params) {
+  if (
+    (!req.session.params?.redirectedFromSearchResult && req.session.params)
+    || req.session.params?.searchType === 'users'
+  ) {
     req.session.params = undefined;
   }
 

--- a/src/app/organisations/search.js
+++ b/src/app/organisations/search.js
@@ -143,12 +143,12 @@ const doSearchAndBuildModel = async (req) => {
 const get = async (req, res) => {
   const model = await buildModel(req);
 
-  if (!req.session.params?.redirectedFromSearch && req.session.params) {
+  if (!req.session.params?.redirectedFromSearchResult && req.session.params) {
     req.session.params = undefined;
   }
 
-  if (req.session.params?.redirectedFromSearch) {
-    req.session.params.redirectedFromSearch = undefined;
+  if (req.session.params?.redirectedFromSearchResult) {
+    req.session.params.redirectedFromSearchResult = undefined;
     await post(req, res);
   } else {
     const model = await buildModel(req);

--- a/src/app/organisations/search.js
+++ b/src/app/organisations/search.js
@@ -141,8 +141,6 @@ const doSearchAndBuildModel = async (req) => {
 };
 
 const get = async (req, res) => {
-  const model = await buildModel(req);
-
   if (!req.session.params?.redirectedFromSearchResult && req.session.params) {
     req.session.params = undefined;
   }

--- a/src/app/organisations/search.js
+++ b/src/app/organisations/search.js
@@ -143,15 +143,13 @@ const doSearchAndBuildModel = async (req) => {
 const get = async (req, res) => {
   const model = await buildModel(req);
 
-  if (!req.session.params?.redirectedFromOrganisations) {
-    if (req.session.params) {
-      req.session.params = undefined;
-    }
+  if (!req.session.params?.redirectedFromSearch && req.session.params) {
+    req.session.params = undefined;
   }
 
-  if (req.session.params?.redirectedFromOrganisations) {
-    req.session.params.redirectedFromOrganisations = undefined;
-    await post(req, res)
+  if (req.session.params?.redirectedFromSearch) {
+    req.session.params.redirectedFromSearch = undefined;
+    await post(req, res);
   } else {
     const model = await buildModel(req);
     sendResult(req, res, 'organisations/views/search', model);

--- a/src/app/organisations/views/search.ejs
+++ b/src/app/organisations/views/search.ejs
@@ -163,7 +163,7 @@ const organisationStatusesQuery = locals.organisationStatuses.filter(x => x.isSe
                     <% } %>
                     <% for (let i = 0; i < locals.organisations.length; i++) { %>
                         <tr>
-                            <td class="breakable"><a href="/organisations/<%= organisations[i].id %>/users?criteria=<%= locals.criteria %>&page=<%= locals.page %>&showFilters=<%= locals.showFilters %>&<%= organisationTypesQuery %>&<%= organisationStatusesQuery %>&currentPage=<%= paginationModel['currentPage'] %>&numberOfPages=<%= paginationModel['numberOfPages'] %>&totalNumberOfResults=<%= paginationModel['totalNumberOfResults'] %>&numberOfResultsOnPage=<%= paginationModel['numberOfResultsOnPage'] %>"><%= organisations[i].name %></a></td>
+                            <td class="breakable"><a href="/organisations/<%= organisations[i].id %>/users?criteria=<%= locals.criteria %>&page=<%= locals.page %>&showFilters=<%= locals.showFilters %>&<%= organisationTypesQuery %>&<%= organisationStatusesQuery %>&numberOfPages=<%= paginationModel['numberOfPages'] %>&totalNumberOfResults=<%= paginationModel['totalNumberOfResults'] %>&numberOfResultsOnPage=<%= paginationModel['numberOfResultsOnPage'] %>"><%= organisations[i].name %></a></td>
                             <td><%= organisations[i].LegalName %></td>
                             <td><%= organisations[i].type ? organisations[i].type.name : organisations[i].providerTypeName || organisations[i].category.name  %></td>
                             <td><%= organisations[i].urn %></td>

--- a/src/app/organisations/views/search.ejs
+++ b/src/app/organisations/views/search.ejs
@@ -163,7 +163,7 @@ const organisationStatusesQuery = locals.organisationStatuses.filter(x => x.isSe
                     <% } %>
                     <% for (let i = 0; i < locals.organisations.length; i++) { %>
                         <tr>
-                            <td class="breakable"><a href="/organisations/<%= organisations[i].id %>/users?criteria=<%= locals.criteria %>&page=<%= locals.page %>&showFilters=<%= locals.showFilters %>&<%= organisationTypesQuery %>&<%= organisationStatusesQuery %>&numberOfPages=<%= paginationModel['numberOfPages'] %>&totalNumberOfResults=<%= paginationModel['totalNumberOfResults'] %>&numberOfResultsOnPage=<%= paginationModel['numberOfResultsOnPage'] %>"><%= organisations[i].name %></a></td>
+                            <td class="breakable"><a href="/organisations/<%= organisations[i].id %>/users?criteria=<%= locals.criteria %>&page=<%= locals.page %>&showFilters=<%= locals.showFilters %>&<%= organisationTypesQuery %>&<%= organisationStatusesQuery %>"><%= organisations[i].name %></a></td>
                             <td><%= organisations[i].LegalName %></td>
                             <td><%= organisations[i].type ? organisations[i].type.name : organisations[i].providerTypeName || organisations[i].category.name  %></td>
                             <td><%= organisations[i].urn %></td>

--- a/src/app/organisations/views/search.ejs
+++ b/src/app/organisations/views/search.ejs
@@ -31,6 +31,12 @@ const paginationModel = {
             }, [])},
     ]
 }
+const organisationTypesQuery = locals.organisationTypes.filter(x => x.isSelected)
+                                .map(x => `organisationType=${x.id}`)
+                                .join('&') || 'organisationType=';
+const organisationStatusesQuery = locals.organisationStatuses.filter(x => x.isSelected)
+                                .map(x => `organisationStatus=${x.id}`)
+                                .join('&') || 'organisationStatus=';
 %>
 
 <div class="row row-spacer">
@@ -157,7 +163,7 @@ const paginationModel = {
                     <% } %>
                     <% for (let i = 0; i < locals.organisations.length; i++) { %>
                         <tr>
-                            <td class="breakable"><a href="/organisations/<%= organisations[i].id %>/users?organisationType=<%= paginationModel['data'][4]['value'] %>&organisationStatus=<%= paginationModel['data'][5]['value'] %>&criteria=<%= paginationModel['data'][0]['value'] %>&showFilters=<%= paginationModel['data'][3]['value'] %>&currentPage=<%= paginationModel['currentPage'] %>&numberOfPages=<%= paginationModel['numberOfPages'] %>&totalNumberOfResults=<%= paginationModel['totalNumberOfResults'] %>&numberOfResultsOnPage=<%= paginationModel['numberOfResultsOnPage'] %>"><%= organisations[i].name %></a></td>
+                            <td class="breakable"><a href="/organisations/<%= organisations[i].id %>/users?criteria=<%= locals.criteria %>&page=<%= locals.page %>&showFilters=<%= locals.showFilters %>&<%= organisationTypesQuery %>&<%= organisationStatusesQuery %>&currentPage=<%= paginationModel['currentPage'] %>&numberOfPages=<%= paginationModel['numberOfPages'] %>&totalNumberOfResults=<%= paginationModel['totalNumberOfResults'] %>&numberOfResultsOnPage=<%= paginationModel['numberOfResultsOnPage'] %>"><%= organisations[i].name %></a></td>
                             <td><%= organisations[i].LegalName %></td>
                             <td><%= organisations[i].type ? organisations[i].type.name : organisations[i].providerTypeName || organisations[i].category.name  %></td>
                             <td><%= organisations[i].urn %></td>

--- a/src/app/users/getOrganisations.js
+++ b/src/app/users/getOrganisations.js
@@ -78,7 +78,8 @@ const action = async (req, res) => {
   req.session.params = {
     ...req.session.params,
     ...req.query,
-    redirectedFromSearchResult: true
+    redirectedFromSearchResult: true,
+    searchType: 'users'
   }
 
   logger.audit(`${req.user.email} (id: ${req.user.sub}) viewed user ${user.email} (id: ${user.id})`, {

--- a/src/app/users/getOrganisations.js
+++ b/src/app/users/getOrganisations.js
@@ -78,8 +78,17 @@ const action = async (req, res) => {
   req.session.params = {
     ...req.session.params,
     ...req.query,
-    redirectedFromSearchResult: true,
-    searchType: 'users'
+    searchType: 'users',
+  };
+
+  // Check if it's possible to re-populate search with the current params.
+  if (
+    req.session.params.showFilters === 'true'
+    || (typeof req.session.params.criteria !== "undefined" && req.session.params.criteria !== '')
+  ) {
+    req.session.params.redirectedFromSearchResult = true;
+  } else {
+    req.session.params.redirectedFromSearchResult = false;
   }
 
   logger.audit(`${req.user.email} (id: ${req.user.sub}) viewed user ${user.email} (id: ${user.id})`, {

--- a/src/app/users/getOrganisations.js
+++ b/src/app/users/getOrganisations.js
@@ -76,6 +76,7 @@ const action = async (req, res) => {
   };
 
   req.session.params = {
+    ...req.session.params,
     ...req.query,
     redirectedFromSearchResult: true
   }

--- a/src/app/users/getOrganisations.js
+++ b/src/app/users/getOrganisations.js
@@ -78,7 +78,6 @@ const action = async (req, res) => {
   req.session.params = {
     ...req.session.params,
     ...req.query,
-    searchType: 'users',
   };
 
   // Check if it's possible to re-populate search with the current params.
@@ -89,6 +88,12 @@ const action = async (req, res) => {
     req.session.params.redirectedFromSearchResult = true;
   } else {
     req.session.params.redirectedFromSearchResult = false;
+  }
+
+  // If searchType isn't set or equal to organisations, set it to users.
+  // This allows us to avoid populating user search after going from the org user list straight to a user profile.
+  if (req.session.params.searchType !== 'organisations') {
+    req.session.params.searchType = 'users';
   }
 
   logger.audit(`${req.user.email} (id: ${req.user.sub}) viewed user ${user.email} (id: ${user.id})`, {

--- a/src/app/users/getOrganisations.js
+++ b/src/app/users/getOrganisations.js
@@ -77,7 +77,7 @@ const action = async (req, res) => {
 
   req.session.params = {
     ...req.query, 
-    redirectedFromOrganisations: true
+    redirectedFromSearch: true
   }
 
   logger.audit(`${req.user.email} (id: ${req.user.sub}) viewed user ${user.email} (id: ${user.id})`, {

--- a/src/app/users/getOrganisations.js
+++ b/src/app/users/getOrganisations.js
@@ -76,8 +76,8 @@ const action = async (req, res) => {
   };
 
   req.session.params = {
-    ...req.query, 
-    redirectedFromSearch: true
+    ...req.query,
+    redirectedFromSearchResult: true
   }
 
   logger.audit(`${req.user.email} (id: ${req.user.sub}) viewed user ${user.email} (id: ${user.id})`, {

--- a/src/app/users/search.js
+++ b/src/app/users/search.js
@@ -114,15 +114,13 @@ const doSearchAndBuildModel = async (req) => {
 const get = async (req, res) => {
   clearNewUserSessionData(req);
 
-  if (!req.session.params?.redirectedFromOrganisations) {
-    if (req.session.params) {
-      req.session.params = undefined;
-    }
+  if (!req.session.params?.redirectedFromSearch && req.session.params) {
+    req.session.params = undefined;
   }
 
-  if (req.session.params?.redirectedFromOrganisations) {
-    req.session.params.redirectedFromOrganisations = undefined;
-    await post(req, res)
+  if (req.session.params?.redirectedFromSearch) {
+    req.session.params.redirectedFromSearch = undefined;
+    await post(req, res);
   } else {
     const model = await buildModel(req);
     sendResult(req, res, 'users/views/search', model);

--- a/src/app/users/search.js
+++ b/src/app/users/search.js
@@ -11,9 +11,6 @@ const clearNewUserSessionData = (req) => {
   if (req.session.user) {
     req.session.user = undefined;
   }
-  // if (req.session.params) {
-  //   req.session.params = undefined;
-  // }
   if (req.session.digipassSerialNumberToAssign) {
     req.session.digipassSerialNumberToAssign = undefined;
   }
@@ -114,7 +111,10 @@ const doSearchAndBuildModel = async (req) => {
 const get = async (req, res) => {
   clearNewUserSessionData(req);
 
-  if (!req.session.params?.redirectedFromSearchResult && req.session.params) {
+  if (
+    (!req.session.params?.redirectedFromSearchResult && req.session.params)
+    || req.session.params?.searchType === 'organisations'
+  ) {
     req.session.params = undefined;
   }
 

--- a/src/app/users/search.js
+++ b/src/app/users/search.js
@@ -114,12 +114,12 @@ const doSearchAndBuildModel = async (req) => {
 const get = async (req, res) => {
   clearNewUserSessionData(req);
 
-  if (!req.session.params?.redirectedFromSearch && req.session.params) {
+  if (!req.session.params?.redirectedFromSearchResult && req.session.params) {
     req.session.params = undefined;
   }
 
-  if (req.session.params?.redirectedFromSearch) {
-    req.session.params.redirectedFromSearch = undefined;
+  if (req.session.params?.redirectedFromSearchResult) {
+    req.session.params.redirectedFromSearchResult = undefined;
     await post(req, res);
   } else {
     const model = await buildModel(req);

--- a/src/app/users/search.js
+++ b/src/app/users/search.js
@@ -125,9 +125,6 @@ const get = async (req, res) => {
     const model = await buildModel(req);
     sendResult(req, res, 'users/views/search', model);
   }
-
-  // const model = await buildModel(req);
-  // sendResult(req, res, 'users/views/search', model);
 };
 
 const post = async (req, res) => {

--- a/src/app/users/utils.js
+++ b/src/app/users/utils.js
@@ -58,19 +58,15 @@ const buildFilters = (paramsSource) => {
 const search = async (req) => {
   let paramsSource = req.method === 'POST' ? req.body : req.query;
 
-  if (req.session.params && Object.keys(paramsSource).length === 0) {
-    let sanitized_criteria = req.session.params['organisationTypes'].replace('?criteria=', '')
+  if (Object.keys(paramsSource).length === 0 && req.session.params) {
     paramsSource = {
-      ...req.session.params, 
-      criteria: sanitized_criteria
-    }
+      ...req.session.params
+    };
   }
 
-  
   if (paramsSource.services) {
-    paramsSource = {...paramsSource, service: paramsSource.services}
+    paramsSource = {...paramsSource, service: paramsSource.services};
   }
-
 
   let criteria = paramsSource.criteria ? paramsSource.criteria.trim() : '';
 

--- a/src/app/users/views/search.ejs
+++ b/src/app/users/views/search.ejs
@@ -245,9 +245,7 @@ if (services && services.length > 0) {
             <% } %>
             <% for (let i = 0; i < locals.users.length; i++) { %>
             <tr>
-                <td><a class="breakable" href="/users/<%= users[i].id %>/organisations?organisationTypes=<%= baseSortUri %>&currentPage=<%= locals.page%>&numberOfPages=<%= locals.page%>&totalNumberOfResults=<%= locals.totalNumberOfResults %>&numberOfResultsOnPage=<%= locals.users ? locals.users.length: undefined%>"><%= users[i].name %></a></td>
-
-
+                <td><a class="breakable" href="/users/<%= users[i].id %>/organisations<%= baseSortUri %>&currentPage=<%= locals.page %>&numberOfPages=<%= locals.numberOfPages %>&totalNumberOfResults=<%= locals.totalNumberOfResults %>&numberOfResultsOnPage=<%= locals.users ? locals.users.length: undefined%>"><%= users[i].name %></a></td>
                 <td><span class="breakable"><%= users[i].email %></span></td>
                 <td>
                     <% if(users[i].organisation) { %>

--- a/src/app/users/views/search.ejs
+++ b/src/app/users/views/search.ejs
@@ -245,7 +245,7 @@ if (services && services.length > 0) {
             <% } %>
             <% for (let i = 0; i < locals.users.length; i++) { %>
             <tr>
-                <td><a class="breakable" href="/users/<%= users[i].id %>/organisations<%= baseSortUri %>&currentPage=<%= locals.page %>&numberOfPages=<%= locals.numberOfPages %>&totalNumberOfResults=<%= locals.totalNumberOfResults %>&numberOfResultsOnPage=<%= locals.users ? locals.users.length: undefined%>"><%= users[i].name %></a></td>
+                <td><a class="breakable" href="/users/<%= users[i].id %>/organisations<%= baseSortUri %>"><%= users[i].name %></a></td>
                 <td><span class="breakable"><%= users[i].email %></span></td>
                 <td>
                     <% if(users[i].organisation) { %>


### PR DESCRIPTION
The changes below have been tested in Dev, and fix the following bugs:

- [NSA-7475](https://dfe-secureaccess.atlassian.net/browse/NSA-7475): An error occurring when going from organisation details page after searching, to the user's tab.
  - Fixed by only allowing search to be populated if showFilters is true, or criteria is not empty.
  - Additionally, added a searchType param to the session, which stops/clears search params when switching from a search result of one type, to the search page of another.
- [NSA-7479](https://dfe-secureaccess.atlassian.net/browse/NSA-7479): Search criteria being populated when switching from a user's services page to the organisations page.
  - Fixed by populating the search params from the currently set session values, not just the query string, as well as the two above fixes for NSA-7475.

Additional changes:

- Renamed `redirectedFromOrganisations` flag to `redirectedFromSearchResult`, to make it clearer what the flag means.
- Fixed query string for the organisations URL, so a replace is no longer necessary to remove an error in the query.
- Removed unnecessary params from the query strings, as they are populated by the search result using the specified criteria, not from the session params.
- Removed unreachable or code commented out during previous search bugfixes that is no longer needed.
