### PR TITLE
[NSA-8521] Search org in support console using special characters

### DIFF
--- a/src/app/organisations/search.js
+++ b/src/app/organisations/search.js
@@ -66,7 +66,7 @@ const search = async (req) => {
 
   let criteria = inputSource.criteria ? inputSource.criteria.trim() : '';
 
-  const organisationRegex = /^[a-zA-Z0-9\s-'&(),.@\\/:]{1,256}$/;
+  const organisationRegex = /^[a-zA-Z0-9\s-'&()#?!*+,.@\\/:]{1,256}$/;
   let filteredError;
   /**
    * Check minimum characters and special characters in search criteria if:


### PR DESCRIPTION
Link to ticket:

- Added - #, !, ?  *, + symbols to accepted special characters when searching for organisations
- Updated tests