### PR TITLE
[NSA-8945] Fix special character issue with create organisation screen

### DIFF
--- a/src/app/organisations/postCreateOrganisation.js
+++ b/src/app/organisations/postCreateOrganisation.js
@@ -21,7 +21,7 @@ const validateInput = async (req) => {
   model.upin = model.upin.trim();
   model.urn = model.urn.trim();
 
-  const nameRegEx = /^[^±!@£$%^*_+§¡€#¢§¶•ªº«\\/<>:;|=.~"]+$/i;
+  const nameRegEx = /^[^±!@£$%^*_+§¡€#¢§¶•ªº«\\<>:;|=.~"]+$/i;
   if (!model.name) {
     model.validationMessages.name = "Please enter a name";
   } else if (!nameRegEx.test(model.name)) {

--- a/src/app/organisations/postEditOrganisation.js
+++ b/src/app/organisations/postEditOrganisation.js
@@ -11,7 +11,7 @@ const validateInput = async (req) => {
   const regex = /[±!@£$%^*_+§¡€#¢§¶•ªº«\\/<>:;|=.~"]/;
   const model = {
     csrfToken: req.csrfToken(),
-    backlink: "users",
+    backLink: "users",
     organisation,
     validationMessages: {},
   };

--- a/test/app/organisations/postCreateOrganisation.test.js
+++ b/test/app/organisations/postCreateOrganisation.test.js
@@ -133,7 +133,24 @@ describe("when displaying the get create organisations", () => {
 
   it("should redirect to the confirm screen if a valid special character is used", async () => {
     // Note: ' is converted into &#39; so we're testing that the unescape works correctly here as well
-    req.body.name = "Test&#39;org";
+    req.body.name = "Test&#39;org/";
+
+    await postCreateOrganisation(req, res);
+
+    expect(res.redirect.mock.calls).toHaveLength(1);
+    expect(res.redirect.mock.calls[0][0]).toBe("confirm-create-org");
+    expect(sendResult).toHaveBeenCalledTimes(0);
+  });
+
+  it("should redirect to the confirm screen all non-mandatory fields are empty", async () => {
+    req.body = {
+      name: "Test name",
+      address: "",
+      ukprn: "",
+      category: "008",
+      upin: "",
+      urn: "",
+    };
 
     await postCreateOrganisation(req, res);
 


### PR DESCRIPTION
This PR:
- Allows `/` to be a valid character for an organisation name.
- Fixes a typo for `backLink` in edit organisation
- Brings the test coverage for editOrganisation to 100%

The last 2 points were boy scouting, the main point of this PR was the special character issue