### PR TITLE
[DSI-7232] User search results disappear when the sort option is used

### DIFF
--- a/src/app/users/search.js
+++ b/src/app/users/search.js
@@ -4,11 +4,13 @@ const { userStatusMap } = require('./../../infrastructure/utils');
 const config = require('./../../infrastructure/config');
 const { getOrganisationCategories } = require('./../../infrastructure/organisations');
 const { getAllServices } = require('./../../infrastructure/applications');
+
 const clearNewUserSessionData = (req) => {
   if (req.session.user) {
     req.session.user = undefined;
   }
 };
+
 const unpackMultiSelect = (parameter) => {
   if (!parameter) {
     return [];
@@ -27,7 +29,6 @@ const getFiltersModel = async (req) => {
       ...req.session.params
     }
   }
-
 
   let showFilters = false;
   if (paramsSource.showFilters !== undefined && paramsSource.showFilters.toLowerCase() === 'true') {
@@ -114,6 +115,8 @@ const get = async (req, res) => {
 
   if (req.session.params?.redirectedFromSearchResult) {
     req.session.params.redirectedFromSearchResult = undefined;
+    await post(req, res);
+  } else if ((req?.query?.search ?? '' === ' true')) {
     await post(req, res);
   } else {
     const model = await buildModel(req);

--- a/src/app/users/utils.js
+++ b/src/app/users/utils.js
@@ -123,7 +123,7 @@ const search = async (req) => {
 
     let sortBy = paramsSource.sort ? paramsSource.sort.toLowerCase() : 'name';
     let sortAsc =
-        (paramsSource.sortdir ? paramsSource.sortdir : 'asc').toLowerCase() ===
+        (paramsSource.sortDir ? paramsSource.sortDir : 'asc').toLowerCase() ===
         'asc';
 
     const filter = buildFilters(paramsSource);

--- a/src/app/users/views/search.ejs
+++ b/src/app/users/views/search.ejs
@@ -51,6 +51,8 @@ if (services && services.length > 0) {
             <form method="post">
                 <input type="hidden" name="_csrf" value="<%= csrfToken %>"/>
                 <input type="hidden" name="showFilters" value="<%= showFilters %>"/>
+                <input type="hidden" name="sort" value="<%= sortBy %>"/>
+                <input type="hidden" name="sortDir" value="<%= sortOrder %>"/>
 
                 <% for (let i = 0; i < organisationTypes.length; i += 1) { %>
                 <% if (organisationTypes[i].isSelected) { %>
@@ -215,23 +217,23 @@ if (services && services.length > 0) {
             %>
             <tr class="sortable">
                 <th scope="col" class="cwp-15">
-                    <a href="<%=baseSortUri%>&sort=name&sortdir=<%= sort.name.nextDirection %>"
+                    <a href="<%=baseSortUri%>&sort=name&sortDir=<%= sort.name.nextDirection %>&search=true"
                        class="<% if (sort.name.applied) { %>sorted dir-<%= (sort.name.nextDirection === 'desc') ? 'd' : 'a' %> <% } %>"
                     >Name</a></th>
                 <th scope="col" class="cwp-35">
-                    <a href="<%=baseSortUri%>&sort=email&sortdir=<%= sort.email.nextDirection %>"
+                    <a href="<%=baseSortUri%>&sort=email&sortDir=<%= sort.email.nextDirection %>&search=true"
                        class="<% if (sort.email.applied) { %>sorted dir-<%= (sort.email.nextDirection === 'desc') ? 'd' : 'a' %> <% } %>"
                     >Email</a></th>
                 <th scope="col" class="cwp-25">
-                    <a href="<%=baseSortUri%>&sort=organisation&sortdir=<%= sort.organisation.nextDirection %>"
+                    <a href="<%=baseSortUri%>&sort=organisation&sortDir=<%= sort.organisation.nextDirection %>&search=true"
                        class="<% if (sort.organisation.applied) { %>sorted dir-<%= (sort.organisation.nextDirection === 'desc') ? 'd' : 'a' %> <% } %>"
                     >Organisation</a></th>
                 <th scope="col" class="cwp-15">
-                    <a href="<%=baseSortUri%>&sort=lastlogin&sortdir=<%= sort.lastLogin.nextDirection %>"
+                    <a href="<%=baseSortUri%>&sort=lastlogin&sortDir=<%= sort.lastLogin.nextDirection %>&search=true"
                        class="<% if (sort.lastLogin.applied) { %>sorted dir-<%= (sort.lastLogin.nextDirection === 'desc') ? 'd' : 'a' %> <% } %>"
                     >Last Login</a></th>
                 <th scope="col" class="cwp-10">
-                    <a href="<%=baseSortUri%>&sort=status&sortdir=<%= sort.status.nextDirection %>"
+                    <a href="<%=baseSortUri%>&sort=status&sortDir=<%= sort.status.nextDirection %>&search=true"
                        class="<% if (sort.status.applied) { %>sorted dir-<%= (sort.status.nextDirection === 'desc') ? 'd' : 'a' %> <% } %>"
                     >Status</a></th>
             </tr>

--- a/test/app/users/utils.search.test.js
+++ b/test/app/users/utils.search.test.js
@@ -266,7 +266,7 @@ describe('When processing a user search request', () => {
 
     test('then it should use sort order specified', async () => {
       req.query.sort = 'email';
-      req.query.sortdir = 'desc';
+      req.query.sortDir = 'desc';
 
       const actual = await search(req);
 


### PR DESCRIPTION
### Summary
Jira ticket: [DSI-7232](https://dfe-secureaccess.atlassian.net/browse/DSI-7232)

### Changes
- change occurrences of `sortdir` to be `sortDir` so that its consistent across GET/POST requests
- modify sort header link to include query-parameter `search=true` so that a GET request knows when to search
- add `sort` and `sortDir` into the search name form, so that the options are persisted
- fix test case