### PR TITLE
Update content-security-policy header (ITHC/DSI-7014)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -233,9 +233,9 @@
       }
     },
     "node_modules/@azure/core-rest-pipeline": {
-      "version": "1.16.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-rest-pipeline/-/core-rest-pipeline-1.16.0.tgz",
-      "integrity": "sha1-YxFy4v4DRs9EENHI4BrZjYSXOOI=",
+      "version": "1.16.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-rest-pipeline/-/core-rest-pipeline-1.16.1.tgz",
+      "integrity": "sha1-BpyvAsooMCfdCjzzeBfmdOvxMMg=",
       "dependencies": {
         "@azure/abort-controller": "^2.0.0",
         "@azure/core-auth": "^1.4.0",
@@ -431,9 +431,9 @@
       }
     },
     "node_modules/@azure/service-bus": {
-      "version": "7.9.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/service-bus/-/service-bus-7.9.4.tgz",
-      "integrity": "sha1-4NOp55swAl9bWQ60EGAu1ni/erk=",
+      "version": "7.9.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/service-bus/-/service-bus-7.9.5.tgz",
+      "integrity": "sha1-rVpvPK+eMmnF6DjXsV7NAw4tjTM=",
       "dependencies": {
         "@azure/abort-controller": "^1.0.0",
         "@azure/core-amqp": "^4.1.1",
@@ -1116,9 +1116,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.10.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint-community/regexpp/-/regexpp-4.10.1.tgz",
-      "integrity": "sha1-NhRh5cs4Rdh05hcxwRz+3WZNg6A=",
+      "version": "4.11.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint-community/regexpp/-/regexpp-4.11.0.tgz",
+      "integrity": "sha1-sP/QMStKP9LW93I35ySKWtOmgK4=",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
@@ -1677,9 +1677,9 @@
       }
     },
     "node_modules/@js-joda/core": {
-      "version": "5.6.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@js-joda/core/-/core-5.6.2.tgz",
-      "integrity": "sha1-GIXRDapATOor1VV1+RCrO75sM9c="
+      "version": "5.6.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@js-joda/core/-/core-5.6.3.tgz",
+      "integrity": "sha1-Qa4cB94evg9t3hq8vJcAoJucYFY="
     },
     "node_modules/@microsoft/applicationinsights-web-snippet": {
       "version": "1.0.1",
@@ -1727,11 +1727,11 @@
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "1.25.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@opentelemetry/core/-/core-1.25.0.tgz",
-      "integrity": "sha1-rQNPXCZp9Ym9cDv7uqOLUfhQQFM=",
+      "version": "1.25.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@opentelemetry/core/-/core-1.25.1.tgz",
+      "integrity": "sha1-/2Z9k50Sit/Hx5Ptri9ryhd/gp0=",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.25.0"
+        "@opentelemetry/semantic-conventions": "1.25.1"
       },
       "engines": {
         "node": ">=14"
@@ -1759,12 +1759,12 @@
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "1.25.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@opentelemetry/resources/-/resources-1.25.0.tgz",
-      "integrity": "sha1-hKHnAJfjQqogR6rJe+EUrRSWZ5M=",
+      "version": "1.25.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@opentelemetry/resources/-/resources-1.25.1.tgz",
+      "integrity": "sha1-u5pnSvJaGmwwhAt1W8adonlv77s=",
       "dependencies": {
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/semantic-conventions": "1.25.0"
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
       },
       "engines": {
         "node": ">=14"
@@ -1774,13 +1774,13 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.25.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.25.0.tgz",
-      "integrity": "sha1-Jj+c4ZABxc16gU0OtA68ZGmudj0=",
+      "version": "1.25.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.25.1.tgz",
+      "integrity": "sha1-y8HmCvJVZV0gIKoUzeF7N70T3zc=",
       "dependencies": {
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/resources": "1.25.0",
-        "@opentelemetry/semantic-conventions": "1.25.0"
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
       },
       "engines": {
         "node": ">=14"
@@ -1790,9 +1790,9 @@
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.25.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.0.tgz",
-      "integrity": "sha1-OQ601CopxmvcMAZq+QNWRem7cnA=",
+      "version": "1.25.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+      "integrity": "sha1-De7LOGGXxenCwo8vifUfuK6fFF4=",
       "engines": {
         "node": ">=14"
       }
@@ -1951,9 +1951,9 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.19.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/express-serve-static-core/-/express-serve-static-core-4.19.3.tgz",
-      "integrity": "sha1-5GmhPkGGyeHAQY+xe+i8j/Gxmno=",
+      "version": "4.19.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/express-serve-static-core/-/express-serve-static-core-4.19.5.tgz",
+      "integrity": "sha1-IYBk4yESb8+QSNHKJd0kZdpV2cY=",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
@@ -2051,9 +2051,9 @@
       "integrity": "sha1-EJZLoN7mrEzUYuJ5W2vr1AcwNDM="
     },
     "node_modules/@types/node": {
-      "version": "20.14.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/node/-/node-20.14.2.tgz",
-      "integrity": "sha1-pfTSvLS2qHv/yqcXcYxaDyCPShg=",
+      "version": "20.14.9",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/node/-/node-20.14.9.tgz",
+      "integrity": "sha1-EujnZasn+MQhoYIMmfXzE6kztCA=",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -2130,9 +2130,9 @@
       "integrity": "sha1-dP75/7qhmOuLWIvgKfOLACmcqiw="
     },
     "node_modules/@types/validator": {
-      "version": "13.11.10",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/validator/-/validator-13.11.10.tgz",
-      "integrity": "sha1-/rNkAYzdHz2XCp6MfxwxTAomT/8="
+      "version": "13.12.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/validator/-/validator-13.12.0.tgz",
+      "integrity": "sha1-H+TDrp3lz1GTzmRxfJnvL6fYdW8="
     },
     "node_modules/@types/yargs": {
       "version": "17.0.32",
@@ -2178,9 +2178,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.11.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/acorn/-/acorn-8.11.3.tgz",
-      "integrity": "sha1-ceCxThOk7BYHJLOPt7DyM7G4HXo=",
+      "version": "8.12.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/acorn/-/acorn-8.12.1.tgz",
+      "integrity": "sha1-cWFr3MviXielRDngBG6JynbfIkg=",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2473,6 +2473,7 @@
       "version": "1.0.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
       "integrity": "sha1-HlWD7BZ2NUCieuUu7Zn/iZIjVo8=",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.5",
         "is-array-buffer": "^3.0.4"
@@ -2569,6 +2570,7 @@
       "version": "1.0.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.3.tgz",
       "integrity": "sha1-CXly9CVeQbw0JeN9w/ZCHPmu/eY=",
+      "dev": true,
       "dependencies": {
         "array-buffer-byte-length": "^1.0.1",
         "call-bind": "^1.0.5",
@@ -2663,6 +2665,7 @@
       "version": "1.0.7",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
       "integrity": "sha1-pcw3XWoDwu/IelU/PgsVIt7xSEY=",
+      "dev": true,
       "dependencies": {
         "possible-typed-array-names": "^1.0.0"
       },
@@ -2825,9 +2828,9 @@
       ]
     },
     "node_modules/bl": {
-      "version": "6.0.12",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/bl/-/bl-6.0.12.tgz",
-      "integrity": "sha1-d8NbluE67/AoSWx5i3U4nd7px/g=",
+      "version": "6.0.13",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/bl/-/bl-6.0.13.tgz",
+      "integrity": "sha1-3F8ojT+El3G7YRKylHer7kwKnZY=",
       "dependencies": {
         "@types/readable-stream": "^4.0.0",
         "buffer": "^6.0.3",
@@ -2885,9 +2888,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.23.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/browserslist/-/browserslist-4.23.0.tgz",
-      "integrity": "sha1-jzrMK75zr3ITOZQwiQ+GxjpWdKs=",
+      "version": "4.23.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/browserslist/-/browserslist-4.23.1.tgz",
+      "integrity": "sha1-zkrwU0s9N9tcGkypi5CA+YUEHpY=",
       "dev": true,
       "funding": [
         {
@@ -2904,10 +2907,10 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001587",
-        "electron-to-chromium": "^1.4.668",
+        "caniuse-lite": "^1.0.30001629",
+        "electron-to-chromium": "^1.4.796",
         "node-releases": "^2.0.14",
-        "update-browserslist-db": "^1.0.13"
+        "update-browserslist-db": "^1.0.16"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -3042,9 +3045,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001629",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001629.tgz",
-      "integrity": "sha1-kHo29GaQMb2KGo28L6CLKeDbKX4=",
+      "version": "1.0.30001640",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001640.tgz",
+      "integrity": "sha1-MsRn1L8fGg+qY/x5PCuoEWnnZS8=",
       "dev": true,
       "funding": [
         {
@@ -3547,6 +3550,7 @@
       "version": "1.0.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/data-view-buffer/-/data-view-buffer-1.0.1.tgz",
       "integrity": "sha1-jqYybv7Bei5CYgaW5nHX1ai8ZrI=",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.6",
         "es-errors": "^1.3.0",
@@ -3563,6 +3567,7 @@
       "version": "1.0.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/data-view-byte-length/-/data-view-byte-length-1.0.1.tgz",
       "integrity": "sha1-kHIcqV/ygGd+t5N0n84QETR2aeI=",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
@@ -3579,6 +3584,7 @@
       "version": "1.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/data-view-byte-offset/-/data-view-byte-offset-1.0.0.tgz",
       "integrity": "sha1-Xgu/tIKO0tG5tADNin0Rm8oP8Yo=",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.6",
         "es-errors": "^1.3.0",
@@ -3835,9 +3841,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.792",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/electron-to-chromium/-/electron-to-chromium-1.4.792.tgz",
-      "integrity": "sha1-c4cS+Z0C9wxXVMpCZHgpFfqUaEk=",
+      "version": "1.4.816",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/electron-to-chromium/-/electron-to-chromium-1.4.816.tgz",
+      "integrity": "sha1-NiRknR5/3lzbrfWdMaUkJF2O6F8=",
       "dev": true
     },
     "node_modules/email-validator": {
@@ -3907,6 +3913,7 @@
       "version": "1.23.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/es-abstract/-/es-abstract-1.23.3.tgz",
       "integrity": "sha1-jwxaNc0hUxJXPFonyH39bIgaCqA=",
+      "dev": true,
       "dependencies": {
         "array-buffer-byte-length": "^1.0.1",
         "arraybuffer.prototype.slice": "^1.0.3",
@@ -3962,27 +3969,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/es-aggregate-error": {
-      "version": "1.0.13",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/es-aggregate-error/-/es-aggregate-error-1.0.13.tgz",
-      "integrity": "sha1-fyi3fJ2NCbvNOkZuS+n+AvqYUgE=",
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.2",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "globalthis": "^1.0.3",
-        "has-property-descriptors": "^1.0.2",
-        "set-function-name": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/es-define-property": {
       "version": "1.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/es-define-property/-/es-define-property-1.0.0.tgz",
@@ -4006,6 +3992,7 @@
       "version": "1.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
       "integrity": "sha1-3bVc1HrC4kBwEmC8Ko4x7LZD2UE=",
+      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -4017,6 +4004,7 @@
       "version": "2.0.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
       "integrity": "sha1-i7YPCkQMLkKBliQoQ41YVFrzl3c=",
+      "dev": true,
       "dependencies": {
         "get-intrinsic": "^1.2.4",
         "has-tostringtag": "^1.0.2",
@@ -4039,6 +4027,7 @@
       "version": "1.2.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
       "integrity": "sha1-5VzUyc3BiLzvsDs2bHNjI/xciYo=",
+      "dev": true,
       "dependencies": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -4771,6 +4760,7 @@
       "version": "0.3.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/for-each/-/for-each-0.3.3.tgz",
       "integrity": "sha1-abRH6IoKXTLD5whPPxcQA0shN24=",
+      "dev": true,
       "dependencies": {
         "is-callable": "^1.1.3"
       }
@@ -4834,6 +4824,7 @@
       "version": "1.1.6",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
       "integrity": "sha1-zfMVt9kO53pMbuIWw8M2LaB1M/0=",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.2.0",
@@ -4851,6 +4842,7 @@
       "version": "1.2.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/functions-have-names/-/functions-have-names-1.2.3.tgz",
       "integrity": "sha1-BAT+TuK6L2B/Dg7DyAuumUEzuDQ=",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -4915,6 +4907,7 @@
       "version": "1.0.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/get-symbol-description/-/get-symbol-description-1.0.2.tgz",
       "integrity": "sha1-UzdE1aogrKTgecjl2vf9RCAoIfU=",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.5",
         "es-errors": "^1.3.0",
@@ -4975,6 +4968,7 @@
       "version": "1.0.4",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/globalthis/-/globalthis-1.0.4.tgz",
       "integrity": "sha1-dDDtOpddl7+1m8zkH1yruvplEjY=",
+      "dev": true,
       "dependencies": {
         "define-properties": "^1.2.1",
         "gopd": "^1.0.1"
@@ -5036,6 +5030,7 @@
       "version": "1.0.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/has-bigints/-/has-bigints-1.0.2.tgz",
       "integrity": "sha1-CHG9Pj1RYm9soJZmaLo11WAtbqo=",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -5191,9 +5186,9 @@
       }
     },
     "node_modules/https-proxy-agent": {
-      "version": "7.0.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
-      "integrity": "sha1-jpe4QaAprY3chzHyZZW62GjLQWg=",
+      "version": "7.0.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
+      "integrity": "sha1-notQE4cymeEfq2/VSEBdotbGArI=",
       "dependencies": {
         "agent-base": "^7.0.2",
         "debug": "4"
@@ -5365,6 +5360,7 @@
       "version": "1.0.7",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/internal-slot/-/internal-slot-1.0.7.tgz",
       "integrity": "sha1-wG3Mo+2HQkmIEAewpVI7FyoZCAI=",
+      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "hasown": "^2.0.0",
@@ -5450,6 +5446,7 @@
       "version": "3.0.4",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
       "integrity": "sha1-eh+Ss9Ye3SvGXSTxMFMOqT1/rpg=",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.2.1"
@@ -5471,6 +5468,7 @@
       "version": "1.0.4",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-bigint/-/is-bigint-1.0.4.tgz",
       "integrity": "sha1-CBR6GHW8KzIAXUHM2Ckd/8ZpHfM=",
+      "dev": true,
       "dependencies": {
         "has-bigints": "^1.0.1"
       },
@@ -5482,6 +5480,7 @@
       "version": "1.1.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
       "integrity": "sha1-XG3CACRt2TIa5LiFoRS7H3X2Nxk=",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -5519,6 +5518,7 @@
       "version": "1.2.7",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha1-O8KoXqdC2eNiBdys3XLKH9xRsFU=",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -5527,11 +5527,14 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.13.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-core-module/-/is-core-module-2.13.1.tgz",
-      "integrity": "sha1-rQ11Msb+qdoevcgnQtdFJcYnM4Q=",
+      "version": "2.14.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-core-module/-/is-core-module-2.14.0.tgz",
+      "integrity": "sha1-Q7jvn0amoIiI22ex/9Tsnj39WdE=",
       "dependencies": {
-        "hasown": "^2.0.0"
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5541,6 +5544,7 @@
       "version": "1.0.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-data-view/-/is-data-view-1.0.1.tgz",
       "integrity": "sha1-S006URtw89wm1CwDypylFdhHdZ8=",
+      "dev": true,
       "dependencies": {
         "is-typed-array": "^1.1.13"
       },
@@ -5555,6 +5559,7 @@
       "version": "1.0.5",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-date-object/-/is-date-object-1.0.5.tgz",
       "integrity": "sha1-CEHVU25yTCVZe/bqYuG9OCmN8x8=",
+      "dev": true,
       "dependencies": {
         "has-tostringtag": "^1.0.0"
       },
@@ -5654,6 +5659,7 @@
       "version": "2.0.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
       "integrity": "sha1-ztkDoCespjgbd3pXQwadc3akl0c=",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -5674,6 +5680,7 @@
       "version": "1.0.7",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-number-object/-/is-number-object-1.0.7.tgz",
       "integrity": "sha1-WdUK2kxFJReE6ZBPUkbHQvB6Qvw=",
+      "dev": true,
       "dependencies": {
         "has-tostringtag": "^1.0.0"
       },
@@ -5716,6 +5723,7 @@
       "version": "1.0.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-shared-array-buffer/-/is-shared-array-buffer-1.0.3.tgz",
       "integrity": "sha1-Ejfxy6BZzbYkMdN43MN9loAYFog=",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.7"
       },
@@ -5741,6 +5749,7 @@
       "version": "1.0.7",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-string/-/is-string-1.0.7.tgz",
       "integrity": "sha1-DdEr8gBvJVu1j2lREO/3SR7rwP0=",
+      "dev": true,
       "dependencies": {
         "has-tostringtag": "^1.0.0"
       },
@@ -5755,6 +5764,7 @@
       "version": "1.0.4",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-symbol/-/is-symbol-1.0.4.tgz",
       "integrity": "sha1-ptrJO2NbBjymhyI23oiRClevE5w=",
+      "dev": true,
       "dependencies": {
         "has-symbols": "^1.0.2"
       },
@@ -5769,6 +5779,7 @@
       "version": "1.1.13",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-typed-array/-/is-typed-array-1.1.13.tgz",
       "integrity": "sha1-1sXKVt9iM0lZMi19fdHMpQ3r4ik=",
+      "dev": true,
       "dependencies": {
         "which-typed-array": "^1.1.14"
       },
@@ -5783,6 +5794,7 @@
       "version": "1.0.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-weakref/-/is-weakref-1.0.2.tgz",
       "integrity": "sha1-lSnzg6kzggXol2XgOS78LxAPBvI=",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2"
       },
@@ -5804,7 +5816,8 @@
     "node_modules/isarray": {
       "version": "2.0.5",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha1-ivHkwSISRMxiRZ+vOJQNTmRKVyM="
+      "integrity": "sha1-ivHkwSISRMxiRZ+vOJQNTmRKVyM=",
+      "dev": true
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -5821,9 +5834,9 @@
       }
     },
     "node_modules/istanbul-lib-instrument": {
-      "version": "6.0.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.2.tgz",
-      "integrity": "sha1-kWVZNs9zgOTkczgwgeOEeLaZk7E=",
+      "version": "6.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "integrity": "sha1-+hVAHfbBWHS8shBfdzMl14xmZ2U=",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.23.9",
@@ -5924,8 +5937,8 @@
     },
     "node_modules/jest": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
-      "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest/-/jest-29.7.0.tgz",
+      "integrity": "sha1-mUZ2/CQXfwiPHF43N/VpcgT/JhM=",
       "dev": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
@@ -6518,11 +6531,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/jsbi": {
-      "version": "4.3.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jsbi/-/jsbi-4.3.0.tgz",
-      "integrity": "sha1-tU7gdPtvy8AGGVWTBcj36RKwR0E="
-    },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jsesc/-/jsesc-2.5.2.tgz",
@@ -6789,88 +6797,13 @@
     },
     "node_modules/login.dfe.audit.winston-sequelize-transport": {
       "version": "3.2.1",
-      "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.audit.winston-sequelize-transport.git#6aab608ca61dcd5607d77e3a8e48301dfac75d2f",
+      "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.audit.winston-sequelize-transport.git#7937950afd8d17f450e0313c0ace4b5d06eb34cd",
       "dependencies": {
         "lodash": "^4.17.15",
         "sequelize": "^6.3.3",
-        "tedious": "^16.4.0",
+        "tedious": "^18.2.1",
         "uuid": "^9.0.0",
         "winston-transport": "^4.5.0"
-      }
-    },
-    "node_modules/login.dfe.audit.winston-sequelize-transport/node_modules/@azure/identity": {
-      "version": "3.4.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/identity/-/identity-3.4.2.tgz",
-      "integrity": "sha1-awFyTJyqx8ratrY8dlhDRb2o4t4=",
-      "dependencies": {
-        "@azure/abort-controller": "^1.0.0",
-        "@azure/core-auth": "^1.5.0",
-        "@azure/core-client": "^1.4.0",
-        "@azure/core-rest-pipeline": "^1.1.0",
-        "@azure/core-tracing": "^1.0.0",
-        "@azure/core-util": "^1.6.1",
-        "@azure/logger": "^1.0.0",
-        "@azure/msal-browser": "^3.5.0",
-        "@azure/msal-node": "^2.5.1",
-        "events": "^3.0.0",
-        "jws": "^4.0.0",
-        "open": "^8.0.0",
-        "stoppable": "^1.1.0",
-        "tslib": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/login.dfe.audit.winston-sequelize-transport/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha1-pS+AvzjaGVLrXGgXkHGYcaGnJQE=",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/login.dfe.audit.winston-sequelize-transport/node_modules/jwa": {
-      "version": "2.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jwa/-/jwa-2.0.0.tgz",
-      "integrity": "sha1-p+nD8p2ulAJ+vK9Jl1yTRVk0EPw=",
-      "dependencies": {
-        "buffer-equal-constant-time": "1.0.1",
-        "ecdsa-sig-formatter": "1.0.11",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/login.dfe.audit.winston-sequelize-transport/node_modules/jws": {
-      "version": "4.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jws/-/jws-4.0.0.tgz",
-      "integrity": "sha1-LU6M9qMY/6oSYV6d7H6G5slzEPQ=",
-      "dependencies": {
-        "jwa": "^2.0.0",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/login.dfe.audit.winston-sequelize-transport/node_modules/tedious": {
-      "version": "16.7.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/tedious/-/tedious-16.7.1.tgz",
-      "integrity": "sha1-EZDzD9maQT8dySUN7kg1zweItlA=",
-      "dependencies": {
-        "@azure/identity": "^3.4.1",
-        "@azure/keyvault-keys": "^4.4.0",
-        "@js-joda/core": "^5.5.3",
-        "bl": "^6.0.3",
-        "es-aggregate-error": "^1.0.9",
-        "iconv-lite": "^0.6.3",
-        "js-md4": "^0.3.2",
-        "jsbi": "^4.3.0",
-        "native-duplexpair": "^1.0.0",
-        "node-abort-controller": "^3.1.1",
-        "sprintf-js": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=16"
       }
     },
     "node_modules/login.dfe.audit.winston-sequelize-transport/node_modules/uuid": {
@@ -7329,11 +7262,6 @@
         "node": "*"
       }
     },
-    "node_modules/node-abort-controller": {
-      "version": "3.1.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
-      "integrity": "sha1-qUN36WSpo3rDl22EjLXHZYM7hUg="
-    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/node-int64/-/node-int64-0.4.0.tgz",
@@ -7341,9 +7269,9 @@
       "dev": true
     },
     "node_modules/node-mocks-http": {
-      "version": "1.14.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/node-mocks-http/-/node-mocks-http-1.14.1.tgz",
-      "integrity": "sha1-ajh84JIp/lRdzAFU0WvDSAYY4BM=",
+      "version": "1.15.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/node-mocks-http/-/node-mocks-http-1.15.0.tgz",
+      "integrity": "sha1-/nux76SrOVc59Al7RPdFRAMmobM=",
       "dev": true,
       "dependencies": {
         "@types/express": "^4.17.21",
@@ -7459,9 +7387,12 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.13.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/object-inspect/-/object-inspect-1.13.1.tgz",
-      "integrity": "sha1-uWxhCTJMz+9rEiFqlWyk3C/5S8I=",
+      "version": "1.13.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/object-inspect/-/object-inspect-1.13.2.tgz",
+      "integrity": "sha1-3qAIhGf7mR5nr0BYFHokgkowQ/8=",
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -7478,6 +7409,7 @@
       "version": "4.1.5",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/object.assign/-/object.assign-4.1.5.tgz",
       "integrity": "sha1-OoM/mrf9uA/J6NIwDIA9IW2P27A=",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.5",
         "define-properties": "^1.2.1",
@@ -8011,6 +7943,7 @@
       "version": "1.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
       "integrity": "sha1-ibtjxvraLD6QrcSmR77us5zHv48=",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -8428,6 +8361,7 @@
       "version": "1.5.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz",
       "integrity": "sha1-E49kSjNQ+YGoWMRPa7GmH/Wb4zQ=",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.6",
         "define-properties": "^1.2.1",
@@ -8589,9 +8523,9 @@
       }
     },
     "node_modules/rhea-promise": {
-      "version": "3.0.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/rhea-promise/-/rhea-promise-3.0.2.tgz",
-      "integrity": "sha1-s0FsWYhfPc8E2RMiuxnWemoKtws=",
+      "version": "3.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/rhea-promise/-/rhea-promise-3.0.3.tgz",
+      "integrity": "sha1-/GjjkBlELFM4o5mbXj4ogG8/ENI=",
       "dependencies": {
         "debug": "^4.0.0",
         "rhea": "^3.0.0",
@@ -8685,6 +8619,7 @@
       "version": "1.1.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/safe-array-concat/-/safe-array-concat-1.1.2.tgz",
       "integrity": "sha1-gdd+4MTouGNjUifHISeN1STCDts=",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "get-intrinsic": "^1.2.4",
@@ -8721,6 +8656,7 @@
       "version": "1.0.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/safe-regex-test/-/safe-regex-test-1.0.3.tgz",
       "integrity": "sha1-pbTA8G4KtQ6iw5XBTYNxIykkw3c=",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.6",
         "es-errors": "^1.3.0",
@@ -8929,6 +8865,7 @@
       "version": "2.0.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/set-function-name/-/set-function-name-2.0.2.tgz",
       "integrity": "sha1-FqcFxaDcL15jjKltiozU4cK5CYU=",
+      "dev": true,
       "dependencies": {
         "define-data-property": "^1.1.4",
         "es-errors": "^1.3.0",
@@ -9179,6 +9116,7 @@
       "version": "1.2.9",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/string.prototype.trim/-/string.prototype.trim-1.2.9.tgz",
       "integrity": "sha1-tvoybXLSx4tt8C93Wcc/j2J0+qQ=",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
@@ -9196,6 +9134,7 @@
       "version": "1.0.8",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/string.prototype.trimend/-/string.prototype.trimend-1.0.8.tgz",
       "integrity": "sha1-NlG4UTcZ6Kn0jefy93ZAsmZSsik=",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
@@ -9209,6 +9148,7 @@
       "version": "1.0.8",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
       "integrity": "sha1-fug03ajHwX7/MRhHK7Nb/tqjTd4=",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
@@ -9544,6 +9484,7 @@
       "version": "1.0.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/typed-array-buffer/-/typed-array-buffer-1.0.2.tgz",
       "integrity": "sha1-GGfF2Dsg/LXM8yZJ5eL8dCRHT/M=",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
@@ -9557,6 +9498,7 @@
       "version": "1.0.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/typed-array-byte-length/-/typed-array-byte-length-1.0.1.tgz",
       "integrity": "sha1-2Sly08/5mj+i52Wij83A8did7Gc=",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "for-each": "^0.3.3",
@@ -9575,6 +9517,7 @@
       "version": "1.0.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/typed-array-byte-offset/-/typed-array-byte-offset-1.0.2.tgz",
       "integrity": "sha1-+eway5JZ85UJPkVn6zwopYDQIGM=",
+      "dev": true,
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
         "call-bind": "^1.0.7",
@@ -9594,6 +9537,7 @@
       "version": "1.0.6",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/typed-array-length/-/typed-array-length-1.0.6.tgz",
       "integrity": "sha1-VxVSB8duZKNFdILf3BydHTxMc6M=",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "for-each": "^0.3.3",
@@ -9624,6 +9568,7 @@
       "version": "1.0.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
       "integrity": "sha1-KQMgIQV9Xmzb0IxRKcIm3/jtb54=",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "has-bigints": "^1.0.2",
@@ -9648,9 +9593,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.16",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/update-browserslist-db/-/update-browserslist-db-1.0.16.tgz",
-      "integrity": "sha1-9tSJ7ZD7LwfWd4TrP1PXiR9zY1Y=",
+      "version": "1.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
+      "integrity": "sha1-fKYcDYZQdmCQcoBG5BaozeaChZ4=",
       "dev": true,
       "funding": [
         {
@@ -9720,9 +9665,9 @@
       }
     },
     "node_modules/v8-to-istanbul": {
-      "version": "9.2.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/v8-to-istanbul/-/v8-to-istanbul-9.2.0.tgz",
-      "integrity": "sha1-LtdkSiRc3dg9Tgh7mzOz5i39EK0=",
+      "version": "9.3.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha1-uVcqv6Yr1VbBbXX968GkEdX/MXU=",
       "dev": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.12",
@@ -9797,6 +9742,7 @@
       "version": "1.0.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
       "integrity": "sha1-E3V7yJsgmwSf5dhkMOIc9AqJqOY=",
+      "dev": true,
       "dependencies": {
         "is-bigint": "^1.0.1",
         "is-boolean-object": "^1.1.0",
@@ -9812,6 +9758,7 @@
       "version": "1.1.15",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/which-typed-array/-/which-typed-array-1.1.15.tgz",
       "integrity": "sha1-JkhZ6bEaZJs4i/qvT3Z98fd5s40=",
+      "dev": true,
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
         "call-bind": "^1.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6893,9 +6893,9 @@
       }
     },
     "node_modules/login.dfe.dao": {
-      "version": "4.2.13",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/login.dfe.dao/-/login.dfe.dao-4.2.13.tgz",
-      "integrity": "sha1-Qjo9k3GIMFdFWwv4UzWy2fxVfC8=",
+      "version": "4.2.15",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/login.dfe.dao/-/login.dfe.dao-4.2.15.tgz",
+      "integrity": "sha1-iLZcqaitaFu3zagKLORogxYb50M=",
       "dependencies": {
         "eslint": "^8.12.0",
         "express": "^4.17.3",
@@ -6906,84 +6906,9 @@
         "sequelize": "^6.17.0",
         "sequelize-mock": "^0.10.2",
         "simpl-schema": "^3.4.1",
-        "tedious": "^16.4.0",
+        "tedious": "^18.2.1",
         "uuid": "^9.0.0",
         "verror": "^1.10.1"
-      }
-    },
-    "node_modules/login.dfe.dao/node_modules/@azure/identity": {
-      "version": "3.4.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/identity/-/identity-3.4.2.tgz",
-      "integrity": "sha1-awFyTJyqx8ratrY8dlhDRb2o4t4=",
-      "dependencies": {
-        "@azure/abort-controller": "^1.0.0",
-        "@azure/core-auth": "^1.5.0",
-        "@azure/core-client": "^1.4.0",
-        "@azure/core-rest-pipeline": "^1.1.0",
-        "@azure/core-tracing": "^1.0.0",
-        "@azure/core-util": "^1.6.1",
-        "@azure/logger": "^1.0.0",
-        "@azure/msal-browser": "^3.5.0",
-        "@azure/msal-node": "^2.5.1",
-        "events": "^3.0.0",
-        "jws": "^4.0.0",
-        "open": "^8.0.0",
-        "stoppable": "^1.1.0",
-        "tslib": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/login.dfe.dao/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha1-pS+AvzjaGVLrXGgXkHGYcaGnJQE=",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/login.dfe.dao/node_modules/jwa": {
-      "version": "2.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jwa/-/jwa-2.0.0.tgz",
-      "integrity": "sha1-p+nD8p2ulAJ+vK9Jl1yTRVk0EPw=",
-      "dependencies": {
-        "buffer-equal-constant-time": "1.0.1",
-        "ecdsa-sig-formatter": "1.0.11",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/login.dfe.dao/node_modules/jws": {
-      "version": "4.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jws/-/jws-4.0.0.tgz",
-      "integrity": "sha1-LU6M9qMY/6oSYV6d7H6G5slzEPQ=",
-      "dependencies": {
-        "jwa": "^2.0.0",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/login.dfe.dao/node_modules/tedious": {
-      "version": "16.7.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/tedious/-/tedious-16.7.1.tgz",
-      "integrity": "sha1-EZDzD9maQT8dySUN7kg1zweItlA=",
-      "dependencies": {
-        "@azure/identity": "^3.4.1",
-        "@azure/keyvault-keys": "^4.4.0",
-        "@js-joda/core": "^5.5.3",
-        "bl": "^6.0.3",
-        "es-aggregate-error": "^1.0.9",
-        "iconv-lite": "^0.6.3",
-        "js-md4": "^0.3.2",
-        "jsbi": "^4.3.0",
-        "native-duplexpair": "^1.0.0",
-        "node-abort-controller": "^3.1.1",
-        "sprintf-js": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=16"
       }
     },
     "node_modules/login.dfe.dao/node_modules/uuid": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "ioredis": "^5.3.2",
         "lodash": "^4.17.21",
         "login.dfe.async-retry": "github:DFE-Digital/login.dfe.async-retry#v2.0.3",
-        "login.dfe.audit.winston-sequelize-transport": "github:DFE-Digital/login.dfe.audit.winston-sequelize-transport#v3.2.1",
+        "login.dfe.audit.winston-sequelize-transport": "github:DFE-Digital/login.dfe.audit.winston-sequelize-transport#v3.2.2",
         "login.dfe.config.schema.common": "github:DFE-Digital/login.dfe.config.schema.common#v2.1.4",
         "login.dfe.dao": "^4.2.12",
         "login.dfe.express-error-handling": "github:DFE-Digital/login.dfe.express-error-handling#v3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "passport": "^0.6.0",
         "sequelize": "^6.18.0",
         "simpl-schema": "^3.4.1",
-        "tedious": "^16.4.0",
+        "tedious": "^18.2.1",
         "uuid": "^8.3.2",
         "winston": "^3.3.3"
       },
@@ -308,19 +308,19 @@
       }
     },
     "node_modules/@azure/identity": {
-      "version": "3.4.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/identity/-/identity-3.4.2.tgz",
-      "integrity": "sha1-awFyTJyqx8ratrY8dlhDRb2o4t4=",
+      "version": "4.3.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/identity/-/identity-4.3.0.tgz",
+      "integrity": "sha1-6NprO/HfTeFRHoE6cWaktbSpnKE=",
       "dependencies": {
         "@azure/abort-controller": "^1.0.0",
         "@azure/core-auth": "^1.5.0",
-        "@azure/core-client": "^1.4.0",
+        "@azure/core-client": "^1.9.2",
         "@azure/core-rest-pipeline": "^1.1.0",
         "@azure/core-tracing": "^1.0.0",
-        "@azure/core-util": "^1.6.1",
+        "@azure/core-util": "^1.3.0",
         "@azure/logger": "^1.0.0",
-        "@azure/msal-browser": "^3.5.0",
-        "@azure/msal-node": "^2.5.1",
+        "@azure/msal-browser": "^3.11.1",
+        "@azure/msal-node": "^2.9.2",
         "events": "^3.0.0",
         "jws": "^4.0.0",
         "open": "^8.0.0",
@@ -328,7 +328,7 @@
         "tslib": "^2.2.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@azure/identity/node_modules/jwa": {
@@ -383,30 +383,30 @@
       }
     },
     "node_modules/@azure/msal-browser": {
-      "version": "3.16.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-browser/-/msal-browser-3.16.0.tgz",
-      "integrity": "sha1-8eLclXAGeDspgWJz1TF2ERYhWjM=",
+      "version": "3.18.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-browser/-/msal-browser-3.18.0.tgz",
+      "integrity": "sha1-2rveLFMZWi4OyEBPYfM3yCwVm3E=",
       "dependencies": {
-        "@azure/msal-common": "14.11.0"
+        "@azure/msal-common": "14.13.0"
       },
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-common": {
-      "version": "14.11.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-common/-/msal-common-14.11.0.tgz",
-      "integrity": "sha1-o0SDrmsQCdAFhHLyxdtFaQcdxRo=",
+      "version": "14.13.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-common/-/msal-common-14.13.0.tgz",
+      "integrity": "sha1-c3e0kJpG0Z6pHa3SSvdwXmqpR68=",
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "2.9.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-node/-/msal-node-2.9.1.tgz",
-      "integrity": "sha1-HcAn9jeJYSzN9J2nIqaAAdQ0oE4=",
+      "version": "2.10.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-node/-/msal-node-2.10.0.tgz",
+      "integrity": "sha1-C4k6sF2+9cljq6CAyIoDMDk8SXM=",
       "dependencies": {
-        "@azure/msal-common": "14.11.0",
+        "@azure/msal-common": "14.13.0",
         "jsonwebtoken": "^9.0.0",
         "uuid": "^8.3.0"
       },
@@ -6798,6 +6798,81 @@
         "winston-transport": "^4.5.0"
       }
     },
+    "node_modules/login.dfe.audit.winston-sequelize-transport/node_modules/@azure/identity": {
+      "version": "3.4.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/identity/-/identity-3.4.2.tgz",
+      "integrity": "sha1-awFyTJyqx8ratrY8dlhDRb2o4t4=",
+      "dependencies": {
+        "@azure/abort-controller": "^1.0.0",
+        "@azure/core-auth": "^1.5.0",
+        "@azure/core-client": "^1.4.0",
+        "@azure/core-rest-pipeline": "^1.1.0",
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-util": "^1.6.1",
+        "@azure/logger": "^1.0.0",
+        "@azure/msal-browser": "^3.5.0",
+        "@azure/msal-node": "^2.5.1",
+        "events": "^3.0.0",
+        "jws": "^4.0.0",
+        "open": "^8.0.0",
+        "stoppable": "^1.1.0",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/login.dfe.audit.winston-sequelize-transport/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha1-pS+AvzjaGVLrXGgXkHGYcaGnJQE=",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/login.dfe.audit.winston-sequelize-transport/node_modules/jwa": {
+      "version": "2.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jwa/-/jwa-2.0.0.tgz",
+      "integrity": "sha1-p+nD8p2ulAJ+vK9Jl1yTRVk0EPw=",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/login.dfe.audit.winston-sequelize-transport/node_modules/jws": {
+      "version": "4.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jws/-/jws-4.0.0.tgz",
+      "integrity": "sha1-LU6M9qMY/6oSYV6d7H6G5slzEPQ=",
+      "dependencies": {
+        "jwa": "^2.0.0",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/login.dfe.audit.winston-sequelize-transport/node_modules/tedious": {
+      "version": "16.7.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/tedious/-/tedious-16.7.1.tgz",
+      "integrity": "sha1-EZDzD9maQT8dySUN7kg1zweItlA=",
+      "dependencies": {
+        "@azure/identity": "^3.4.1",
+        "@azure/keyvault-keys": "^4.4.0",
+        "@js-joda/core": "^5.5.3",
+        "bl": "^6.0.3",
+        "es-aggregate-error": "^1.0.9",
+        "iconv-lite": "^0.6.3",
+        "js-md4": "^0.3.2",
+        "jsbi": "^4.3.0",
+        "native-duplexpair": "^1.0.0",
+        "node-abort-controller": "^3.1.1",
+        "sprintf-js": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/login.dfe.audit.winston-sequelize-transport/node_modules/uuid": {
       "version": "9.0.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/uuid/-/uuid-9.0.1.tgz",
@@ -6834,6 +6909,81 @@
         "tedious": "^16.4.0",
         "uuid": "^9.0.0",
         "verror": "^1.10.1"
+      }
+    },
+    "node_modules/login.dfe.dao/node_modules/@azure/identity": {
+      "version": "3.4.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/identity/-/identity-3.4.2.tgz",
+      "integrity": "sha1-awFyTJyqx8ratrY8dlhDRb2o4t4=",
+      "dependencies": {
+        "@azure/abort-controller": "^1.0.0",
+        "@azure/core-auth": "^1.5.0",
+        "@azure/core-client": "^1.4.0",
+        "@azure/core-rest-pipeline": "^1.1.0",
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-util": "^1.6.1",
+        "@azure/logger": "^1.0.0",
+        "@azure/msal-browser": "^3.5.0",
+        "@azure/msal-node": "^2.5.1",
+        "events": "^3.0.0",
+        "jws": "^4.0.0",
+        "open": "^8.0.0",
+        "stoppable": "^1.1.0",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/login.dfe.dao/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha1-pS+AvzjaGVLrXGgXkHGYcaGnJQE=",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/login.dfe.dao/node_modules/jwa": {
+      "version": "2.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jwa/-/jwa-2.0.0.tgz",
+      "integrity": "sha1-p+nD8p2ulAJ+vK9Jl1yTRVk0EPw=",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/login.dfe.dao/node_modules/jws": {
+      "version": "4.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jws/-/jws-4.0.0.tgz",
+      "integrity": "sha1-LU6M9qMY/6oSYV6d7H6G5slzEPQ=",
+      "dependencies": {
+        "jwa": "^2.0.0",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/login.dfe.dao/node_modules/tedious": {
+      "version": "16.7.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/tedious/-/tedious-16.7.1.tgz",
+      "integrity": "sha1-EZDzD9maQT8dySUN7kg1zweItlA=",
+      "dependencies": {
+        "@azure/identity": "^3.4.1",
+        "@azure/keyvault-keys": "^4.4.0",
+        "@js-joda/core": "^5.5.3",
+        "bl": "^6.0.3",
+        "es-aggregate-error": "^1.0.9",
+        "iconv-lite": "^0.6.3",
+        "js-md4": "^0.3.2",
+        "jsbi": "^4.3.0",
+        "native-duplexpair": "^1.0.0",
+        "node-abort-controller": "^3.1.1",
+        "sprintf-js": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/login.dfe.dao/node_modules/uuid": {
@@ -9259,24 +9409,22 @@
       }
     },
     "node_modules/tedious": {
-      "version": "16.7.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/tedious/-/tedious-16.7.1.tgz",
-      "integrity": "sha1-EZDzD9maQT8dySUN7kg1zweItlA=",
+      "version": "18.2.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/tedious/-/tedious-18.2.1.tgz",
+      "integrity": "sha1-s4IYi6e1yAo7Empch26C9P9efwk=",
       "dependencies": {
-        "@azure/identity": "^3.4.1",
+        "@azure/identity": "^4.2.1",
         "@azure/keyvault-keys": "^4.4.0",
-        "@js-joda/core": "^5.5.3",
-        "bl": "^6.0.3",
-        "es-aggregate-error": "^1.0.9",
+        "@js-joda/core": "^5.6.1",
+        "@types/node": ">=18",
+        "bl": "^6.0.11",
         "iconv-lite": "^0.6.3",
         "js-md4": "^0.3.2",
-        "jsbi": "^4.3.0",
         "native-duplexpair": "^1.0.0",
-        "node-abort-controller": "^3.1.1",
-        "sprintf-js": "^1.1.2"
+        "sprintf-js": "^1.1.3"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/tedious/node_modules/iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "passport": "^0.6.0",
     "sequelize": "^6.18.0",
     "simpl-schema": "^3.4.1",
-    "tedious": "^16.4.0",
+    "tedious": "^18.2.1",
     "uuid": "^8.3.2",
     "winston": "^3.3.3"
   },

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "ioredis": "^5.3.2",
     "lodash": "^4.17.21",
     "login.dfe.async-retry": "github:DFE-Digital/login.dfe.async-retry#v2.0.3",
-    "login.dfe.audit.winston-sequelize-transport": "github:DFE-Digital/login.dfe.audit.winston-sequelize-transport#v3.2.1",
+    "login.dfe.audit.winston-sequelize-transport": "github:DFE-Digital/login.dfe.audit.winston-sequelize-transport#v3.2.2",
     "login.dfe.config.schema.common": "github:DFE-Digital/login.dfe.config.schema.common#v2.1.4",
     "login.dfe.dao": "^4.2.12",
     "login.dfe.express-error-handling": "github:DFE-Digital/login.dfe.express-error-handling#v3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "login.dfe.support",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "",
   "scripts": {
     "web": "settings='./config/support.dev.json' node src/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -57,37 +57,45 @@ const init = async () => {
 
   const app = express();
 
+  logger.info('set helmet policy defaults');
+  
+
   if (config.hostingEnvironment.hstsMaxAge) {
-   app.use(helmet({
-      noCache: true,
-      frameguard: {
-        action: 'deny',
-      },
-      hsts: {
+    app.use(helmet({
+      strictTransportSecurity: {
         maxAge: config.hostingEnvironment.hstsMaxAge,
         preload: true,
+        includeSubDomains: true,
       },
     }));
   }
 
-  logger.info('set helmet policy defaults');
+  const self = "'self'";
+  const allowedOrigin = '*.signin.education.gov.uk';
 
   // Setting helmet Content Security Policy
-  const scriptSources = ["'self'", "'unsafe-inline'", "'unsafe-eval'", 'localhost', '*.signin.education.gov.uk'];
+  const scriptSources = [self, "'unsafe-inline'", "'unsafe-eval'", allowedOrigin];
+  const styleSources = [self, "'unsafe-inline'", allowedOrigin];
+  const imgSources = [self, 'data:', 'blob:', allowedOrigin];
+  const fontSources = [self, 'data:', allowedOrigin];
+
+  if (config.hostingEnvironment.env === 'dev') {
+    scriptSources.push('localhost');
+    styleSources.push('localhost');
+    imgSources.push('localhost');
+    fontSources.push('localhost');
+  }
+
 
   app.use(helmet.contentSecurityPolicy({
-    browserSniff: false,
-    setAllHeaders: false,
     directives: {
-      defaultSrc: ["'self'"],
-      childSrc: ["'none'"],
-      objectSrc: ["'none'"],
+      defaultSrc: [self],
       scriptSrc: scriptSources,
-      styleSrc: ["'self'", "'unsafe-inline'", 'localhost', '*.signin.education.gov.uk'],
-      imgSrc: ["'self'", 'data:', 'blob:', 'localhost', '*.signin.education.gov.uk'],
-      fontSrc: ["'self'", 'data:', '*.signin.education.gov.uk'],
-      connectSrc: ["'self'"],
-      formAction: ["'self'", '*'],
+      styleSrc: styleSources,
+      imgSrc: imgSources,
+      fontSrc: fontSources,
+      connectSrc: [self],
+      formAction: [self, '*'],
     },
   }));
 


### PR DESCRIPTION
Update some of the http-response-headers.

- `content-security-policy` header wasn't as secure as it could be; namely, it included `localhost` in production. This has been changed so that it only outputs `localhost` in `dev`
- `x-contact-type-options` now set to `nosniff`

Equally, at the time of writing `npm audit` reported `1 medium vulnerability` with `tedious` which has now been upgraded; `npm audit` now reports `0 vulnerabilities`.