### PR TITLE
[NSA-8656] Add dropdown to deactivate invited user view

### DIFF
--- a/src/app/users/postConfirmInvitationDeactivate.js
+++ b/src/app/users/postConfirmInvitationDeactivate.js
@@ -20,7 +20,13 @@ const updateUserIndex = async (uid, correlationId) => {
 const postConfirmDeactivate = async (req, res) => {
   const user = await getUserDetails(req);
 
-  if (req.body.reason.match(/^\s*$/) !== null) {
+  if (req.body['select-reason'] && req.body['select-reason'] !== 'Select a reason' && req.body.reason.trim() === '') {
+    req.body.reason = req.body['select-reason'];
+  } else if (req.body['select-reason'] && req.body['select-reason'] !== 'Select a reason' && req.body.reason.length > 0) {
+    req.body.reason = `${req.body['select-reason']} - ${req.body.reason}`;
+  };
+
+  if (req.body['select-reason'] && req.body['select-reason'] === 'Select a reason' && req.body.reason.match(/^\s*$/) !== null) {
     sendResult(req, res, 'users/views/confirmDeactivate', {
       csrfToken: req.csrfToken(),
       backLink: 'services',

--- a/src/app/users/views/confirmInvitationDeactivate.ejs
+++ b/src/app/users/views/confirmInvitationDeactivate.ejs
@@ -9,10 +9,18 @@
                 <legend><p>Please confirm you would like to deactivate the user.</p></legend>
                 <div class="form-group <%= (locals.validationMessages.reason !== undefined) ? 'form-group-error' : '' %>">
                     <label class="form-label" for="reason">Reason for deactivation of user (mandatory)</span> </label>
+                    <select class="govuk-select form-group select2-container--classic font-small" style="padding: 5px 0px;" name="select-reason" required>
+                        <option selected value="Select a reason">Select a reason</option>
+                        <option value="Generic email" >Generic email</option>
+                        <option value="Username and email mismatch" >Username and email mismatch</option>
+                        <option value="User has left organisation" >User has left organisation</option>
+                        <option value="Security breach" >Security breach</option>
+                        <option value="Student, parent or general enquiry" >Student, parent or general enquiry</option>
+                    </select>
                     <% if (locals.validationMessages.reason !== undefined) { %>
                     <p class="error-message" id="validation-reason"><%= locals.validationMessages.reason %></p>
                     <% } %>
-                    <textarea class="form-control full-width" rows="6" id="reason" name="reason"
+                    <textarea class="form-control full-width form-group" rows="6" id="reason" name="reason"  placeholder="Please select a reason from the dropdown menu, or type a reason here."
                             <% if (locals.validationMessages.reason !== undefined) { %>
                            aria-invalid="true" aria-describedby="validation-reason"
                             <% } %>

--- a/test/app/users/postConfirmInvitationDeactivate.test.js
+++ b/test/app/users/postConfirmInvitationDeactivate.test.js
@@ -49,7 +49,7 @@ describe('When processing a post for a user invitation deactivate request', () =
     expect(deactivateInvite.mock.calls[0][2]).toBe(req.id);
   });
 
-  test('when given a reason from the select menu, it updates the user setting the status to deactivated', async () => {
+  test('when given a reason from the select menu, it updates the user setting status to deactivated', async () => {
     req = getRequestMock({
       body: {
         reason: '',
@@ -62,6 +62,22 @@ describe('When processing a post for a user invitation deactivate request', () =
     expect(deactivateInvite.mock.calls).toHaveLength(1);
     expect(deactivateInvite.mock.calls[0][0]).toBe(expectedUserId);
     expect(deactivateInvite.mock.calls[0][1]).toBe('some selected reason for deactivation');
+    expect(deactivateInvite.mock.calls[0][2]).toBe(req.id);
+  });
+  
+  test('when given a reason from the select menu and further information in the textarea, it updates the user setting status to deactivated', async () => {
+    req = getRequestMock({
+      body: {
+        reason: 'some text reason for deactivation',
+        'select-reason': 'some selected reason for deactivation',
+      },
+    });
+
+    await post(req, res);
+
+    expect(deactivateInvite.mock.calls).toHaveLength(1);
+    expect(deactivateInvite.mock.calls[0][0]).toBe(expectedUserId);
+    expect(deactivateInvite.mock.calls[0][1]).toBe('some selected reason for deactivation - some text reason for deactivation');
     expect(deactivateInvite.mock.calls[0][2]).toBe(req.id);
   });
 

--- a/test/app/users/postConfirmInvitationDeactivate.test.js
+++ b/test/app/users/postConfirmInvitationDeactivate.test.js
@@ -49,7 +49,7 @@ describe('When processing a post for a user invitation deactivate request', () =
     expect(deactivateInvite.mock.calls[0][2]).toBe(req.id);
   });
 
-  test('when given a reason from the select menu', async () => {
+  test('when given a reason from the select menu, it updates the user setting the status to deactivated', async () => {
     req = getRequestMock({
       body: {
         reason: '',

--- a/test/app/users/postConfirmInvitationDeactivate.test.js
+++ b/test/app/users/postConfirmInvitationDeactivate.test.js
@@ -49,6 +49,22 @@ describe('When processing a post for a user invitation deactivate request', () =
     expect(deactivateInvite.mock.calls[0][2]).toBe(req.id);
   });
 
+  test('when given a reason from the select menu', async () => {
+    req = getRequestMock({
+      body: {
+        reason: '',
+        'select-reason': 'some selected reason for deactivation',
+      },
+    });
+
+    await post(req, res);
+
+    expect(deactivateInvite.mock.calls).toHaveLength(1);
+    expect(deactivateInvite.mock.calls[0][0]).toBe(expectedUserId);
+    expect(deactivateInvite.mock.calls[0][1]).toBe('some selected reason for deactivation');
+    expect(deactivateInvite.mock.calls[0][2]).toBe(req.id);
+  });
+
   test('then the user index is updated', async () => {
     await post(req, res);
 
@@ -78,11 +94,13 @@ describe('When processing a post for a user invitation deactivate request', () =
     req = getRequestMock({
       body: {
         reason: '',
+        'select-reason': 'Select a reason',
       },
       params: {
         uid: 'inv-4878fe2a-28a9-4bab-a07b-dbb9747f87f5',
       },
     });
+
     await post(req, res);
 
     expect(sendResult.mock.calls).toHaveLength(1);


### PR DESCRIPTION
Link to ticket: [NSA-8656](https://dfe-secureaccess.atlassian.net/browse/NSA-8656)

Following on from NSA-8523, add a dropdown menu to the deactivate invited users view to allow a support user to select a common reason for deactivating a user. 