### PR TITLE
[DSI-7491] - Disable change email option for DSI team members

### DIFF
--- a/src/app/users/getAudit.js
+++ b/src/app/users/getAudit.js
@@ -1,4 +1,8 @@
-const { sendResult, mapUserStatus } = require("./../../infrastructure/utils");
+const {
+  sendResult,
+  mapUserStatus,
+  isInternalEntraUser,
+} = require("./../../infrastructure/utils");
 const { getUserDetailsById } = require("./utils");
 const { dateFormat } = require("../helpers/dateFormatterHelper");
 const { getPageOfUserAudits } = require("./../../infrastructure/audit");
@@ -205,6 +209,7 @@ const getAudit = async (req, res) => {
   cachedUsers = {};
   const correlationId = req.id;
   const user = await getCachedUserById(req.params.uid, req.id);
+  const showChangeEmail = !isInternalEntraUser(user);
   user.formattedLastLogin = user.lastLogin
     ? dateFormat(user.lastLogin, "longDateFormat")
     : "";
@@ -272,6 +277,7 @@ const getAudit = async (req, res) => {
   sendResult(req, res, "users/views/audit", {
     csrfToken: req.csrfToken(),
     user,
+    showChangeEmail,
     organisations: userOrganisations,
     audits,
     numberOfPages: pageOfAudits.numberOfPages,

--- a/src/app/users/getOrganisations.js
+++ b/src/app/users/getOrganisations.js
@@ -1,7 +1,10 @@
 const flatten = require("lodash/flatten");
 const uniq = require("lodash/uniq");
 const sortBy = require("lodash/sortBy");
-const { sendResult } = require("../../infrastructure/utils");
+const {
+  sendResult,
+  isInternalEntraUser,
+} = require("../../infrastructure/utils");
 const { getUserDetails } = require("./utils");
 const { dateFormat } = require("../helpers/dateFormatterHelper");
 const {
@@ -81,6 +84,7 @@ const getPendingRequests = async (userId, correlationId) => {
 
 const action = async (req, res) => {
   const user = await getUserDetails(req);
+  const showChangeEmail = !isInternalEntraUser(user);
   user.formattedLastLogin = user.lastLogin
     ? dateFormat(user.lastLogin, "longDateFormat")
     : "";
@@ -140,6 +144,7 @@ const action = async (req, res) => {
   sendResult(req, res, "users/views/organisations", {
     csrfToken: req.csrfToken(),
     user,
+    showChangeEmail,
     organisations: sortedOrgs,
     isInvitation: req.params.uid.startsWith("inv-"),
   });

--- a/src/app/users/getServices.js
+++ b/src/app/users/getServices.js
@@ -1,4 +1,7 @@
-const { sendResult } = require("../../infrastructure/utils");
+const {
+  sendResult,
+  isInternalEntraUser,
+} = require("../../infrastructure/utils");
 const { getUserDetails } = require("./utils");
 const { dateFormat } = require("../helpers/dateFormatterHelper");
 const {
@@ -54,6 +57,7 @@ const getOrganisations = async (userId, correlationId) => {
 
 const action = async (req, res) => {
   const user = await getUserDetails(req);
+  const showChangeEmail = !isInternalEntraUser(user);
   user.formattedLastLogin = user.lastLogin
     ? dateFormat(user.lastLogin, "longDateFormat")
     : "";
@@ -126,6 +130,7 @@ const action = async (req, res) => {
   sendResult(req, res, "users/views/services", {
     csrfToken: req.csrfToken(),
     user,
+    showChangeEmail,
     organisations: allOrganisationsForUser,
     isInvitation: req.params.uid.startsWith("inv-"),
   });

--- a/src/app/users/index.js
+++ b/src/app/users/index.js
@@ -1,6 +1,7 @@
 const express = require("express");
 const { asyncWrapper } = require("login.dfe.express-error-handling");
 const { isLoggedIn, setCurrentArea } = require("../../infrastructure/utils");
+const isAuthorizedToChangeEmail = require("../../infrastructure/utils/isAuthorizedToChangeEmail");
 const logger = require("../../infrastructure/logger");
 
 const search = require("./search");
@@ -167,9 +168,6 @@ const users = (csrf) => {
     asyncWrapper(postManageConsoleRoles),
   );
 
-  router.get("/:uid/edit-email", csrf, asyncWrapper(getEditEmail));
-  router.post("/:uid/edit-email", csrf, asyncWrapper(postEditEmail));
-
   router.get(
     "/:uid/confirm-deactivation",
     csrf,
@@ -179,6 +177,19 @@ const users = (csrf) => {
     "/:uid/confirm-deactivation",
     csrf,
     asyncWrapper(postConfirmDeactivate),
+  );
+
+  router.get(
+    "/:uid/edit-email",
+    csrf,
+    isAuthorizedToChangeEmail,
+    asyncWrapper(getEditEmail),
+  );
+  router.post(
+    "/:uid/edit-email",
+    csrf,
+    isAuthorizedToChangeEmail,
+    asyncWrapper(postEditEmail),
   );
 
   router.get(

--- a/src/app/users/utils.js
+++ b/src/app/users/utils.js
@@ -235,6 +235,9 @@ const mapUserToSupportModel = (user, userFromSearch) => {
     firstName: user.given_name,
     lastName: user.family_name,
     email: user.email,
+    isEntra: user.isEntra,
+    isInternalUser: user.isInternalUser,
+    entraOid: user.entraOid,
     organisation: userFromSearch.primaryOrganisation
       ? {
           name: userFromSearch.primaryOrganisation,
@@ -305,6 +308,9 @@ const getUserDetailsById = async (uid, correlationId) => {
       firstName: user.firstName,
       lastName: user.lastName,
       email: user.email,
+      isEntra: user.isEntra,
+      isInternalUser: user.isInternalUser,
+      entraOid: user.entraOid,
       lastLogin: user.lastLogin,
       status: user.status,
       loginsInPast12Months: {

--- a/src/app/users/views/summaryPartial.ejs
+++ b/src/app/users/views/summaryPartial.ejs
@@ -70,7 +70,7 @@
                         <% if (locals.organisations.length > 0 && locals.user.status.id !== 0) { %>
                             <li><a href="select-organisation">Add services</a></li>
                         <% } %>
-                        <% if(locals.user.status.id !== 0) { %>
+                        <% if(locals.user.status.id !== 0 && showChangeEmail) { %>
                             <li><a href="edit-email">Change user's email address</a></li>
                         <% } %>
                         <% if(locals.user.status.id === 0) { %>

--- a/src/infrastructure/utils/index.js
+++ b/src/infrastructure/utils/index.js
@@ -1,4 +1,5 @@
 const isLoggedIn = require("./isLoggedIn");
+const isInternalEntraUser = require("./isInternalEntraUser");
 const setCurrentArea = require("./setCurrentArea");
 const sendResult = require("./sendResult");
 const { mapUserStatus, userStatusMap } = require("./mapUserStatus");
@@ -8,6 +9,7 @@ const isServiceCreator = require("./isServiceCreator");
 
 module.exports = {
   isLoggedIn,
+  isInternalEntraUser,
   setCurrentArea,
   sendResult,
   mapUserStatus,

--- a/src/infrastructure/utils/isAuthorizedToChangeEmail.js
+++ b/src/infrastructure/utils/isAuthorizedToChangeEmail.js
@@ -1,0 +1,25 @@
+const isInternalEntraUser = require("./isInternalEntraUser");
+const Account = require("./../../infrastructure/directories");
+
+// Middleware to check if user is authorized to
+// change their email or password
+const isAuthorizedToChangeEmail = async (req, res, next) => {
+  try {
+    const userId = req.params?.uid;
+    if (!userId) {
+      return res.status(401).render("errors/views/notAuthorised");
+    }
+    const user = await Account.getUser(userId);
+
+    // If the user is an internal DSI user and has migrated to Entra,
+    // they are not allowed to change their email
+    if (isInternalEntraUser(user)) {
+      return res.status(401).render("errors/views/notAuthorised");
+    }
+    return next();
+  } catch (error) {
+    next(error);
+  }
+};
+
+module.exports = isAuthorizedToChangeEmail;

--- a/src/infrastructure/utils/isAuthorizedToChangeEmail.js
+++ b/src/infrastructure/utils/isAuthorizedToChangeEmail.js
@@ -1,8 +1,7 @@
 const isInternalEntraUser = require("./isInternalEntraUser");
 const Account = require("./../../infrastructure/directories");
 
-// Middleware to check if user is authorized to
-// change their email or password
+// Middleware to check if a user's email is authorized to be changed
 const isAuthorizedToChangeEmail = async (req, res, next) => {
   try {
     const userId = req.params?.uid;
@@ -11,8 +10,8 @@ const isAuthorizedToChangeEmail = async (req, res, next) => {
     }
     const user = await Account.getUser(userId);
 
-    // If the user is an internal DSI user and has migrated to Entra,
-    // they are not allowed to change their email
+    // If the user is an internal DSI user who has been migrated to Entra, 
+    // their email address should not be authorized for change
     if (isInternalEntraUser(user)) {
       return res.status(401).render("errors/views/notAuthorised");
     }

--- a/src/infrastructure/utils/isInternalEntraUser.js
+++ b/src/infrastructure/utils/isInternalEntraUser.js
@@ -1,0 +1,6 @@
+// Check if the user is an internal DSI user and has migrated to Entra
+const isInternalEntraUser = (user) => {
+  return !!(user?.isInternalUser && user?.isEntra && user?.entraOid);
+};
+
+module.exports = isInternalEntraUser;

--- a/test/infrastructure/utils/isAuthorizedToChangeEmail.test.js
+++ b/test/infrastructure/utils/isAuthorizedToChangeEmail.test.js
@@ -1,0 +1,76 @@
+const isAuthorizedToChangeEmail = require("../../../src/infrastructure/utils/isAuthorizedToChangeEmail");
+const Account = require("../../../src/infrastructure/directories");
+
+jest.mock("../../../src/infrastructure/config", () =>
+  require("../../utils").configMockFactory(),
+);
+
+jest.mock("../../../src/infrastructure/directories");
+
+describe("isAuthorizedToChangeEmail middleware function", () => {
+  let req, res, next;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    req = {
+      params: {
+        uid: "user-id",
+      },
+    };
+    res = {
+      status: jest.fn().mockReturnThis(),
+      render: jest.fn(),
+    };
+    next = jest.fn();
+
+    Account.getUser.mockReset().mockResolvedValue({
+      isInternalUser: false,
+      isEntra: true,
+      entraOid: "userEntraOid",
+    });
+  });
+
+  it("should call next if user is authorized to change their email address or password", async () => {
+    await isAuthorizedToChangeEmail(req, res, next);
+
+    expect(Account.getUser).toHaveBeenCalledWith("user-id");
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.render).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("should return 401 if user is not present in the request", async () => {
+    req.params = null;
+
+    await isAuthorizedToChangeEmail(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.render).toHaveBeenCalledWith("errors/views/notAuthorised");
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("should return 401 if user is an internal DSI user which migrated to Entra", async () => {
+    Account.getUser.mockReset().mockResolvedValue({
+      isInternalUser: true,
+      isEntra: true,
+      entraOid: "userEntraOid",
+    });
+
+    await isAuthorizedToChangeEmail(req, res, next);
+
+    expect(Account.getUser).toHaveBeenCalledWith("user-id");
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.render).toHaveBeenCalledWith("errors/views/notAuthorised");
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("should call next with error if an exception occurs", async () => {
+    const error = new Error("it error");
+    Account.getUser.mockRejectedValue(error);
+
+    await isAuthorizedToChangeEmail(req, res, next);
+
+    expect(next).toHaveBeenCalledWith(error);
+  });
+});

--- a/test/infrastructure/utils/isAuthorizedToChangeEmail.test.js
+++ b/test/infrastructure/utils/isAuthorizedToChangeEmail.test.js
@@ -31,7 +31,7 @@ describe("isAuthorizedToChangeEmail middleware function", () => {
     });
   });
 
-  it("should call next if user is authorized to change their email address or password", async () => {
+  it("should call next if the user's email address is authorized to be changed", async () => {
     await isAuthorizedToChangeEmail(req, res, next);
 
     expect(Account.getUser).toHaveBeenCalledWith("user-id");

--- a/test/infrastructure/utils/isInternalEntraUser.test.js
+++ b/test/infrastructure/utils/isInternalEntraUser.test.js
@@ -1,0 +1,54 @@
+const { isInternalEntraUser } = require("../../../src/infrastructure/utils");
+
+describe("isInternalEntraUser helper function", () => {
+  it("should return true when user is internal DSI user, `is_entra` flag is true, and `entra_oid` is not null", () => {
+    const user = {
+      isInternalUser: true,
+      isEntra: true,
+      entraOid: "entra-oid",
+    };
+    expect(isInternalEntraUser(user)).toBe(true);
+  });
+
+  it("should return false when user is not internal DSI user", () => {
+    const user = {
+      isInternalUser: false,
+      isEntra: true,
+      entraOid: "some-oid",
+    };
+    expect(isInternalEntraUser(user)).toBe(false);
+  });
+
+  it("should return false when user has `is_entra` flag set to false", () => {
+    const user = {
+      isInternalUser: true,
+      isEntra: false,
+      entraOid: "some-oid",
+    };
+    expect(isInternalEntraUser(user)).toBe(false);
+  });
+
+  it("should return false when user does not have entraOid", () => {
+    const user = {
+      isInternalUser: true,
+      isEntra: true,
+      entraOid: null,
+    };
+    expect(isInternalEntraUser(user)).toBe(false);
+  });
+
+  it("should return false when user is undefined", () => {
+    const user = undefined;
+    expect(isInternalEntraUser(user)).toBe(false);
+  });
+
+  it("should return false when user is null", () => {
+    const user = null;
+    expect(isInternalEntraUser(user)).toBe(false);
+  });
+
+  it("should return false when user is an empty object", () => {
+    const user = {};
+    expect(isInternalEntraUser(user)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
**Jira ticket:** https://dfe-secureaccess.atlassian.net/browse/DSI-7491

## Changes
- Implement functionality to prevent DSI team members who have migrated to Entra from modifying their email:

  - Hide Email change options on the summary partial from user.
  - Protect the email change routes with middleware to restrict these users from updating their authentication details.
 
- Add unit tests to these changes