### PR TITLE
[NSA-8833] Fix issue with certain characters being rejected

### DIFF
--- a/src/app/organisations/postCreateOrganisation.js
+++ b/src/app/organisations/postCreateOrganisation.js
@@ -1,11 +1,12 @@
 const { sendResult } = require("../../infrastructure/utils");
 const { searchOrganisations } = require("../../infrastructure/organisations");
 const logger = require("../../infrastructure/logger");
+const { unescape } = require("lodash");
 
 const validateInput = async (req) => {
   const model = {
-    name: req.body.name || "",
-    address: req.body.address || "",
+    name: unescape(req.body.name) || "",
+    address: unescape(req.body.address) || "",
     ukprn: req.body.ukprn || "",
     category: req.body.category || "",
     upin: req.body.upin || "",

--- a/test/app/organisations/postCreateOrganisation.test.js
+++ b/test/app/organisations/postCreateOrganisation.test.js
@@ -131,6 +131,17 @@ describe("when displaying the get create organisations", () => {
     expect(sendResult.mock.calls[0][3]).toStrictEqual(exampleErrorResponse);
   });
 
+  it("should redirect to the confirm screen if a valid special character is used", async () => {
+    // Note: ' is converted into &#39; so we're testing that the unescape works correctly here as well
+    req.body.name = "Test&#39;org";
+
+    await postCreateOrganisation(req, res);
+
+    expect(res.redirect.mock.calls).toHaveLength(1);
+    expect(res.redirect.mock.calls[0][0]).toBe("confirm-create-org");
+    expect(sendResult).toHaveBeenCalledTimes(0);
+  });
+
   it("should render an the page with an error in validationMessages if validation fails on name with over 256 characters", async () => {
     req.body.name = "Test123456".repeat(26); // 260 character length string
     exampleErrorResponse.name = "Test123456".repeat(26);


### PR DESCRIPTION
Original issue was `'` being rejected, even though it's an allowed character.
Turns out, it was converting it into `&#39;` and then it was failing because `#` is invalid. 

This PR unescapes the name and address so the special character validation can work.