### PR TITLE
[NSA-8655] Create organisation page

### DIFF
--- a/src/app/organisations/getConfirmCreateOrganisation.js
+++ b/src/app/organisations/getConfirmCreateOrganisation.js
@@ -1,0 +1,22 @@
+const { sendResult } = require('../../infrastructure/utils');
+
+const getConfirmCreateOrganisation = async (req, res) => {
+  if (!req.session.createOrgData) {
+    return res.redirect('/');
+  }
+
+  sendResult(req, res, 'organisations/views/confirmCreateOrganisation', {
+    csrfToken: req.csrfToken(),
+    layout: 'sharedViews/layoutNew.ejs',
+    backLink: true,
+    validationMessages: {},
+    name: req.session.createOrgData.name,
+    address: req.session.createOrgData.address,
+    ukprn: req.session.createOrgData.ukprn,
+    category: req.session.createOrgData.category,
+    upin: req.session.createOrgData.upin,
+    urn: req.session.createOrgData.urn,
+  });
+};
+
+module.exports = getConfirmCreateOrganisation;

--- a/src/app/organisations/getConfirmCreateOrganisation.js
+++ b/src/app/organisations/getConfirmCreateOrganisation.js
@@ -2,7 +2,7 @@ const { sendResult } = require('../../infrastructure/utils');
 
 const getConfirmCreateOrganisation = async (req, res) => {
   if (!req.session.createOrgData) {
-    return res.redirect('/');
+    return res.redirect('/organisations');
   }
 
   sendResult(req, res, 'organisations/views/confirmCreateOrganisation', {

--- a/src/app/organisations/getConfirmCreateOrganisation.js
+++ b/src/app/organisations/getConfirmCreateOrganisation.js
@@ -8,6 +8,7 @@ const getConfirmCreateOrganisation = async (req, res) => {
   sendResult(req, res, 'organisations/views/confirmCreateOrganisation', {
     csrfToken: req.csrfToken(),
     layout: 'sharedViews/layoutNew.ejs',
+    currentPage: 'organisations',
     backLink: true,
     validationMessages: {},
     name: req.session.createOrgData.name,

--- a/src/app/organisations/getCreateOrganisation.js
+++ b/src/app/organisations/getCreateOrganisation.js
@@ -1,0 +1,12 @@
+const { sendResult } = require('../../infrastructure/utils');
+
+const getCreateOrganisation = async (req, res) => {
+  sendResult(req, res, 'organisations/views/createOrganisation', {
+    csrfToken: req.csrfToken(),
+    layout: 'sharedViews/layoutNew.ejs',
+    backLink: true,
+    validationMessages: {},
+  });
+};
+
+module.exports = getCreateOrganisation;

--- a/src/app/organisations/getCreateOrganisation.js
+++ b/src/app/organisations/getCreateOrganisation.js
@@ -4,6 +4,7 @@ const getCreateOrganisation = async (req, res) => {
   sendResult(req, res, 'organisations/views/createOrganisation', {
     csrfToken: req.csrfToken(),
     layout: 'sharedViews/layoutNew.ejs',
+    currentPage: 'organisations',
     backLink: true,
     validationMessages: {},
   });

--- a/src/app/organisations/index.js
+++ b/src/app/organisations/index.js
@@ -12,6 +12,8 @@ const getppsyncStatus = require('./getppsyncStatus');
 const postppsyncStatus = require('./postPpsyncStatus');
 const getCreateOrganisation = require('./getCreateOrganisation');
 const postCreateOrganisation = require('./postCreateOrganisation');
+const getConfirmCreateOrganisation = require('./getConfirmCreateOrganisation');
+const postConfirmCreateOrganisation = require('./postConfirmCreateOrganisation');
 
 const router = express.Router({ mergeParams: true });
 
@@ -27,8 +29,10 @@ const users = (csrf) => {
   router.get('/run-pp-sync', csrf, asyncWrapper(getppsyncStatus));
   router.post('/run-pp-sync', csrf, asyncWrapper(postppsyncStatus));
 
-  router.get('/create', csrf, asyncWrapper(getCreateOrganisation));
-  router.post('/create', csrf, asyncWrapper(postCreateOrganisation));
+  router.get('/create-org', csrf, asyncWrapper(getCreateOrganisation));
+  router.post('/create-org', csrf, asyncWrapper(postCreateOrganisation));
+  router.get('/confirm-create-org', csrf, asyncWrapper(getConfirmCreateOrganisation));
+  router.post('/confirm-create-org', csrf, asyncWrapper(postConfirmCreateOrganisation));
 
   router.get('/:id', (req, res) => {
     res.redirect('users');

--- a/src/app/organisations/index.js
+++ b/src/app/organisations/index.js
@@ -10,6 +10,8 @@ const organisationUsers = require('./organisationUsers');
 const webServiceSync = require('./webServiceSync');
 const getppsyncStatus = require('./getppsyncStatus');
 const postppsyncStatus = require('./postPpsyncStatus');
+const getCreateOrganisation = require('./getCreateOrganisation');
+const postCreateOrganisation = require('./postCreateOrganisation');
 
 const router = express.Router({ mergeParams: true });
 
@@ -24,6 +26,9 @@ const users = (csrf) => {
   // DO NOT UNCOMMENT
   router.get('/run-pp-sync', csrf, asyncWrapper(getppsyncStatus));
   router.post('/run-pp-sync', csrf, asyncWrapper(postppsyncStatus));
+
+  router.get('/create', csrf, asyncWrapper(getCreateOrganisation));
+  router.post('/create', csrf, asyncWrapper(postCreateOrganisation));
 
   router.get('/:id', (req, res) => {
     res.redirect('users');

--- a/src/app/organisations/postConfirmCreateOrganisation.js
+++ b/src/app/organisations/postConfirmCreateOrganisation.js
@@ -1,0 +1,14 @@
+const logger = require('../../infrastructure/logger');
+
+const postCreateOrganisation = async (req, res) => {
+  // TODO Do we need to validate again?  Do we just get the data from the session? That
+  // way can guarantee it's not been tampered with.
+
+  console.log('Verify data is still in session?');
+  console.log('Hit organisations API to create new record');
+  console.log('Flash a success message');
+  console.log('Clear out session data');
+  return res.redirect('/');
+};
+
+module.exports = postCreateOrganisation;

--- a/src/app/organisations/postConfirmCreateOrganisation.js
+++ b/src/app/organisations/postConfirmCreateOrganisation.js
@@ -2,28 +2,30 @@ const { createOrganisation } = require('../../infrastructure/organisations');
 const logger = require('../../infrastructure/logger');
 
 const postCreateOrganisation = async (req, res) => {
-  // TODO Do we need to validate again?  Do we just get the data from the session? That
-  // way can guarantee it's not been tampered with.
-
+  const correlationId = req.id;
   if (!req.session.createOrgData) {
     return res.redirect('/');
   }
 
   const model = req.session.createOrgData;
-
   const body = {
     name: model.name,
     address: model.address,
     ukprn: model.ukprn,
-    category: model.category,
+    category: {
+      id: model.category,
+    },
     upin: model.upin,
     urn: model.urn,
   };
 
-  await createOrganisation(body, req.id);
-  res.flash('info', `Organisation with name ${model.name} successfully created`);
+  logger.info(`About to create organisation with name ${model.name}`, { correlationId });
+  await createOrganisation(body, correlationId);
+  logger.info(`Organisation with name ${model.name} successfully created`, { correlationId });
+  res.flash('info', `Organisation with name '${model.name}' successfully created`);
+
   req.session.createOrgData = undefined;
-  return res.redirect('/');
+  return res.redirect('/organisations');
 };
 
 module.exports = postCreateOrganisation;

--- a/src/app/organisations/postConfirmCreateOrganisation.js
+++ b/src/app/organisations/postConfirmCreateOrganisation.js
@@ -4,7 +4,7 @@ const logger = require('../../infrastructure/logger');
 const postCreateOrganisation = async (req, res) => {
   const correlationId = req.id;
   if (!req.session.createOrgData) {
-    return res.redirect('/');
+    return res.redirect('/organisations');
   }
 
   const model = req.session.createOrgData;

--- a/src/app/organisations/postConfirmCreateOrganisation.js
+++ b/src/app/organisations/postConfirmCreateOrganisation.js
@@ -1,13 +1,28 @@
+const { createOrganisation } = require('../../infrastructure/organisations');
 const logger = require('../../infrastructure/logger');
 
 const postCreateOrganisation = async (req, res) => {
   // TODO Do we need to validate again?  Do we just get the data from the session? That
   // way can guarantee it's not been tampered with.
 
-  console.log('Verify data is still in session?');
-  console.log('Hit organisations API to create new record');
-  console.log('Flash a success message');
-  console.log('Clear out session data');
+  if (!req.session.createOrgData) {
+    return res.redirect('/');
+  }
+
+  const model = req.session.createOrgData;
+
+  const body = {
+    name: model.name,
+    address: model.address,
+    ukprn: model.ukprn,
+    category: model.category,
+    upin: model.upin,
+    urn: model.urn,
+  };
+
+  await createOrganisation(body, req.id);
+  res.flash('info', `Organisation with name ${model.name} successfully created`);
+  req.session.createOrgData = undefined;
   return res.redirect('/');
 };
 

--- a/src/app/organisations/postCreateOrganisation.js
+++ b/src/app/organisations/postCreateOrganisation.js
@@ -39,7 +39,7 @@ const validateInput = async (req) => {
   if (model.ukprn) {
     const ukprnRegex = /^\d{8}$/i;
     if (!ukprnRegex.test(model.ukprn)) {
-      model.validationMessages.ukprn = 'UKPRN can only an 8 digit number';
+      model.validationMessages.ukprn = 'UKPRN can only be an 8 digit number';
     }
   }
 
@@ -50,14 +50,14 @@ const validateInput = async (req) => {
   if (model.upin) {
     const upinRegex = /^\d{6}$/i;
     if (!upinRegex.test(model.upin)) {
-      model.validationMessages.upin = 'UPIN can only an 6 digit number';
+      model.validationMessages.upin = 'UPIN can only be a 6 digit number';
     }
   }
 
   if (model.urn) {
     const urnRegex = /^\d{6}$/i;
     if (!urnRegex.test(model.urn)) {
-      model.validationMessages.urn = 'URN can only an 6 digit number';
+      model.validationMessages.urn = 'URN can only be a 6 digit number';
     }
   }
 

--- a/src/app/organisations/postCreateOrganisation.js
+++ b/src/app/organisations/postCreateOrganisation.js
@@ -1,0 +1,38 @@
+const { sendResult } = require('../../infrastructure/utils');
+
+const validateInput = async (req) => {
+  const nameRegEx = /^[^±!@£$%^&*_+§¡€#¢§¶•ªº«\\/<>?:;|=.,~"]{1,60}$/i;
+  const model = {
+    name: req.body.name || '',
+    address: req.body.address || '',
+    validationMessages: {},
+    layout: 'sharedViews/layoutNew.ejs',
+  };
+
+  if (!model.name) {
+    model.validationMessages.name = 'Please enter a name';
+  } else if (!nameRegEx.test(model.name)) {
+    model.validationMessages.name = 'Special characters cannot be used';
+  }
+
+  if (!model.address) {
+    model.validationMessages.address = 'Please enter an address';
+  } else if (!nameRegEx.test(model.address)) {
+    model.validationMessages.address = 'Special characters cannot be used';
+  }
+
+  return model;
+};
+
+const postCreateOrganisation = async (req, res) => {
+  const model = await validateInput(req);
+  if (Object.keys(model.validationMessages).length > 0) {
+    model.csrfToken = req.csrfToken();
+    return sendResult(req, res, 'organisations/views/createOrganisation', model);
+  }
+
+  console.log('Hit organisation API to create org');
+  return res.redirect('/organisations');
+};
+
+module.exports = postCreateOrganisation;

--- a/src/app/organisations/postCreateOrganisation.js
+++ b/src/app/organisations/postCreateOrganisation.js
@@ -1,4 +1,5 @@
 const { sendResult } = require('../../infrastructure/utils');
+const { searchOrganisations } = require('../../infrastructure/organisations');
 const logger = require('../../infrastructure/logger');
 
 const validateInput = async (req) => {
@@ -12,6 +13,13 @@ const validateInput = async (req) => {
     urn: req.body.urn || '',
     validationMessages: {},
   };
+
+  model.name = model.name.trim();
+  model.address = model.address.trim();
+  model.ukprn = model.ukprn.trim();
+  model.category = model.category.trim();
+  model.upin = model.upin.trim();
+  model.urn = model.urn.trim();
 
   if (!model.name) {
     model.validationMessages.name = 'Please enter a name';
@@ -49,6 +57,10 @@ const validateInput = async (req) => {
 
 const postCreateOrganisation = async (req, res) => {
   const model = await validateInput(req);
+
+  const result = searchOrganisations(model.name, undefined, undefined, 1, req.id);
+  console.log(result);
+  // TODO validate on name, ukprn, urn and upin to ensure it's unique
   if (Object.keys(model.validationMessages).length > 0) {
     model.csrfToken = req.csrfToken();
     model.layout = 'sharedViews/layoutNew.ejs';

--- a/src/app/organisations/views/confirmCreateOrganisation.ejs
+++ b/src/app/organisations/views/confirmCreateOrganisation.ejs
@@ -1,5 +1,4 @@
 <div class="govuk-width-container">
-  <a href="#" class="govuk-back-link">Back</a>
   <main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/src/app/organisations/views/confirmCreateOrganisation.ejs
+++ b/src/app/organisations/views/confirmCreateOrganisation.ejs
@@ -1,0 +1,67 @@
+<div class="govuk-width-container">
+  <a href="#" class="govuk-back-link">Back</a>
+  <main class="govuk-main-wrapper " id="main-content" role="main">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds-from-desktop">
+        <h1 class="govuk-heading-l">Review create organisation</h1>
+        <h2 class="govuk-heading-m">Review details</h2>
+        <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Name
+            </dt>
+            <dd class="govuk-summary-list__value">
+              <%= locals.name %>
+            </dd>
+          </div>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Address
+            </dt>
+            <dd class="govuk-summary-list__value">
+              <%= locals.address %>
+            </dd>
+          </div>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              UKPRN
+            </dt>
+            <dd class="govuk-summary-list__value">
+              <%= locals.ukprn %>
+            </dd>
+          </div>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Category
+            </dt>
+            <dd class="govuk-summary-list__value">
+              <%= locals.category %>
+            </dd>
+          </div>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              UPIN
+            </dt>
+            <dd class="govuk-summary-list__value">
+              <%= locals.upin %>
+            </dd>
+          </div>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              URN
+            </dt>
+            <dd class="govuk-summary-list__value">
+              <%= locals.urn %>
+            </dd>
+          </div>
+        </dl>
+        <form method="post" novalidate>
+          <input type="hidden" name="_csrf" value="<%=csrfToken%>" />
+          <button type="submit" class="govuk-button" data-module="govuk-button">
+            Create organisation
+          </button>
+        </form>
+      </div>
+    </div>
+  </main>
+</div>

--- a/src/app/organisations/views/createOrganisation.ejs
+++ b/src/app/organisations/views/createOrganisation.ejs
@@ -1,0 +1,39 @@
+<div class="govuk-width-container">
+  <div class="col-8">
+    <h1 class="govuk-heading-xl">
+        Create new organisation
+    </h1>
+      <form method="post">
+        <input type="hidden" name="_csrf" value="<%=csrfToken%>" />
+        <div class="govuk-form-group">
+          <label class="govuk-label" for="name">
+            Name
+          </label>
+          <% if (locals.validationMessages.name !== undefined) { %>
+          <p id="name-error" class="govuk-error-message">
+            <span class="govuk-visually-hidden">Error:</span><%= locals.validationMessages.name %>
+          </p>
+          <% } %>
+          <input class="govuk-input" id="name" name="name" type="text" spellcheck="false">
+        </div>
+        <div class="govuk-form-group">
+          <label class="govuk-label" for="address">
+            Address
+          </label>
+          <% if (locals.validationMessages.address !== undefined) { %>
+            <p id="address-error" class="govuk-error-message">
+              <span class="govuk-visually-hidden">Error:</span><%= locals.validationMessages.address %>
+            </p>
+            <% } %>
+          <input class="govuk-input" id="address" name="address" type="text" spellcheck="false">
+        </div>
+        <div class="govuk-button-group">
+          <button type="submit" class="govuk-button" data-module="govuk-button">
+            Continue
+          </button>
+        </div>
+    </form>
+</div>
+
+
+

--- a/src/app/organisations/views/createOrganisation.ejs
+++ b/src/app/organisations/views/createOrganisation.ejs
@@ -14,7 +14,7 @@
             <span class="govuk-visually-hidden">Error:</span><%= locals.validationMessages.name %>
           </p>
           <% } %>
-          <input class="govuk-input" id="name" name="name" type="text" spellcheck="false">
+          <input class="govuk-input" id="name" name="name" type="text" spellcheck="false" value="<%= locals.name %>">
         </div>
         <div class="govuk-form-group">
           <label class="govuk-label" for="address">
@@ -25,7 +25,7 @@
               <span class="govuk-visually-hidden">Error:</span><%= locals.validationMessages.address %>
             </p>
             <% } %>
-          <input class="govuk-input" id="address" name="address" type="text" spellcheck="false">
+          <input class="govuk-input" id="address" name="address" type="text" spellcheck="false" value="<%= locals.address %>">
         </div>
         <div class="govuk-form-group">
           <label class="govuk-label" for="ukprn">
@@ -36,7 +36,7 @@
               <span class="govuk-visually-hidden">Error:</span><%= locals.validationMessages.ukprn %>
             </p>
             <% } %>
-          <input class="govuk-input" id="ukprn" name="ukprn" type="text" spellcheck="false">
+          <input class="govuk-input" id="ukprn" name="ukprn" type="text" spellcheck="false" value="<%= locals.ukprn %>">
         </div>
 
         <div class="govuk-form-group <%= (locals.validationMessages.category !== undefined) ? 'govuk-form-group--error' : '' %>">
@@ -49,8 +49,8 @@
           </p>
           <% } %>
           <select class="govuk-select <%= (locals.validationMessages.category !== undefined) ? 'govuk-select--error' : '' %>" id="category" name="category" aria-describedby="category-error">
-            <option value="" selected>Select a category</option>
-            <option value="008">008 (Other stakeholders)</option>
+            <option value="" <%= (locals.category === undefined) ? 'selected' : '' %>>Select a category</option>
+            <option value="008" <%= (locals.category === "008") ? 'selected' : '' %>>008 (Other stakeholders)</option>
           </select>
         </div>
 
@@ -63,7 +63,7 @@
               <span class="govuk-visually-hidden">Error:</span><%= locals.validationMessages.upin %>
             </p>
             <% } %>
-          <input class="govuk-input" id="upin" name="upin" type="text" spellcheck="false">
+          <input class="govuk-input" id="upin" name="upin" type="text" spellcheck="false" value="<%= locals.upin %>">
         </div>
         <div class="govuk-form-group">
           <label class="govuk-label" for="urn">
@@ -74,7 +74,7 @@
               <span class="govuk-visually-hidden">Error:</span><%= locals.validationMessages.urn %>
             </p>
             <% } %>
-          <input class="govuk-input" id="urn" name="urn" type="text" spellcheck="false">
+          <input class="govuk-input" id="urn" name="urn" type="text" spellcheck="false" value="<%= locals.urn %>">
         </div>
         <div class="govuk-button-group">
           <button type="submit" class="govuk-button" data-module="govuk-button">

--- a/src/app/organisations/views/createOrganisation.ejs
+++ b/src/app/organisations/views/createOrganisation.ejs
@@ -27,9 +27,58 @@
             <% } %>
           <input class="govuk-input" id="address" name="address" type="text" spellcheck="false">
         </div>
+        <div class="govuk-form-group">
+          <label class="govuk-label" for="ukprn">
+            UKPRN
+          </label>
+          <% if (locals.validationMessages.ukprn !== undefined) { %>
+            <p id="ukprn-error" class="govuk-error-message">
+              <span class="govuk-visually-hidden">Error:</span><%= locals.validationMessages.ukprn %>
+            </p>
+            <% } %>
+          <input class="govuk-input" id="ukprn" name="ukprn" type="text" spellcheck="false">
+        </div>
+
+        <div class="govuk-form-group <%= (locals.validationMessages.category !== undefined) ? 'govuk-form-group--error' : '' %>">
+          <label class="govuk-label" for="category">
+            Category
+          </label>
+          <% if (locals.validationMessages.category !== undefined) { %>
+          <p id="category-error" class="govuk-error-message">
+            <span class="govuk-visually-hidden">Error:</span> <%= locals.validationMessages.category %>
+          </p>
+          <% } %>
+          <select class="govuk-select <%= (locals.validationMessages.category !== undefined) ? 'govuk-select--error' : '' %>" id="category" name="category" aria-describedby="category-error">
+            <option value="" selected>Select a category</option>
+            <option value="008">008 (Other stakeholders)</option>
+          </select>
+        </div>
+
+        <div class="govuk-form-group">
+          <label class="govuk-label" for="upin">
+            UPIN
+          </label>
+          <% if (locals.validationMessages.upin !== undefined) { %>
+            <p id="upin-error" class="govuk-error-message">
+              <span class="govuk-visually-hidden">Error:</span><%= locals.validationMessages.upin %>
+            </p>
+            <% } %>
+          <input class="govuk-input" id="upin" name="upin" type="text" spellcheck="false">
+        </div>
+        <div class="govuk-form-group">
+          <label class="govuk-label" for="urn">
+            URN
+          </label>
+          <% if (locals.validationMessages.urn !== undefined) { %>
+            <p id="urn-error" class="govuk-error-message">
+              <span class="govuk-visually-hidden">Error:</span><%= locals.validationMessages.urn %>
+            </p>
+            <% } %>
+          <input class="govuk-input" id="urn" name="urn" type="text" spellcheck="false">
+        </div>
         <div class="govuk-button-group">
           <button type="submit" class="govuk-button" data-module="govuk-button">
-            Continue
+            Submit
           </button>
         </div>
     </form>

--- a/src/app/organisations/views/search.ejs
+++ b/src/app/organisations/views/search.ejs
@@ -94,6 +94,7 @@ const organisationStatusesQuery = locals.organisationStatuses.filter(x => x.isSe
             <h2 class="heading-medium">Actions</h2>
             <ul class="list">
                 <li><a href="/organisations/run-pp-sync">Run Provider Profile sync</a></li>
+                <li><a href="/organisations/create">Create new organisation</a></li>
             </ul>
         </aside>
     </div>

--- a/src/app/organisations/views/search.ejs
+++ b/src/app/organisations/views/search.ejs
@@ -94,7 +94,7 @@ const organisationStatusesQuery = locals.organisationStatuses.filter(x => x.isSe
             <h2 class="heading-medium">Actions</h2>
             <ul class="list">
                 <li><a href="/organisations/run-pp-sync">Run Provider Profile sync</a></li>
-                <li><a href="/organisations/create">Create new organisation</a></li>
+                <li><a href="/organisations/create-org">Create new organisation</a></li>
             </ul>
         </aside>
     </div>

--- a/src/infrastructure/organisations/api.js
+++ b/src/infrastructure/organisations/api.js
@@ -7,12 +7,12 @@ const callOrganisationsApi = async (endpoint, method, body, correlationId) => {
 
   try {
     return await fetchApi(`${config.organisations.service.url}/${endpoint}`, {
-      method: method,
+      method,
       headers: {
         authorization: `bearer ${token}`,
         'x-correlation-id': correlationId,
       },
-      body: body,
+      body,
     });
   } catch (e) {
     const status = e.statusCode ? e.statusCode : 500;
@@ -153,6 +153,10 @@ const listOrganisationStatus = async (correlationId) => {
   return callOrganisationsApi('organisations/states', 'GET', undefined, correlationId);
 };
 
+const createOrganisation = async (body, correlationId) => {
+  return callOrganisationsApi(`organisations/`, 'POST', body, correlationId);
+};
+
 const listRequests = async (page, filterStates, correlationId) => {
   let uri = `organisations/requests?page=${page}`;
   if (filterStates && filterStates.length > 0) {
@@ -198,8 +202,8 @@ const getCategories = async () => {
   return await callOrganisationsApi('organisations/categories', 'GET',undefined, undefined);
 }
 
-
 module.exports = {
+  createOrganisation,
   getUserOrganisations,
   getInvitationOrganisations,
   getServiceById,
@@ -228,5 +232,5 @@ module.exports = {
   putUserInOrganisation,
   listOrganisationStatus,
   getPendingRequestsAssociatedWithUser,
-  getCategories
+  getCategories,
 };

--- a/src/infrastructure/organisations/static.js
+++ b/src/infrastructure/organisations/static.js
@@ -171,11 +171,16 @@ const getPendingRequestsAssociatedWithUser = async (userId, correlationId) => {
   return Promise.resolve();
 };
 
+const createOrganisation = async (body, correlationId) => {
+  return Promise.resolve();
+};
+
 const getCategories = async (id) => {
   return (await getCategories());
 };
 
 module.exports = {
+  createOrganisation,
   getUserOrganisations,
   getInvitationOrganisations,
   getServiceById,

--- a/test/app/organisations/getConfirmCreateOrganisation.test.js
+++ b/test/app/organisations/getConfirmCreateOrganisation.test.js
@@ -1,0 +1,56 @@
+jest.mock('./../../../src/infrastructure/config', () => require('../../utils').configMockFactory());
+jest.mock('./../../../src/infrastructure/utils');
+
+const { getRequestMock, getResponseMock } = require('../../utils');
+const { sendResult } = require('../../../src/infrastructure/utils');
+const getConfirmCreateOrganisation = require('../../../src/app/organisations/getConfirmCreateOrganisation');
+
+const res = getResponseMock();
+
+describe('when displaying the get confirm create organisations', () => {
+  let req;
+
+  beforeEach(() => {
+    req = getRequestMock({
+      session: {
+        createOrgData: {
+          name: 'Test name',
+          address: '123 address street',
+          ukprn: '12345678',
+          category: '008',
+          upin: '',
+          urn: '',
+        },
+      },
+    });
+    res.mockResetAll();
+  });
+
+  it('should redirect to the organisations page if there is no createOrgData session data', async () => {
+    req = getRequestMock();
+    await getConfirmCreateOrganisation(req, res);
+
+    expect(res.redirect.mock.calls).toHaveLength(1);
+    expect(res.redirect.mock.calls[0][0]).toBe('/organisations');
+    expect(sendResult).toHaveBeenCalledTimes(0);
+  });
+
+  it('should return the confirm create organisation view when data is in the session', async () => {
+    await getConfirmCreateOrganisation(req, res);
+
+    expect(sendResult).toHaveBeenCalledTimes(1);
+    expect(sendResult).toHaveBeenCalledWith(req, res, 'organisations/views/confirmCreateOrganisation', {
+      csrfToken: req.csrfToken(),
+      backLink: true,
+      currentPage: 'organisations',
+      layout: 'sharedViews/layoutNew.ejs',
+      validationMessages: {},
+      name: 'Test name',
+      address: '123 address street',
+      ukprn: '12345678',
+      category: '008',
+      upin: '',
+      urn: '',
+    });
+  });
+});

--- a/test/app/organisations/getCreateOrganisation.test.js
+++ b/test/app/organisations/getCreateOrganisation.test.js
@@ -1,0 +1,30 @@
+jest.mock('./../../../src/infrastructure/config', () => require('../../utils').configMockFactory());
+jest.mock('./../../../src/infrastructure/utils');
+
+const { getRequestMock, getResponseMock } = require('../../utils');
+const { sendResult } = require('../../../src/infrastructure/utils');
+const getCreateOrganisation = require('../../../src/app/organisations/getCreateOrganisation');
+
+const res = getResponseMock();
+
+describe('when displaying the get create organisations', () => {
+  let req;
+
+  beforeEach(() => {
+    req = getRequestMock();
+    res.mockResetAll();
+  });
+
+  it('then it should return the create organisation view', async () => {
+    await getCreateOrganisation(req, res);
+
+    expect(sendResult).toHaveBeenCalledTimes(1);
+    expect(sendResult).toHaveBeenCalledWith(req, res, 'organisations/views/createOrganisation', {
+      csrfToken: req.csrfToken(),
+      backLink: true,
+      currentPage: 'organisations',
+      layout: 'sharedViews/layoutNew.ejs',
+      validationMessages: {},
+    });
+  });
+});

--- a/test/app/organisations/postConfirmCreateOrganisation.test.js
+++ b/test/app/organisations/postConfirmCreateOrganisation.test.js
@@ -1,0 +1,51 @@
+jest.mock('./../../../src/infrastructure/config', () => require('../../utils').configMockFactory());
+jest.mock('./../../../src/infrastructure/utils');
+jest.mock('./../../../src/infrastructure/organisations');
+
+const { getRequestMock, getResponseMock } = require('../../utils');
+const { sendResult } = require('../../../src/infrastructure/utils');
+const { createOrganisation } = require('../../../src/infrastructure/organisations');
+const postConfirmCreateOrganisation = require('../../../src/app/organisations/postConfirmCreateOrganisation');
+
+const res = getResponseMock();
+
+describe('when displaying the get create organisations', () => {
+  let req;
+  beforeEach(() => {
+    req = getRequestMock({
+      session: {
+        createOrgData: {
+          name: 'Test name',
+          address: 'Test address',
+          ukprn: '12345678',
+          category: '008',
+          upin: '123456',
+          urn: '654321',
+          validationMessages: {},
+        },
+      },
+    });
+    res.mockResetAll();
+
+    createOrganisation.mockReset().mockReturnValue({});
+  });
+
+  it('should redirect to the confirm page on success', async () => {
+    await postConfirmCreateOrganisation(req, res);
+
+    expect(res.redirect.mock.calls).toHaveLength(1);
+    expect(res.redirect.mock.calls[0][0]).toBe('/organisations');
+    expect(res.flash.mock.calls).toHaveLength(1);
+    expect(sendResult).toHaveBeenCalledTimes(0);
+  });
+
+  it('should redirect back to /organisations if nothing is in the session', async () => {
+    req.session = {};
+
+    await postConfirmCreateOrganisation(req, res);
+
+    expect(res.redirect.mock.calls).toHaveLength(1);
+    expect(res.redirect.mock.calls[0][0]).toBe('/organisations');
+    expect(sendResult).toHaveBeenCalledTimes(0);
+  });
+});

--- a/test/app/organisations/postCreateOrganisation.test.js
+++ b/test/app/organisations/postCreateOrganisation.test.js
@@ -1,0 +1,200 @@
+jest.mock('./../../../src/infrastructure/config', () => require('../../utils').configMockFactory());
+jest.mock('./../../../src/infrastructure/utils');
+jest.mock('./../../../src/infrastructure/organisations');
+
+const { getRequestMock, getResponseMock } = require('../../utils');
+const { sendResult } = require('../../../src/infrastructure/utils');
+const { searchOrganisations } = require('../../../src/infrastructure/organisations');
+const postCreateOrganisation = require('../../../src/app/organisations/postCreateOrganisation');
+
+const res = getResponseMock();
+
+const orgsResultWithNoResults = {
+  organisations: [],
+  page: 1,
+  totalNumberOfPages: 1,
+  totalNumberOfRecords: 0,
+};
+
+const orgsResultWithResults = {
+  organisations: [
+    { id: 'org-1', name: 'organisation one' },
+    { id: 'org-2', name: 'organisation two' },
+  ],
+  page: 1,
+  totalNumberOfPages: 1,
+  totalNumberOfRecords: 2,
+};
+
+describe('when displaying the get create organisations', () => {
+  let req;
+  let exampleErrorResponse;
+
+  beforeEach(() => {
+    req = getRequestMock({
+      body: {
+        name: 'Test name',
+        address: 'Test address',
+        ukprn: '12345678',
+        category: '008',
+        upin: '123456',
+        urn: '654321',
+      },
+      session: {
+        save: jest.fn(cb => cb()),
+      },
+    });
+    res.mockResetAll();
+
+    searchOrganisations.mockReset().mockReturnValue(orgsResultWithNoResults);
+    sendResult.mockReset();
+
+    // Example data that each error test can modify so it doens't need to be copied
+    // again and again
+    exampleErrorResponse = {
+      name: 'Test name',
+      address: 'Test address',
+      ukprn: '12345678',
+      category: '008',
+      upin: '123456',
+      urn: '654321',
+      validationMessages: {},
+      csrfToken: 'token',
+      currentPage: 'organisations',
+      layout: 'sharedViews/layoutNew.ejs',
+      backLink: true,
+    };
+  });
+
+  it('should redirect to the confirm page on success', async () => {
+    await postCreateOrganisation(req, res);
+
+    expect(res.redirect.mock.calls).toHaveLength(1);
+    expect(res.redirect.mock.calls[0][0]).toBe('confirm-create-org');
+    expect(sendResult).toHaveBeenCalledTimes(0);
+  });
+
+  it('should render the page if there is an error saving to the session', async () => {
+    req.session = {
+      save: jest.fn(cb => cb('Something went wrong')),
+    };
+
+    await postCreateOrganisation(req, res);
+
+    expect(sendResult).toHaveBeenCalledTimes(1);
+    expect(sendResult).toHaveBeenCalledWith(req, res, 'organisations/views/createOrganisation', {
+      csrfToken: req.csrfToken(),
+      backLink: true,
+      currentPage: 'organisations',
+      layout: 'sharedViews/layoutNew.ejs',
+      name: 'Test name',
+      address: 'Test address',
+      ukprn: '12345678',
+      category: '008',
+      upin: '123456',
+      urn: '654321',
+      validationMessages: {
+        name: 'Something went wrong submitting data, please try again',
+      },
+    });
+  });
+
+  it('should render an the page with an error in validationMessages if validation fails on name', async () => {
+    req.body.name = '';
+    exampleErrorResponse.name = '';
+    exampleErrorResponse.validationMessages.name = 'Please enter a name';
+
+    await postCreateOrganisation(req, res);
+
+    expect(sendResult).toHaveBeenCalledTimes(1);
+    expect(sendResult.mock.calls[0][3]).toStrictEqual(exampleErrorResponse);
+  });
+
+  it('should render an the page with an error in validationMessages if validation fails on name with special characters', async () => {
+    req.body.name = 'Test $%^ org';
+    exampleErrorResponse.name = 'Test $%^ org';
+    exampleErrorResponse.validationMessages.name = 'Special characters cannot be used';
+
+    await postCreateOrganisation(req, res);
+
+    expect(sendResult).toHaveBeenCalledTimes(1);
+    expect(sendResult.mock.calls[0][3]).toStrictEqual(exampleErrorResponse);
+  });
+
+  it('should render an the page with an error in validationMessages if validation fails on name with over 256 characters', async () => {
+    req.body.name = 'Test123456'.repeat(26); // 260 character length string
+    exampleErrorResponse.name = 'Test123456'.repeat(26);
+    exampleErrorResponse.validationMessages.name = 'Name cannot be longer than 256 characters';
+
+    await postCreateOrganisation(req, res);
+
+    expect(sendResult).toHaveBeenCalledTimes(1);
+    expect(sendResult.mock.calls[0][3]).toStrictEqual(exampleErrorResponse);
+  });
+
+  it('should render an the page with an error in validationMessages if validation fails on address', async () => {
+    req.body.address = '123 £$% street';
+    exampleErrorResponse.address = '123 £$% street';
+    exampleErrorResponse.validationMessages.address = 'Special characters cannot be used';
+
+    await postCreateOrganisation(req, res);
+
+    expect(sendResult).toHaveBeenCalledTimes(1);
+    expect(sendResult.mock.calls[0][3]).toStrictEqual(exampleErrorResponse);
+  });
+
+  it('should render an the page with an error in validationMessages if validation fails on ukprn', async () => {
+    req.body.ukprn = '1234567890';
+    exampleErrorResponse.ukprn = '1234567890';
+    exampleErrorResponse.validationMessages.ukprn = 'UKPRN can only an 8 digit number';
+
+    await postCreateOrganisation(req, res);
+
+    expect(sendResult).toHaveBeenCalledTimes(1);
+    expect(sendResult.mock.calls[0][3]).toStrictEqual(exampleErrorResponse);
+  });
+
+  it('should render an the page with an error in validationMessages if validation fails on category', async () => {
+    req.body.category = '';
+    exampleErrorResponse.category = '';
+    exampleErrorResponse.validationMessages.category = 'Please enter a category';
+
+    await postCreateOrganisation(req, res);
+
+    expect(sendResult).toHaveBeenCalledTimes(1);
+    expect(sendResult.mock.calls[0][3]).toStrictEqual(exampleErrorResponse);
+  });
+
+  it('should render an the page with an error in validationMessages if validation fails on upin', async () => {
+    req.body.upin = '1234567';
+    exampleErrorResponse.upin = '1234567';
+    exampleErrorResponse.validationMessages.upin = 'UPIN can only an 6 digit number';
+
+    await postCreateOrganisation(req, res);
+
+    expect(sendResult).toHaveBeenCalledTimes(1);
+    expect(sendResult.mock.calls[0][3]).toStrictEqual(exampleErrorResponse);
+  });
+
+  it('should render an the page with an error in validationMessages if validation fails on urn', async () => {
+    req.body.urn = '1234567';
+    exampleErrorResponse.urn = '1234567';
+    exampleErrorResponse.validationMessages.urn = 'URN can only an 6 digit number';
+
+    await postCreateOrganisation(req, res);
+
+    expect(sendResult).toHaveBeenCalledTimes(1);
+    expect(sendResult.mock.calls[0][3]).toStrictEqual(exampleErrorResponse);
+  });
+
+  it('should render an the page with an error in validationMessages if an organisation with a matching ukprn and/or exists', async () => {
+    searchOrganisations.mockReset().mockReturnValue(orgsResultWithResults);
+    exampleErrorResponse.validationMessages.ukprn = 'An organisation with this UKPRN already exists';
+    exampleErrorResponse.validationMessages.urn = 'An organisation with this URN already exists';
+
+    await postCreateOrganisation(req, res);
+
+    expect(sendResult).toHaveBeenCalledTimes(1);
+    expect(sendResult.mock.calls[0][3]).toStrictEqual(exampleErrorResponse);
+  });
+});

--- a/test/app/organisations/postCreateOrganisation.test.js
+++ b/test/app/organisations/postCreateOrganisation.test.js
@@ -146,7 +146,7 @@ describe('when displaying the get create organisations', () => {
   it('should render an the page with an error in validationMessages if validation fails on ukprn', async () => {
     req.body.ukprn = '1234567890';
     exampleErrorResponse.ukprn = '1234567890';
-    exampleErrorResponse.validationMessages.ukprn = 'UKPRN can only an 8 digit number';
+    exampleErrorResponse.validationMessages.ukprn = 'UKPRN can only be an 8 digit number';
 
     await postCreateOrganisation(req, res);
 
@@ -168,7 +168,7 @@ describe('when displaying the get create organisations', () => {
   it('should render an the page with an error in validationMessages if validation fails on upin', async () => {
     req.body.upin = '1234567';
     exampleErrorResponse.upin = '1234567';
-    exampleErrorResponse.validationMessages.upin = 'UPIN can only an 6 digit number';
+    exampleErrorResponse.validationMessages.upin = 'UPIN can only be a 6 digit number';
 
     await postCreateOrganisation(req, res);
 
@@ -179,7 +179,7 @@ describe('when displaying the get create organisations', () => {
   it('should render an the page with an error in validationMessages if validation fails on urn', async () => {
     req.body.urn = '1234567';
     exampleErrorResponse.urn = '1234567';
-    exampleErrorResponse.validationMessages.urn = 'URN can only an 6 digit number';
+    exampleErrorResponse.validationMessages.urn = 'URN can only be a 6 digit number';
 
     await postCreateOrganisation(req, res);
 

--- a/test/infrastructure/organisations/api.createOrganisations.test.js
+++ b/test/infrastructure/organisations/api.createOrganisations.test.js
@@ -1,0 +1,124 @@
+jest.mock('login.dfe.async-retry');
+jest.mock('login.dfe.jwt-strategies');
+jest.mock('./../../../src/infrastructure/config', () => require('../../utils').configMockFactory({
+  organisations: {
+    type: 'api',
+    service: {
+      url: 'http://organisations.test',
+    },
+  },
+}));
+
+const { fetchApi } = require('login.dfe.async-retry');
+const jwtStrategy = require('login.dfe.jwt-strategies');
+const { createOrganisation } = require('../../../src/infrastructure/organisations/api');
+
+const correlationId = 'abc123';
+const apiResponse = {};
+
+const body = {
+  name: 'Test name',
+  address: 'Test address',
+  ukprn: '12345678',
+  category: {
+    id: '008',
+  },
+  upin: '123456',
+  urn: '123456',
+};
+
+describe('when getting a users organisations mapping from api', () => {
+  beforeEach(() => {
+    fetchApi.mockReset();
+    fetchApi.mockImplementation(() => {
+      return apiResponse;
+    });
+
+    jwtStrategy.mockReset();
+    jwtStrategy.mockImplementation(() => {
+      return {
+        getBearerToken: jest.fn().mockReturnValue('token'),
+      };
+    })
+  });
+
+
+
+  it('then it should call associated-with-user resource with user id', async () => {
+    await createOrganisation(body, correlationId);
+
+    expect(fetchApi.mock.calls).toHaveLength(1);
+    expect(fetchApi.mock.calls[0][0]).toBe('http://organisations.test/organisations/');
+    expect(fetchApi.mock.calls[0][1]).toMatchObject({
+      method: 'POST',
+    });
+  });
+
+  it('then it should use the token from jwt strategy as bearer token', async () => {
+    await createOrganisation(body, correlationId);
+
+    expect(fetchApi.mock.calls[0][1]).toMatchObject({
+      headers: {
+        authorization: 'bearer token',
+      },
+    });
+  });
+
+  it('then it should include the correlation id', async () => {
+    await createOrganisation(body, correlationId);
+
+    expect(fetchApi.mock.calls[0][1]).toMatchObject({
+      headers: {
+        'x-correlation-id': correlationId,
+      },
+    });
+  });
+
+  it('should return null on a 404 response', async () => {
+    fetchApi.mockImplementation(() => {
+      const error = new Error('not found');
+      error.statusCode = 404;
+      throw error;
+    });
+
+    const result = await createOrganisation(body, correlationId);
+    expect(result).toEqual(null);
+  });
+
+  it('should return null on a 401 response', async () => {
+    fetchApi.mockImplementation(() => {
+      const error = new Error('unauthorized');
+      error.statusCode = 401;
+      throw error;
+    });
+
+    const result = await createOrganisation(body, correlationId);
+    expect(result).toEqual(null);
+  });
+
+  it('should return false on a 409 response', async () => {
+    fetchApi.mockImplementation(() => {
+      const error = new Error('Conflict');
+      error.statusCode = 409;
+      throw error;
+    });
+
+    const result = await createOrganisation(body, correlationId);
+    expect(result).toEqual(false);
+  });
+
+  it('should raise an exception on any failure status code that is not 401, 404 or 409', async () => {
+    fetchApi.mockImplementation(() => {
+      const error = new Error('Server Error');
+      error.statusCode = 500;
+      throw error;
+    });
+
+    try {
+      await createOrganisation(body, correlationId);
+    } catch (e) {
+      expect(e.statusCode).toEqual(500);
+      expect(e.message).toEqual('Server Error');
+    }
+  });
+});


### PR DESCRIPTION
Adds a page to the support service to add an organisation.
It should be noted that this is more of an MVP than a full solution.  In the short term, this should allow us to stop having to write as many database scripts to add organisations into environments. They're usually pretty simple requests, which is why we included the fields we did in the first pass.

In the long term, this page should be iterated on so that it fits our needs.  With enough use, we'll find out what's missing from this page and get some more solid requirements together for it.