### PR TITLE
[NSA-8499] Add manage console identifier to key vault 

### DIFF
--- a/src/app/users/getManageConsoleRoles.js
+++ b/src/app/users/getManageConsoleRoles.js
@@ -27,11 +27,10 @@ const checkIfRolesChanged = (rolesSelectedBeforeSession, newRolesSelected) => {
 
 const getManageConsoleRoles = async (req, res) => {
 
-  const manage = await getServiceById('manage');
   const serviceSelectedByUser = await getServiceById(req.params.sid);
   const user = await getUserDetails(req);
-  const userManageRoles = await getSingleServiceForUser(req.params.uid, config.access.identifiers.departmentForEducation, manage.id, req.id);
-  const manageConsoleRolesForAllServices = await listRolesOfService(manage.id);
+  const userManageRoles = await getSingleServiceForUser(req.params.uid, config.access.identifiers.departmentForEducation, config.access.identifiers.manageServiceIdentifiers, req.id);
+  const manageConsoleRolesForAllServices = await listRolesOfService(config.access.identifiers.manageServiceIdentifiers);
   const manageConsoleRolesForSelectedService = manageConsoleRolesForAllServices.filter(service => service.code.split('_')[0] === req.params.sid);
   const manageConsoleRoleIds = manageConsoleRolesForSelectedService.map(service => service.id);
   const addOrChangeService = addOrChangeManageConsoleServiceTitle(userManageRoles, manageConsoleRoleIds);

--- a/src/app/users/getManageConsoleRoles.js
+++ b/src/app/users/getManageConsoleRoles.js
@@ -4,6 +4,9 @@ const { getUserDetails } = require('./utils');
 const { getServiceById } = require('../../infrastructure/applications')
 const { listRolesOfService, getSingleUserService, getSingleInvitationService } = require('../../infrastructure/access');
 
+const manageServiceId = config.access.identifiers.manageService;
+const dfeId = config.access.identifiers.departmentForEducation;
+
 const getSingleServiceForUser = async (userId, organisationId, serviceId, correlationId) => {
   const userService = userId.startsWith('inv-') ? await getSingleInvitationService(userId.substr(4), serviceId, organisationId, correlationId) : await getSingleUserService(userId, serviceId, organisationId, correlationId);
   const application = await getServiceById(serviceId, correlationId);
@@ -29,8 +32,8 @@ const getManageConsoleRoles = async (req, res) => {
 
   const serviceSelectedByUser = await getServiceById(req.params.sid);
   const user = await getUserDetails(req);
-  const userManageRoles = await getSingleServiceForUser(req.params.uid, config.access.identifiers.departmentForEducation, config.access.identifiers.manageServiceIdentifiers, req.id);
-  const manageConsoleRolesForAllServices = await listRolesOfService(config.access.identifiers.manageServiceIdentifiers);
+  const userManageRoles = await getSingleServiceForUser(req.params.uid, dfeId, manageServiceId, req.id);
+  const manageConsoleRolesForAllServices = await listRolesOfService(manageServiceId);
   const manageConsoleRolesForSelectedService = manageConsoleRolesForAllServices.filter(service => service.code.split('_')[0] === req.params.sid);
   const manageConsoleRoleIds = manageConsoleRolesForSelectedService.map(service => service.id);
   const addOrChangeService = addOrChangeManageConsoleServiceTitle(userManageRoles, manageConsoleRoleIds);

--- a/src/app/users/postManageConsoleRoles.js
+++ b/src/app/users/postManageConsoleRoles.js
@@ -13,11 +13,10 @@ const postManageConsoleRoles = async (req, res) => {
     rolesSelectedNew = [req.body.role];
   };
 
-  const manage = await getServiceById('manage');
   const serviceSelectedByUser = await getServiceById(req.params.sid);
   const user = await getUserDetails(req);
-  const userManageRoles = await getSingleServiceForUser(req.params.uid, config.access.identifiers.departmentForEducation, manage.id, req.id);
-  const manageConsoleRolesForAllServices = await listRolesOfService(manage.id);
+  const userManageRoles = await getSingleServiceForUser(req.params.uid, config.access.identifiers.departmentForEducation, config.access.identifiers.manageServiceIdentifiers, req.id);
+  const manageConsoleRolesForAllServices = await listRolesOfService(config.access.identifiers.manageServiceIdentifiers);
   const manageConsoleRolesForSelectedService = manageConsoleRolesForAllServices.filter(service => service.code.split('_')[0] === req.params.sid);
   let manageConsoleRoleIds = [];
   manageConsoleRolesForSelectedService.forEach(obj => manageConsoleRoleIds.push(obj.id));
@@ -53,13 +52,13 @@ const postManageConsoleRoles = async (req, res) => {
   if (!checkIfRolesChanged(currentRoles, newRoles)) {
     return res.redirect(`/users/${req.params.uid}/manage-console-services`);
   } else if (user.hasManageAccess) {
-    updateUserService(req.params.uid, manage.id, config.access.identifiers.departmentForEducation, newRoles, req.id);
+    updateUserService(req.params.uid, config.access.identifiers.manageServiceIdentifiers, config.access.identifiers.departmentForEducation, newRoles, req.id);
 
     res.flash('info', [`Roles updated`, `The selected roles have been updated for ${serviceSelectedByUser.name}`]);
     return res.redirect(`/users/${req.params.uid}/manage-console-services`);
   } else {
     await putUserInOrganisation(req.params.uid, config.access.identifiers.departmentForEducation, 1, 0, req.id);
-    addUserService(req.params.uid, manage.id, config.access.identifiers.departmentForEducation, newRoles, req.id);
+    addUserService(req.params.uid, config.access.identifiers.manageServiceIdentifiers, config.access.identifiers.departmentForEducation, newRoles, req.id);
     res.flash('info', [`Roles updated`, `The selected roles have been updated for ${serviceSelectedByUser.name}`]);
     return res.redirect(`/users/${req.params.uid}/manage-console-services`);
   };

--- a/src/app/users/postManageConsoleRoles.js
+++ b/src/app/users/postManageConsoleRoles.js
@@ -6,6 +6,10 @@ const { listRolesOfService, updateUserService, addUserService } = require('../..
 const { getSingleServiceForUser, addOrChangeManageConsoleServiceTitle, checkIfRolesChanged } = require('./getManageConsoleRoles');
 const { putUserInOrganisation } = require('./../../infrastructure/organisations');
 
+
+const manageServiceId = config.access.identifiers.manageService;
+const dfeId = config.access.identifiers.departmentForEducation;
+
 const postManageConsoleRoles = async (req, res) => {
 
   let rolesSelectedNew = req.body.role ? req.body.role : [];
@@ -15,8 +19,8 @@ const postManageConsoleRoles = async (req, res) => {
 
   const serviceSelectedByUser = await getServiceById(req.params.sid);
   const user = await getUserDetails(req);
-  const userManageRoles = await getSingleServiceForUser(req.params.uid, config.access.identifiers.departmentForEducation, config.access.identifiers.manageServiceIdentifiers, req.id);
-  const manageConsoleRolesForAllServices = await listRolesOfService(config.access.identifiers.manageServiceIdentifiers);
+  const userManageRoles = await getSingleServiceForUser(req.params.uid, dfeId, manageServiceId, req.id);
+  const manageConsoleRolesForAllServices = await listRolesOfService(manageServiceId);
   const manageConsoleRolesForSelectedService = manageConsoleRolesForAllServices.filter(service => service.code.split('_')[0] === req.params.sid);
   let manageConsoleRoleIds = [];
   manageConsoleRolesForSelectedService.forEach(obj => manageConsoleRoleIds.push(obj.id));
@@ -52,13 +56,13 @@ const postManageConsoleRoles = async (req, res) => {
   if (!checkIfRolesChanged(currentRoles, newRoles)) {
     return res.redirect(`/users/${req.params.uid}/manage-console-services`);
   } else if (user.hasManageAccess) {
-    updateUserService(req.params.uid, config.access.identifiers.manageServiceIdentifiers, config.access.identifiers.departmentForEducation, newRoles, req.id);
+    updateUserService(req.params.uid, manageServiceId, dfeId, newRoles, req.id);
 
     res.flash('info', [`Roles updated`, `The selected roles have been updated for ${serviceSelectedByUser.name}`]);
     return res.redirect(`/users/${req.params.uid}/manage-console-services`);
   } else {
-    await putUserInOrganisation(req.params.uid, config.access.identifiers.departmentForEducation, 1, 0, req.id);
-    addUserService(req.params.uid, config.access.identifiers.manageServiceIdentifiers, config.access.identifiers.departmentForEducation, newRoles, req.id);
+    await putUserInOrganisation(req.params.uid, dfeId, 1, 0, req.id);
+    addUserService(req.params.uid, manageServiceId, dfeId, newRoles, req.id);
     res.flash('info', [`Roles updated`, `The selected roles have been updated for ${serviceSelectedByUser.name}`]);
     return res.redirect(`/users/${req.params.uid}/manage-console-services`);
   };

--- a/src/app/users/utils.js
+++ b/src/app/users/utils.js
@@ -13,7 +13,6 @@ const {
     getServicesByUserId,
     getServicesByInvitationId
 } = require('./../../infrastructure/access');
-const { getServiceById } = require('./../../infrastructure/applications');
 const { mapUserStatus } = require('./../../infrastructure/utils');
 const config = require('./../../infrastructure/config');
 const sortBy = require('lodash/sortBy');
@@ -225,8 +224,7 @@ const mapUserToSupportModel = (user, userFromSearch) => {
 };
 
 const checkManageAccess = async (arr) => {
-    const manage = await getServiceById('manage');
-    return arr.some((entry) => entry.serviceId === manage.id);
+    return arr.some((entry) => entry.serviceId === config.access.identifiers.manageServiceIdentifiers);
 };
 
 const getUserDetailsById = async (uid, correlationId) => {

--- a/src/infrastructure/config/schema.js
+++ b/src/infrastructure/config/schema.js
@@ -131,7 +131,6 @@ const notificationsSchema = new SimpleSchema({
   connectionString: patterns.redis
 });
 
-
 const accessIdentifiers = new SimpleSchema({
   identifiers: {
     type: Object,
@@ -139,6 +138,7 @@ const accessIdentifiers = new SimpleSchema({
   'identifiers.service': patterns.uuid,
   'identifiers.organisation': patterns.uuid,
   'identifiers.departmentForEducation': patterns.uuid,
+  'identifiers.manageServiceIdentifiers': patterns.uuid,
 });
 
 accessIdentifiers.extend(schemas.apiClient);

--- a/src/infrastructure/config/schema.js
+++ b/src/infrastructure/config/schema.js
@@ -138,7 +138,7 @@ const accessIdentifiers = new SimpleSchema({
   'identifiers.service': patterns.uuid,
   'identifiers.organisation': patterns.uuid,
   'identifiers.departmentForEducation': patterns.uuid,
-  'identifiers.manageServiceIdentifiers': patterns.uuid,
+  'identifiers.manageService': patterns.uuid,
 });
 
 accessIdentifiers.extend(schemas.apiClient);

--- a/test/app/users/getManageConsoleRoles.test.js
+++ b/test/app/users/getManageConsoleRoles.test.js
@@ -11,6 +11,11 @@ jest.mock('./../../../src/infrastructure/config', () =>
       service: {
         url: 'http://support.test',
       },
+    access: {
+      identifiers: {
+        manageService: 'manageServiceId',
+      },
+    },
     },
   })
 );

--- a/test/app/users/getManageConsoleRoles.test.js
+++ b/test/app/users/getManageConsoleRoles.test.js
@@ -4,21 +4,22 @@ const {
   checkIfRolesChanged 
 } = require('./../../../src/app/users/getManageConsoleRoles');
 
-jest.mock('./../../../src/infrastructure/config', () => 
-  require('./../../utils').configMockFactory({
-    support: {
-      type: 'api',
-      service: {
-        url: 'http://support.test',
-      },
-    access: {
-      identifiers: {
-        manageService: 'manageServiceId',
-      },
+jest.mock('./../../../src/infrastructure/config', () => require('./../../utils').configMockFactory({
+  support: {
+    type: 'api',
+    service: {
+      url: 'http://support.test',
     },
-    },
-  })
-);
+  },
+  access: {
+    identifiers: {
+      // service: "service1",
+      // organisation: "organisation1",
+      departmentForEducation: "departmentForEducation1",
+      manageService: "manageService1"
+    }
+  }
+}));
 
 jest.mock('./../../../src/infrastructure/utils', () => ({
   sendResult: jest.fn(),

--- a/test/app/users/postManageConsoleRoles.test.js
+++ b/test/app/users/postManageConsoleRoles.test.js
@@ -11,7 +11,8 @@ jest.mock('./../../../src/infrastructure/config', () => require('./../../utils')
     identifiers: {
       service: "service1",
       organisation: "organisation1",
-      departmentForEducation: "departmentForEducation1"
+      departmentForEducation: "departmentForEducation1",
+      manageServiceIdentifiers: "manageServiceIdentifiers1"
     }
   }
 }));
@@ -103,11 +104,10 @@ describe('when changing a user\'s manage console access', () => {
 
     await postManageConsoleRoles(req, res);
 
-    expect(getServiceById).toHaveBeenCalled();
     expect(updateUserService).toHaveBeenCalledTimes(1);
     expect(updateUserService).toHaveBeenCalledWith(
       'userId',
-      'testService1',
+      'manageServiceIdentifiers1', 
       'departmentForEducation1',
       ['role1', 'role2'],
       'correlationId'
@@ -148,13 +148,12 @@ describe('when changing a user\'s manage console access', () => {
 
     await postManageConsoleRoles(req, res);
 
-    expect(getServiceById).toHaveBeenCalled();
     expect(putUserInOrganisation).toHaveBeenCalledTimes(1);
     expect(addUserService).toHaveBeenCalledTimes(1);
     expect(updateUserService).not.toHaveBeenCalled()
     expect(addUserService).toHaveBeenCalledWith(
       'userId',
-      'testService1',
+      'manageServiceIdentifiers1',
       'departmentForEducation1',
       ['role1', 'role2'],
       'correlationId'

--- a/test/app/users/postManageConsoleRoles.test.js
+++ b/test/app/users/postManageConsoleRoles.test.js
@@ -12,7 +12,7 @@ jest.mock('./../../../src/infrastructure/config', () => require('./../../utils')
       service: "service1",
       organisation: "organisation1",
       departmentForEducation: "departmentForEducation1",
-      manageServiceIdentifiers: "manageServiceIdentifiers1"
+      manageService: "manageService1"
     }
   }
 }));
@@ -107,7 +107,7 @@ describe('when changing a user\'s manage console access', () => {
     expect(updateUserService).toHaveBeenCalledTimes(1);
     expect(updateUserService).toHaveBeenCalledWith(
       'userId',
-      'manageServiceIdentifiers1', 
+      'manageService1', 
       'departmentForEducation1',
       ['role1', 'role2'],
       'correlationId'
@@ -153,7 +153,7 @@ describe('when changing a user\'s manage console access', () => {
     expect(updateUserService).not.toHaveBeenCalled()
     expect(addUserService).toHaveBeenCalledWith(
       'userId',
-      'manageServiceIdentifiers1',
+      'manageService1',
       'departmentForEducation1',
       ['role1', 'role2'],
       'correlationId'


### PR DESCRIPTION
- Added manage console id to schema
- Removed calls to getServiceById relating to the Manage Console service in getManageConsoleRoles and postManageConsoleRoles, and updated relevant function calls to use manageServiceIdentifier
- Updated tests to reflect the above changes