### PR TITLE
Feature/nsa 7928 changing deactivation message optional to mandatory

### DIFF
--- a/src/app/users/views/confirmInvitationDeactivate.ejs
+++ b/src/app/users/views/confirmInvitationDeactivate.ejs
@@ -8,7 +8,7 @@
             <fieldset>
                 <legend><p>Please confirm you would like to deactivate the user.</p></legend>
                 <div class="form-group <%= (locals.validationMessages.reason !== undefined) ? 'form-group-error' : '' %>">
-                    <label class="form-label" for="reason">Reason for deactivation of user (optional)</span> </label>
+                    <label class="form-label" for="reason">Reason for deactivation of user (mandatory)</span> </label>
                     <% if (locals.validationMessages.reason !== undefined) { %>
                     <p class="error-message" id="validation-reason"><%= locals.validationMessages.reason %></p>
                     <% } %>


### PR DESCRIPTION
Support Console - change the displayed message when deactivating an invited user from 'optional' to 'mandatory'.