### PR TITLE
[NSA-8025] Update Audit ID query to avoid timeouts

### DIFF
--- a/src/infrastructure/audit/sequelize.js
+++ b/src/infrastructure/audit/sequelize.js
@@ -52,8 +52,16 @@ const getPageOfUserAudits = async (userId, pageNumber) => {
   const queryWhere = `
     WHERE type != 'technical-audit'
     AND id IN (
-      SELECT AL.id FROM AuditLogs AL LEFT JOIN AuditLogMeta ALM on AL.id = ALM.auditId
-        WHERE AL.userId = :userId OR (ALM.[key] IN ('editedUser', 'viewedUser') AND ALM.[value] = :userId)
+      SELECT AL.id
+        FROM AuditLogs AL
+        WHERE AL.userId = :userId
+      UNION
+      SELECT AL.id
+        FROM AuditLogs AL
+        JOIN AuditLogMeta ALM
+          ON ALM.auditId = AL.id
+        WHERE ALM.[key] IN ('editedUser', 'viewedUser')
+          AND ALM.[Value] = :userId
     )`;
   const queryOpts = {
     type: QueryTypes.SELECT,


### PR DESCRIPTION
Ticket: https://dfe-secureaccess.atlassian.net/browse/NSA-8025

Updates the inner query to get audit record IDs by replacing the `LEFT JOIN` and `OR` with a `UNION` of both sides of the `OR`.

This change allows the database to seek the index of AuditLogs' user ID and search the second part of the union instead of having to search two indexes in the original query, which is more prone to struggling when other queries are running etc.

This inner query has been tested in the DB/locally to run faster and more consistently, there are some local benchmarks in the ticket, and when myself and Lee ran both the old and new version in the Prod DB, the old version ran between 3-5 seconds or over a minute randomly, but we never saw that long fluctuation with the new query.