### PR TITLE
[NSA-8856] Check if status exists before querying id

### DIFF
--- a/src/app/users/views/organisations.ejs
+++ b/src/app/users/views/organisations.ejs
@@ -38,14 +38,14 @@
 
                                         <% if (org.urn) { %>
                                             <dt><abbr title="Unique Reference Number">URN: </abbr></dt>
-                                            <% if (org.status.id === 4) { %>
+                                            <% if (org.status && org.status.id === 4) { %>
                                                 <dd><%=org.urn%></dd>
                                             <%}else {%>
                                                 <dd><a href="https://get-information-schools.service.gov.uk/Establishments/Establishment/Details/<%=org.urn%>" target="_blank"><%=org.urn%></a></dd>
                                                 <%}%>
                                         <%}else if(org.uid) {%>
                                             <dt><abbr title="Unique Identifier">UID: </abbr></dt>
-                                            <% if (org.status.id === 2) { %>
+                                            <% if (org.status && org.status.id === 2) { %>
                                                 <dd><%=org.uid%></dd>
                                             <%}else {%>
                                                 <dd><a href="https://get-information-schools.service.gov.uk/Groups/Group/Details/<%=org.uid%>" target="_blank"><%=org.uid%></a></dd>


### PR DESCRIPTION
There was a bug where it would throw an error on this screen after inviting a user.
This is because the invited user organisation wouldn't return the status (for some reason?).  We can fix this bug by first checking if there is an `status` attribute in the org, and only if there is then checking the `id`.