### PR TITLE
[NSA-8939] Convert users audit page in support to new GDS style

### DIFF
--- a/src/app/organisations/getppsyncStatus.js
+++ b/src/app/organisations/getppsyncStatus.js
@@ -25,6 +25,8 @@ const getppsyncStatus = async (req, res) => {
   }
   sendResult(req, res, "organisations/views/ppsyncStatus", {
     csrfToken: req.csrfToken(),
+    backLink: true,
+    layout: "sharedViews/layoutNew.ejs",
     audits: ppauditData.audits,
     syncInP: req.syncInP,
     cancelLink: "/organisations",

--- a/src/app/organisations/postPpsyncStatus.js
+++ b/src/app/organisations/postPpsyncStatus.js
@@ -37,6 +37,7 @@ const postPpsyncStatus = async (req, res) => {
 
   if (Object.keys(model.validationMessages).length > 0) {
     model.csrfToken = req.csrfToken();
+    model.layout = "sharedViews/layoutNew.ejs";
     const ppauditData = await organisation.getPpAuditPaging(pageNumber);
     model.audits = ppauditData.audits;
     model.numberOfPages = ppauditData.totalNumberOfPages;

--- a/src/app/organisations/views/ppsyncStatus.ejs
+++ b/src/app/organisations/views/ppsyncStatus.ejs
@@ -1,89 +1,89 @@
-<a href="/organisations" class="link-back">Back</a>
-<div class="row">
-    <div class="col-12">
-        <h1 class="heading-large">Run Provider Profile Sync</h1>
-    </div>
-    <div class="col-12">
-        <p>The following table tells you if the sync has run successfully or failed on each step.</p>
-    </div>
-</div>
-<%
-const paginationModel = {
-    currentPage: locals.page,
-    numberOfPages: locals.numberOfPages,
-    totalNumberOfResults: locals.totalNumberOfResults,
-    numberOfResultsOnPage: locals.audits.length,
-    data: [],
-};
-%>
-
-<%- include('../../sharedViews/pagination', paginationModel); %>
-<div class="row">
-    <div class="col-12">
-        <table class="data">
-            <thead>
-                <tr>
-                    <th scope="col" class="cwp-20">Start date</th>
-                    <th scope="col" class="cwp-30">End date</th>
-                   <!-- <th scope="col" class="cwp-15">Status</th> -->
-                    <th scope="col" class="cwp-15">Step1</th>
-                    <th scope="col" class="cwp-10">Step2</th>
-                    <th scope="col" class="cwp-10">Step3</th>
-                </tr>
-            </thead>
-            <tbody>
-            <% for(let a = 0;a < locals.audits.length; a++) { %>
-            <% const audit = locals.audits[a]; %>
-                <tr>
-                    <%if (audit.formattedStartDate){%>
-                    <td><%= audit.formattedStartDate %></td>
-                        <%}else{%>
-                            <td></td>
-                        <%}%>
-                    <%if (audit.formattedEndDate){%>
-                    <td><%= audit.formattedEndDate %></td>
-                        <%}else{%>
-                            <td></td>
-                        <%}%>
-                    <td class="breakable"><%= audit.statusStep1 === 2? 'SUCCESS' : (audit.statusStep1 === 3?'FAILURE' : '') %></td>
-                    <td class="breakable"><%= audit.statusStep2 === 2? 'SUCCESS' : (audit.statusStep2 === 3?'FAILURE' : '') %></td>
-                    <td class="breakable"><%= audit.statusStep3 === 2? 'SUCCESS' : (audit.statusStep3 === 3?'FAILURE' : '') %></td>
-                </tr>
-            <% } %>
-            </tbody>
-        </table>
-        <%- include('../../sharedViews/pagination', paginationModel); %>
-        <div class="row">
-            <div class="col-12">
-                <h2 class="heading-medium">Provider Profile Email</h2>
-            </div>
-            <div class="col-12">
-                <form method="post" id="form-pp-sync">
-
-                    <div class="form-group <%= (locals.validationMessages.emailStatus !== undefined) ? 'form-group-error' : '' %>">
-                        <input type="hidden" name="_csrf" value="<%= csrfToken %>"/>
-                        <p>Tick this box to confirm you have received the Provider Profile email.</p>
-                        <% if (locals.validationMessages.emailStatus !== undefined) { %>
-                            <p class="error-message" id="validation-firstName"><%= locals.validationMessages.emailStatus %></p>
-                        <% } %>
-                        <div class="multiple-choice">
-                         <input type="checkbox" id="emailStatus" name="emailStatus" value="checked"> <label> Email received </label>
-                        </div>
-                    </div>
-
-                  <div class="form-submit submit-buttons">
-                    <%if(locals.syncInP){%>
-                        <button type="submit" disabled class="button">Submit</button>
-                     <%}else{%>
-                    <button type="submit" class="button">Submit</button>
-                        <%}%>
-                    <a href="<%= locals.cancelLink %>" class="button button-secondary">Cancel</a>
-                </div>
-                </form>
-            </div>
-
-
+<div class="govuk-width-container">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-heading-l">Run Provider Profile Sync</h1>
+        </div>
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body">The following table tells you if the sync has run successfully or failed on each step.</p>
         </div>
     </div>
+    <%
+    const paginationModel = {
+        currentPage: locals.page,
+        numberOfPages: locals.numberOfPages,
+        totalNumberOfResults: locals.totalNumberOfResults,
+        numberOfResultsOnPage: locals.audits.length,
+        data: [],
+    };
+    %>
+    <%- include('../../sharedViews/paginationNew', paginationModel); %>
+    <div class="govuk-grid-row"> 
+        <div class="govuk-grid-column-full">
+            <table class="govuk-table">
+                <thead class="govuk-table__head">
+                    <tr class="govuk-table__row">
+                        <th scope="col" class="govuk-table__header">Start date</th>
+                        <th scope="col" class="govuk-table__header">End date</th>
+                    <!-- <th scope="col" class="cwp-15">Status</th> -->
+                        <th scope="col" class="govuk-table__header">Step1</th>
+                        <th scope="col" class="govuk-table__header">Step2</th>
+                        <th scope="col" class="govuk-table__header">Step3</th>
+                    </tr>
+                </thead>
+                <tbody class="govuk-table__body">
+                <% for(let a = 0;a < locals.audits.length; a++) { %>
+                <% const audit = locals.audits[a]; %>
+                    <tr class="govuk-table__row">
+                        <%if (audit.formattedStartDate){%>
+                        <td class="govuk-table__cell"><%= audit.formattedStartDate %></td>
+                            <%}else{%>
+                                <td class="govuk-table__cell"></td>
+                            <%}%>
+                        <%if (audit.formattedEndDate){%>
+                        <td class="govuk-table__cell"><%= audit.formattedEndDate %></td>
+                            <%}else{%>
+                                <td class="govuk-table__cell"></td>
+                            <%}%>
+                        <td class="govuk-table__cell"><%= audit.statusStep1 === 2? 'SUCCESS' : (audit.statusStep1 === 3?'FAILURE' : '') %></td>
+                        <td class="govuk-table__cell"><%= audit.statusStep2 === 2? 'SUCCESS' : (audit.statusStep2 === 3?'FAILURE' : '') %></td>
+                        <td class="govuk-table__cell"><%= audit.statusStep3 === 2? 'SUCCESS' : (audit.statusStep3 === 3?'FAILURE' : '') %></td>
+                    </tr>
+                <% } %>
+                </tbody>
+            </table>
+            <%- include('../../sharedViews/paginationNew', paginationModel); %>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-two-thirds">
+                    <h2 class="govuk-heading-m">Provider Profile Email</h2>
+                </div>
+                <div class="govuk-grid-column-two-thirds">
+                    <form method="post" id="form-pp-sync">
 
+                        <div class="govuk-form-group <%= (locals.validationMessages.emailStatus !== undefined) ? 'govuk-form-group-error' : '' %>">
+                            <input type="hidden" name="_csrf" value="<%= csrfToken %>"/>
+                                <p class="govuk-body">Tick this box to confirm you have received the Provider Profile email.</p>
+                            <% if (locals.validationMessages.emailStatus !== undefined) { %>
+                                <p class="govuk-body" id="validation-firstName"><%= locals.validationMessages.emailStatus %></p>
+                            <% } %>
+                            <div class="govuk-checkboxes">
+                                <div class="govuk-checkboxes__item">
+                                    <input class="govuk-checkboxes__input" type="checkbox" id="emailStatus" name="emailStatus" value="checked"> 
+                                    <label class="govuk-label govuk-checkboxes__label"> Email received </label>
+                                </div>
+                            </div>
+                        </div>
 
+                    <div class="form-submit submit-buttons">
+                        <%if(locals.syncInP){%>
+                            <button type="submit" disabled class="govuk-button">Submit</button>
+                        <%}else{%>
+                            <button type="submit" class="govuk-button">Submit</button>
+                            <%}%>
+                        <a href="<%= locals.cancelLink %>" class="govuk-button govuk-button--secondary">Cancel</a>
+                    </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/app/organisations/views/ppsyncStatus.ejs
+++ b/src/app/organisations/views/ppsyncStatus.ejs
@@ -53,17 +53,14 @@
             </table>
             <%- include('../../sharedViews/paginationNew', paginationModel); %>
             <div class="govuk-grid-row">
-                <div class="govuk-grid-column-two-thirds">
+                <div class="govuk-grid-column-full">
                     <h2 class="govuk-heading-m">Provider Profile Email</h2>
-                </div>
-                <div class="govuk-grid-column-two-thirds">
                     <form method="post" id="form-pp-sync">
-
-                        <div class="govuk-form-group <%= (locals.validationMessages.emailStatus !== undefined) ? 'govuk-form-group-error' : '' %>">
+                        <div class="govuk-form-group <%= (locals.validationMessages.emailStatus !== undefined) ? 'govuk-form-group--error' : '' %>">
                             <input type="hidden" name="_csrf" value="<%= csrfToken %>"/>
                                 <p class="govuk-body">Tick this box to confirm you have received the Provider Profile email.</p>
                             <% if (locals.validationMessages.emailStatus !== undefined) { %>
-                                <p class="govuk-body" id="validation-firstName"><%= locals.validationMessages.emailStatus %></p>
+                                <p class="govuk-error-message" id="validation-firstName"><%= locals.validationMessages.emailStatus %></p>
                             <% } %>
                             <div class="govuk-checkboxes">
                                 <div class="govuk-checkboxes__item">
@@ -72,15 +69,14 @@
                                 </div>
                             </div>
                         </div>
-
-                    <div class="form-submit submit-buttons">
-                        <%if(locals.syncInP){%>
-                            <button type="submit" disabled class="govuk-button">Submit</button>
-                        <%}else{%>
-                            <button type="submit" class="govuk-button">Submit</button>
-                            <%}%>
-                        <a href="<%= locals.cancelLink %>" class="govuk-button govuk-button--secondary">Cancel</a>
-                    </div>
+                        <div class="govuk-button-group">
+                            <%if(locals.syncInP){%>
+                                <button type="submit" disabled class="govuk-button">Submit</button>
+                            <%}else{%>
+                                <button type="submit" class="govuk-button">Submit</button>
+                                <%}%>
+                            <a href="<%= locals.cancelLink %>" class="govuk-button govuk-button--secondary">Cancel</a>
+                        </div>
                     </form>
                 </div>
             </div>

--- a/src/app/organisations/views/search.ejs
+++ b/src/app/organisations/views/search.ejs
@@ -173,7 +173,7 @@ const organisationStatusesQuery = locals.organisationStatuses.filter(x => x.isSe
                         <% } %>
                         <% for (let i = 0; i < locals.organisations.length; i++) { %>
                             <tr class="govuk-table__row govuk-body">
-                                <td class="govuk-table__cell govuk-body-s"><a href="/organisations/<%= organisations[i].id %>/users?criteria=<%= locals.criteria %>&page=<%= locals.page %>&showFilters=<%= locals.showFilters %>&<%= organisationTypesQuery %>&<%= organisationStatusesQuery %>"><%= organisations[i].name %></a></td>
+                                <td class="govuk-table__cell govuk-body-s"><a class="govuk-link" href="/organisations/<%= organisations[i].id %>/users?criteria=<%= locals.criteria %>&page=<%= locals.page %>&showFilters=<%= locals.showFilters %>&<%= organisationTypesQuery %>&<%= organisationStatusesQuery %>"><%= organisations[i].name %></a></td>
                                 <td class="govuk-table__cell govuk-body-s"><%= organisations[i].LegalName %></td>
                                 <td class="govuk-table__cell govuk-body-s"><%= organisations[i].type ? organisations[i].type.name : organisations[i].providerTypeName || organisations[i].category.name  %></td>
                                 <td class="govuk-table__cell govuk-body-s"><%= organisations[i].urn %></td>

--- a/src/app/organisations/views/search.ejs
+++ b/src/app/organisations/views/search.ejs
@@ -1,15 +1,15 @@
 <% if (locals.flash.info || locals.activeSync) { %>
-    <div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
-        <div class="govuk-notification-banner__header">
-            <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">Success</h2>
-        </div>
-        <div class="govuk-notification-banner__content">
-            <p class="govuk-body"><%= locals.flash.info || locals.activeSync %></p>
+    <div class="govuk-width-container">
+        <div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-5" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+            <div class="govuk-notification-banner__header">
+                <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">Success</h2>
+            </div>
+            <div class="govuk-notification-banner__content">
+                <p class="govuk-body"><%= locals.flash.info || locals.activeSync %></p>
+            </div>
         </div>
     </div>
 <% } %>
-
-
 <%
 const paginationModel = {
     disableNextAndPrevious: true,

--- a/src/app/sharedViews/layoutNew.ejs
+++ b/src/app/sharedViews/layoutNew.ejs
@@ -65,7 +65,6 @@
                     DfE Sign-In support console
                 </a>
                 <% if (locals.isLoggedIn) { %>
-                    <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide navigation menu">Menu</button>
                     <nav>
                         <ul id="navigation" class="govuk-header__navigation " aria-label="Navigation menu">
                             <li class="govuk-header__navigation-item">

--- a/src/app/sharedViews/layoutNew.ejs
+++ b/src/app/sharedViews/layoutNew.ejs
@@ -70,6 +70,7 @@
                     DfE Sign-In support console
                 </a>
                 <% if (locals.isLoggedIn) { %>
+                    <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" hidden aria-controls="navigation" aria-label="Show or hide navigation menu">Menu</button>
                     <nav>
                         <ul id="navigation" class="govuk-header__navigation " aria-label="Navigation menu">
                             <li class="govuk-header__navigation-item">

--- a/src/app/users/getAudit.js
+++ b/src/app/users/getAudit.js
@@ -276,6 +276,8 @@ const getAudit = async (req, res) => {
 
   sendResult(req, res, "users/views/audit", {
     csrfToken: req.csrfToken(),
+    layout: "sharedViews/layoutNew.ejs",
+    backLink: true,
     user,
     showChangeEmail,
     organisations: userOrganisations,

--- a/src/app/users/getOrganisations.js
+++ b/src/app/users/getOrganisations.js
@@ -143,6 +143,8 @@ const action = async (req, res) => {
 
   sendResult(req, res, "users/views/organisations", {
     csrfToken: req.csrfToken(),
+    layout: "sharedViews/layoutNew.ejs",
+    backLink: "/users",
     user,
     showChangeEmail,
     organisations: sortedOrgs,

--- a/src/app/users/getServices.js
+++ b/src/app/users/getServices.js
@@ -129,6 +129,8 @@ const action = async (req, res) => {
 
   sendResult(req, res, "users/views/services", {
     csrfToken: req.csrfToken(),
+    layout: "sharedViews/layoutNew.ejs",
+    backLink: true,
     user,
     showChangeEmail,
     organisations: allOrganisationsForUser,

--- a/src/app/users/postCancelChangeEmail.js
+++ b/src/app/users/postCancelChangeEmail.js
@@ -9,7 +9,7 @@ const {
 
 const updateUserIndex = async (uid, correlationId) => {
   const user = await getUserDetailsById(uid, correlationId);
-  user.pendingEmail = undefined;
+  user.pendingEmail = null;
 
   await updateUserDetails(user, correlationId);
 

--- a/src/app/users/views/audit.ejs
+++ b/src/app/users/views/audit.ejs
@@ -5,7 +5,10 @@
         <div class="govuk-grid-column-full">
             <form method="POST">
                 <input type="hidden" name="_csrf" value="<%= csrfToken %>"/>
-                    <button class="govuk-button" style="margin-bottom: 1.25em;" type="submit" onclick="this.form.submit(); this.disabled=true; this.innerText='Processing Update';">Update and refresh</button>
+                <button class="govuk-button govuk-!-margin-bottom-3" type="submit" 
+                        onclick="this.form.submit(); this.disabled=true; this.innerText='Processing Update';">
+                    Update and refresh
+                </button>
             </form>
         </div>
     </div>
@@ -22,35 +25,43 @@
     %>
 
     <%- include('../../sharedViews/paginationNew', paginationModel); %>
+
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
-            <table class="govuk-table">
-                <thead class="govuk-table__head">
-                    <tr class="govuk-table__row">
-                        <th scope="col" class="govuk-table__header">Date</th>
-                        <th scope="col" class="govuk-table__header">Event</th>
-                        <th scope="col" class="govuk-table__header">Service</th>
-                        <th scope="col" class="govuk-table__header">Organisation</th>
-                        <th scope="col" class="govuk-table__header">Result</th>
-                        <th scope="col" class="govuk-table__header">User</th>
-                    </tr>
-                </thead>
-                <tbody class="govuk-table__body">
-                <% for(let a = 0;a < locals.audits.length; a++) { %>
-                <% const audit = locals.audits[a]; %>
-                    <tr class="govuk-table__row">
-                        <td><%= audit.formattedTimestamp %></td>
-                        <td class="govuk-table__cell"><%= audit.event.description %></td>
-                        <td class="govuk-table__cell"><%= audit.service ? audit.service.name : '' %></td>
-                        <td class="govuk-table__cell"><%= audit.organisation ? audit.organisation.name: '' %></td>
-                        <td class="govuk-table__cell"><%= audit.result ? 'Success' : 'Failure' %></td>
-                        <td class="govuk-table__cell"><%= audit.user ? audit.user.name : '' %></td>
-                    </tr>
-                <% } %>
-                </tbody>
-            </table>
-            <%- include('../../sharedViews/pagination', paginationModel); %>
+            <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="audit">
+                <table class="govuk-table">
+                    <thead class="govuk-table__head">
+                        <tr class="govuk-table__row">
+                            <th scope="col" class="govuk-table__header">Date</th>
+                            <th scope="col" class="govuk-table__header">Event</th>
+                            <th scope="col" class="govuk-table__header">Service</th>
+                            <th scope="col" class="govuk-table__header">Organisation</th>
+                            <th scope="col" class="govuk-table__header">Result</th>
+                            <th scope="col" class="govuk-table__header">User</th>
+                        </tr>
+                    </thead>
+                    <tbody class="govuk-table__body">
+                        <% if (locals.audits.length > 0) { %>
+                            <% for(let a = 0; a < locals.audits.length; a++) { %>
+                                <% const audit = locals.audits[a]; %>
+                                <tr class="govuk-table__row">
+                                    <td class="govuk-table__cell"><%= audit.formattedTimestamp %></td>
+                                    <td class="govuk-table__cell"><%= audit.event.description %></td>
+                                    <td class="govuk-table__cell"><%= audit.service ? audit.service.name : '' %></td>
+                                    <td class="govuk-table__cell"><%= audit.organisation ? audit.organisation.name : '' %></td>
+                                    <td class="govuk-table__cell"><%= audit.result ? 'Success' : 'Failure' %></td>
+                                    <td class="govuk-table__cell"><%= audit.user ? audit.user.name : '' %></td>
+                                </tr>
+                            <% } %>
+                        <% } else { %>
+                            <tr class="govuk-table__row">
+                                <td colspan="6" class="govuk-table__cell govuk-body">No audit records available.</td>
+                            </tr>
+                        <% } %>
+                    </tbody>
+                </table>
+            </div>
+            <%- include('../../sharedViews/paginationNew', paginationModel); %>
         </div>
     </div>
 </div>
-

--- a/src/app/users/views/audit.ejs
+++ b/src/app/users/views/audit.ejs
@@ -1,51 +1,56 @@
-<%- include('summaryPartial', {area: 'audit', user: locals.user}); %>
+<div class="govuk-width-container">
+    <%- include('summaryPartial', {area: 'audit', user: locals.user}); %>
 
-<div class="row meta">
-    <div class="col-12">
-        <form method="POST">
-            <input type="hidden" name="_csrf" value="<%= csrfToken %>"/>
-                <button class="button" style="margin-bottom: 1.25em;" type="submit" onclick="this.form.submit(); this.disabled=true; this.innerText='Processing Update';">Update and refresh</button>
-        </form>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <form method="POST">
+                <input type="hidden" name="_csrf" value="<%= csrfToken %>"/>
+                    <button class="govuk-button" style="margin-bottom: 1.25em;" type="submit" onclick="this.form.submit(); this.disabled=true; this.innerText='Processing Update';">Update and refresh</button>
+            </form>
+        </div>
+    </div>
+
+    <%
+        const paginationModel = {
+            disableNextAndPrevious: true,
+            currentPage: locals.page,
+            numberOfPages: locals.numberOfPages,
+            totalNumberOfResults: locals.totalNumberOfResults,
+            numberOfResultsOnPage: locals.audits.length,
+            data: [],
+        };
+    %>
+
+    <%- include('../../sharedViews/paginationNew', paginationModel); %>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <table class="govuk-table">
+                <thead class="govuk-table__head">
+                    <tr class="govuk-table__row">
+                        <th scope="col" class="govuk-table__header">Date</th>
+                        <th scope="col" class="govuk-table__header">Event</th>
+                        <th scope="col" class="govuk-table__header">Service</th>
+                        <th scope="col" class="govuk-table__header">Organisation</th>
+                        <th scope="col" class="govuk-table__header">Result</th>
+                        <th scope="col" class="govuk-table__header">User</th>
+                    </tr>
+                </thead>
+                <tbody class="govuk-table__body">
+                <% for(let a = 0;a < locals.audits.length; a++) { %>
+                <% const audit = locals.audits[a]; %>
+                    <tr class="govuk-table__row">
+                        <td><%= audit.formattedTimestamp %></td>
+                        <td class="govuk-table__cell"><%= audit.event.description %></td>
+                        <td class="govuk-table__cell"><%= audit.service ? audit.service.name : '' %></td>
+                        <td class="govuk-table__cell"><%= audit.organisation ? audit.organisation.name: '' %></td>
+                        <td class="govuk-table__cell"><%= audit.result ? 'Success' : 'Failure' %></td>
+                        <td class="govuk-table__cell"><%= audit.user ? audit.user.name : '' %></td>
+                    </tr>
+                <% } %>
+                </tbody>
+            </table>
+            <%- include('../../sharedViews/pagination', paginationModel); %>
+        </div>
     </div>
 </div>
 
-<%
-	const paginationModel = {
-		currentPage: locals.page,
-		numberOfPages: locals.numberOfPages,
-		totalNumberOfResults: locals.totalNumberOfResults,
-		numberOfResultsOnPage: locals.audits.length,
-		data: [],
-	};
-%>
-
-<%- include('../../sharedViews/pagination', paginationModel); %>
-<div class="row">
-    <div class="col-12">
-        <table class="data">
-            <thead>
-                <tr>
-                    <th scope="col" class="cwp-20">Date</th>
-                    <th scope="col" class="cwp-30">Event</th>
-                    <th scope="col" class="cwp-15">Service</th>
-                    <th scope="col" class="cwp-10">Organisation</th>
-                    <th scope="col" class="cwp-10">Result</th>
-                    <th scope="col" class="cwp-15">User</th>
-                </tr>
-            </thead>
-            <tbody>
-            <% for(let a = 0;a < locals.audits.length; a++) { %>
-            <% const audit = locals.audits[a]; %>
-                <tr>
-                    <td><%= audit.formattedTimestamp %></td>
-                    <td class="breakable"><%= audit.event.description %></td>
-                    <td class="breakable"><%= audit.service ? audit.service.name : '' %></td>
-                    <td class="breakable"><%= audit.organisation ? audit.organisation.name: '' %></td>
-                    <td class="breakable"><%= audit.result ? 'Success' : 'Failure' %></td>
-                    <td class="breakable"><%= audit.user ? audit.user.name : '' %></td>
-                </tr>
-            <% } %>
-            </tbody>
-        </table>
-        <%- include('../../sharedViews/pagination', paginationModel); %>
-    </div>

--- a/src/app/users/views/audit.ejs
+++ b/src/app/users/views/audit.ejs
@@ -1,18 +1,6 @@
 <div class="govuk-width-container">
     <%- include('summaryPartial', {area: 'audit', user: locals.user}); %>
 
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <form method="POST">
-                <input type="hidden" name="_csrf" value="<%= csrfToken %>"/>
-                <button class="govuk-button govuk-!-margin-bottom-3" type="submit" 
-                        onclick="this.form.submit(); this.disabled=true; this.innerText='Processing Update';">
-                    Update and refresh
-                </button>
-            </form>
-        </div>
-    </div>
-
     <%
         const paginationModel = {
             disableNextAndPrevious: true,
@@ -24,12 +12,22 @@
         };
     %>
 
-    <%- include('../../sharedViews/paginationNew', paginationModel); %>
-
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
-            <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="audit">
+            <div class="govuk-tabs__panel" id="audit">
                 <table class="govuk-table">
+                    <div class="govuk-grid-row">
+                        <div class="govuk-grid-column-full">
+                            <form method="POST">
+                                <input type="hidden" name="_csrf" value="<%= csrfToken %>"/>
+                                <button class="govuk-button" type="submit" 
+                                        onclick="this.form.submit(); this.disabled=true; this.innerText='Processing Update';">
+                                    Update and refresh
+                                </button>
+                            </form>
+                        </div>
+                    </div>
+                    <%- include('../../sharedViews/paginationNew', paginationModel); %>
                     <thead class="govuk-table__head">
                         <tr class="govuk-table__row">
                             <th scope="col" class="govuk-table__header">Date</th>

--- a/src/app/users/views/organisations.ejs
+++ b/src/app/users/views/organisations.ejs
@@ -1,107 +1,108 @@
 <div class="govuk-width-container">
     <%- include('summaryPartial', {area: 'organisations', user: locals.user, isInvitation: locals.isInvitation}); %>
-    <% if (locals.organisations.length > 0) {%>
-    <table class="govuk-table">
-        <thead class="govuk-grid-row">
-            <tr class="govuk-table__row">
-                <th scope="col" class="govuk-table__header govuk-!-font-size-16 govuk-!-padding-top-0">Organisation</th>
-                <% if (!locals.isInvitation ) {%>
-                <th scope="col" class="govuk-table__header govuk-!-font-size-16 govuk-!-padding-top-0">Legacy ID/Name</th>
-                <% }%>
-                <th scope="col" class="govuk-table__header govuk-!-font-size-16 govuk-!-padding-top-0">Permission level</th>
-                <th scope="col" class="govuk-table__header"></th>
-                <th scope="col" class="govuk-table__header"></th>
-            </tr>
-        </thead>
-        <tbody>
-            <% for (let o = 0; o < locals.organisations.length; o++) { %>
-            <% const org = locals.organisations[o];%>
-                <% if (org.requestDate) { %>
-                <tr class="govuk-table__row pending">
-                <% } else { %>
-                <tr class="govuk-table__row">
-                <% }%>
-                    <td class="govuk-table__cell"> <%=org.name%> <br>
-                        <article class="organisation-services govuk-!-margin-bottom-0">
-                            <section class="organisation">
-                                <div class="user">
-                                    <a href="" class="info-link">Information and approvers <span class="vh">for <%=org.name%></span> </a>
-                                </div>
-                                <div class="meta js-hidden">
-                                    <div class="approvers">
-                                        <dl class="inline condensed small-dt">
-                                            <% if (org.LegalName) { %>
-                                            <dt class="govuk-summary-list__key"><abbr title="Registered legal name">Legal name: </abbr></dt>
-                                            <dd class="govuk-summary-list__value"><%=org.LegalName%></dd>
-                                            <% } %>
-                                            <% if (org.urn) { %>
-                                                <dt class="govuk-summary-list__key"><abbr title="Unique Reference Number">URN: </abbr></dt>
-                                                <% if (org.status && org.status.id === 4) { %>
-                                                    <dd class="govuk-summary-list__value"><%=org.urn%></dd>
-                                                <%}else {%>
-                                                    <dd class="govuk-summary-list__value"><a href="https://get-information-schools.service.gov.uk/Establishments/Establishment/Details/<%=org.urn%>" target="_blank"><%=org.urn%></a></dd>
-                                                    <%}%>
-                                            <%}else if(org.uid) {%>
-                                                <dt class="govuk-summary-list__key"><abbr title="Unique Identifier">UID: </abbr></dt>
-                                                <% if (org.status && org.status.id === 2) { %>
-                                                    <dd class="govuk-summary-list__value"><%=org.uid%></dd>
-                                                <%}else {%>
-                                                    <dd class="govuk-summary-list__value"><a href="https://get-information-schools.service.gov.uk/Groups/Group/Details/<%=org.uid%>" target="_blank"><%=org.uid%></a></dd>
-                                                <%}%>
-                                            <%}%>
-                                            <% if (org.ukprn) { %>
-                                            <dt class="govuk-summary-list__key"><abbr title="UK Provider Reference Number">UKPRN: </abbr></dt>
-                                            <dd class="govuk-summary-list__value"><%=org.ukprn%></dd>
-                                            <% } %>
-                                            <% if (org.upin) { %>
-                                            <dt class="govuk-summary-list__key"><abbr title="The Independent Specialist Provider's Unique Provider Identification Number">UPIN: </abbr></dt>
-                                            <dd class="govuk-summary-list__value"><%=org.upin%></dd>
-                                            <% } %>
-                                            <% if (org.status && org.status.name) { %>
-                                            <dt class="govuk-summary-list__key"><abbr title="Status">Status: </abbr></dt>
-                                            <dd class="govuk-summary-list__value"><%=org.status.name%></dd>
-                                            <% } %>
-                                            <% if (org.approvers && org.approvers.length > 0) { %>
-                                                <dt class="govuk-summary-list__key">Approvers:</dt>
-                                                <dd class="govuk-summary-list__value">
-                                                    <ul>
-                                                        <% for (let a = 0; a < org.approvers.length; a++) { %>
-                                                        <li><%=org.approvers[a].name%> <a href="mailto:<%=org.approvers[a].email%>"><%=org.approvers[a].email%></a></li>
+
+    <% if (locals.organisations.length > 0) { %>
+        <div class="govuk-tabs__panel" id="organisations">
+            <table class="govuk-table">
+                <thead class="govuk-grid-row">
+                    <tr class="govuk-table__row">
+                        <th scope="col" class="govuk-table__header govuk-!-font-size-16 govuk-!-padding-top-0">Organisation</th>
+                        <% if (!locals.isInvitation) { %>
+                        <th scope="col" class="govuk-table__header govuk-!-font-size-16 govuk-!-padding-top-0">Legacy ID/Name</th>
+                        <% } %>
+                        <th scope="col" class="govuk-table__header govuk-!-font-size-16 govuk-!-padding-top-0">Permission level</th>
+                        <th scope="col" class="govuk-table__header"></th>
+                        <th scope="col" class="govuk-table__header"></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <% for (let o = 0; o < locals.organisations.length; o++) { %>
+                    <% const org = locals.organisations[o]; %>
+                        <tr class="govuk-table__row <%= org.requestDate ? 'pending' : '' %>">
+                            <td class="govuk-table__cell"> 
+                                <%= org.name %> 
+                                <br>
+                                <article class="organisation-services govuk-!-margin-bottom-0">
+                                    <section class="organisation">
+                                        <div class="user">
+                                            <a href="" class="info-link">Information and approvers <span class="vh">for <%= org.name %></span> </a>
+                                        </div>
+                                        <div class="meta js-hidden">
+                                            <div class="approvers">
+                                                <dl class="inline condensed small-dt">
+                                                    <% if (org.LegalName) { %>
+                                                    <dt class="govuk-summary-list__key"><abbr title="Registered legal name">Legal name: </abbr></dt>
+                                                    <dd class="govuk-summary-list__value"><%= org.LegalName %></dd>
+                                                    <% } %>
+                                                    <% if (org.urn) { %>
+                                                        <dt class="govuk-summary-list__key"><abbr title="Unique Reference Number">URN: </abbr></dt>
+                                                        <% if (org.status && org.status.id === 4) { %>
+                                                            <dd class="govuk-summary-list__value"><%= org.urn %></dd>
+                                                        <% } else { %>
+                                                            <dd class="govuk-summary-list__value"><a href="https://get-information-schools.service.gov.uk/Establishments/Establishment/Details/<%= org.urn %>" target="_blank"><%= org.urn %></a></dd>
                                                         <% } %>
-                                                    </ul>
-                                                </dd>
-                                            <% } %>
-                                        </dl>
-                                    </div>
-                                </div>
-                            </section>
-                        </article>
-                    </td>
-                    <% if (!locals.isInvitation ) {%>
-                    <td class="govuk-table__cell"><%= org.numericIdentifier && org.textIdentifier ? `${org.numericIdentifier} / ${org.textIdentifier}` : '' -%></td>
-                    <% }%>
-                    <% if (org.role) { %>
-                    <td class="govuk-table__cell"><%=org.role.name%></td>
-                    <% } else { %>
-                        <td class="govuk-table__cell">
-                            Requested <br> <%= org.formattedRequestDate %>
-                        </td>
+                                                    <% } else if (org.uid) { %>
+                                                        <dt class="govuk-summary-list__key"><abbr title="Unique Identifier">UID: </abbr></dt>
+                                                        <% if (org.status && org.status.id === 2) { %>
+                                                            <dd class="govuk-summary-list__value"><%= org.uid %></dd>
+                                                        <% } else { %>
+                                                            <dd class="govuk-summary-list__value"><a href="https://get-information-schools.service.gov.uk/Groups/Group/Details/<%= org.uid %>" target="_blank"><%= org.uid %></a></dd>
+                                                        <% } %>
+                                                    <% } %>
+                                                    <% if (org.ukprn) { %>
+                                                    <dt class="govuk-summary-list__key"><abbr title="UK Provider Reference Number">UKPRN: </abbr></dt>
+                                                    <dd class="govuk-summary-list__value"><%= org.ukprn %></dd>
+                                                    <% } %>
+                                                    <% if (org.upin) { %>
+                                                    <dt class="govuk-summary-list__key"><abbr title="The Independent Specialist Provider's Unique Provider Identification Number">UPIN: </abbr></dt>
+                                                    <dd class="govuk-summary-list__value"><%= org.upin %></dd>
+                                                    <% } %>
+                                                    <% if (org.status && org.status.name) { %>
+                                                    <dt class="govuk-summary-list__key"><abbr title="Status">Status: </abbr></dt>
+                                                    <dd class="govuk-summary-list__value"><%= org.status.name %></dd>
+                                                    <% } %>
+                                                    <% if (org.approvers && org.approvers.length > 0) { %>
+                                                        <dt class="govuk-summary-list__key">Approvers:</dt>
+                                                        <dd class="govuk-summary-list__value">
+                                                            <ul>
+                                                                <% for (let a = 0; a < org.approvers.length; a++) { %>
+                                                                <li><%= org.approvers[a].name %> <a href="mailto:<%= org.approvers[a].email %>"><%= org.approvers[a].email %></a></li>
+                                                                <% } %>
+                                                            </ul>
+                                                        </dd>
+                                                    <% } %>
+                                                </dl>
+                                            </div>
+                                        </div>
+                                    </section>
+                                </article>
+                            </td>
+                            <% if (!locals.isInvitation) { %>
+                            <td class="govuk-table__cell"><%= org.numericIdentifier && org.textIdentifier ? `${org.numericIdentifier} / ${org.textIdentifier}` : '' %></td>
+                            <% } %>
+                            <% if (org.role) { %>
+                            <td class="govuk-table__cell"><%= org.role.name %></td>
+                            <% } else { %>
+                                <td class="govuk-table__cell">
+                                    Requested <br> <%= org.formattedRequestDate %>
+                                </td>
+                            <% } %>
+                            <% if (org.requestDate) { %>
+                            <td class="govuk-table__cell"></td>
+                            <td class="govuk-table__cell"><a href="/access-requests/<%= org.requestId %>/organisation/review">Review request</a> </td>
+                            <% } else { %>
+                                <td class="govuk-table__cell">
+                                    <a class="govuk-link" href="/users/<%= user.id %>/organisations/<%= org.id %>/edit-permission">Edit <span class="visually-hidden"> user</span> permission level</a>
+                                </td>
+                                <td class="govuk-table__cell">
+                                    <a class="govuk-link" href="/users/<%= user.id %>/organisations/<%= org.id %>/remove-organisation">Remove <span class="visually-hidden"> user</span> organisation</a>
+                                </td>
+                            <% } %>
+                        </tr>
                     <% } %>
-                    <% if (org.requestDate) { %>
-                    <td class="govuk-table__cell"></td>
-                    <td class="govuk-table__cell"><a href="/access-requests/<%=org.requestId%>/organisation/review">Review request</a> </td>
-                    <% } else { %>
-                        <td class="govuk-table__cell">
-                            <a class="govuk-link" href="/users/<%=user.id%>/organisations/<%=org.id%>/edit-permission">Edit <span class="visually-hidden"> user</span> permission level</a>
-                        </td>
-                        <td class="govuk-table__cell">
-                            <a class="govuk-link" href="/users/<%=user.id%>/organisations/<%=org.id%>/remove-organisation">Remove <span class="visually-hidden"> user</span> organisation</a>
-                        </td>
-                    <% } %>
-                </tr>
-            <%}%>
-        </tbody>
-    </table>
+                </tbody>
+            </table>
+        </div>
     <% } else { %>
     <div class="empty-state">
         <p><%= user.name %> is not associated with any organisations</p>

--- a/src/app/users/views/organisations.ejs
+++ b/src/app/users/views/organisations.ejs
@@ -1,115 +1,110 @@
-<a href="/users" class="link-back">Back</a>
-<%- include('summaryPartial', {area: 'organisations', user: locals.user, isInvitation: locals.isInvitation}); %>
-
-<% if (locals.organisations.length > 0) {%>
-<table class="data no-borders">
-    <thead>
-        <tr>
-            <th scope="col" class="cwp-20">Organisation</th>
-            <% if (!locals.isInvitation ) {%>
-            <th scope="col" class="cwp-15">Legacy ID/Name</th>
-            <% }%>
-            <th scope="col" class="cwp-15">Permission level</th>
-            <th scope="col" class="cwp-15"></th>
-            <th scope="col" class="cwp-15"></th>
-        </tr>
-    </thead>
-    <tbody>
-        <% for (let o = 0; o < locals.organisations.length; o++) { %>
-        <% const org = locals.organisations[o];%>
-            <% if (org.requestDate) { %>
-            <tr class="pending">
-            <% } else { %>
-            <tr>
-            <% }%>
-                <td> <%=org.name%> <br>
-                    <article class="organisation-services" style="margin-bottom: 0">
-                        <section class="organisation">
-                            <div class="user">
-                                <a href="" class="info-link">Information and approvers <span class="vh">for <%=org.name%></span> </a>
-                            </div>
-                            <div class="meta js-hidden">
-                                <div class="approvers">
-                                    <dl class="inline condensed small-dt">
-                                        <% if (org.LegalName) { %>
-                                        <dt><abbr title="Registered legal name">Legal name: </abbr></dt>
-                                        <dd><%=org.LegalName%></dd>
-                                        <% } %>
-
-                                        <% if (org.urn) { %>
-                                            <dt><abbr title="Unique Reference Number">URN: </abbr></dt>
-                                            <% if (org.status && org.status.id === 4) { %>
-                                                <dd><%=org.urn%></dd>
-                                            <%}else {%>
-                                                <dd><a href="https://get-information-schools.service.gov.uk/Establishments/Establishment/Details/<%=org.urn%>" target="_blank"><%=org.urn%></a></dd>
-                                                <%}%>
-                                        <%}else if(org.uid) {%>
-                                            <dt><abbr title="Unique Identifier">UID: </abbr></dt>
-                                            <% if (org.status && org.status.id === 2) { %>
-                                                <dd><%=org.uid%></dd>
-                                            <%}else {%>
-                                                <dd><a href="https://get-information-schools.service.gov.uk/Groups/Group/Details/<%=org.uid%>" target="_blank"><%=org.uid%></a></dd>
-                                            <%}%> 
-                                        <%}%>
-                                        
-                                        <% if (org.ukprn) { %>
-                                        <dt><abbr title="UK Provider Reference Number">UKPRN: </abbr></dt>
-                                        <dd><%=org.ukprn%></dd>
-                                        <% } %>
-
-                                        <% if (org.upin) { %>
-                                        <dt><abbr title="The Independent Specialist Provider's Unique Provider Identification Number">UPIN: </abbr></dt>
-                                        <dd><%=org.upin%></dd>
-                                        <% } %>
-
-                                        <% if (org.status && org.status.name) { %>
-                                        <dt><abbr title="Status">Status: </abbr></dt>
-                                        <dd><%=org.status.name%></dd>
-                                        <% } %>
-
-                                        <% if (org.approvers && org.approvers.length > 0) { %>
-                                            <dt>Approvers:</dt>
-                                            <dd>
-                                                <ul>
-                                                    <% for (let a = 0; a < org.approvers.length; a++) { %>
-                                                    <li><%=org.approvers[a].name%> <a href="mailto:<%=org.approvers[a].email%>"><%=org.approvers[a].email%></a></li>
-                                                    <% } %>
-                                                </ul>
-                                            </dd>
-                                        <% } %>
-                                    </dl>
-                                </div>
-                            </div>
-                        </section>
-                    </article>
-                </td>
+<div class="govuk-width-container">
+    <%- include('summaryPartial', {area: 'organisations', user: locals.user, isInvitation: locals.isInvitation}); %>
+    <% if (locals.organisations.length > 0) {%>
+    <table class="govuk-table">
+        <thead class="govuk-grid-row">
+            <tr class="govuk-table__row">
+                <th scope="col" class="govuk-table__header govuk-!-font-size-16 govuk-!-padding-top-0">Organisation</th>
                 <% if (!locals.isInvitation ) {%>
-                <td><%= org.numericIdentifier && org.textIdentifier ? `${org.numericIdentifier} / ${org.textIdentifier}` : '' -%></td>
+                <th scope="col" class="govuk-table__header govuk-!-font-size-16 govuk-!-padding-top-0">Legacy ID/Name</th>
                 <% }%>
-                <% if (org.role) { %>
-                <td><%=org.role.name%></td>
-                <% } else { %>
-                    <td>
-                        Requested <br> <%= org.formattedRequestDate %>
-                    </td>
-                <% } %>
-                <% if (org.requestDate) { %>
-                <td></td>
-                <td><a href="/access-requests/<%=org.requestId%>/organisation/review">Review request</a> </td>
-                <% } else { %>
-                    <td>
-                        <a class="govuk-link" href="/users/<%=user.id%>/organisations/<%=org.id%>/edit-permission">Edit <span class="visually-hidden"> user</span> permission level</a> 
-                    </td>
-                    <td>
-                        <a href="/users/<%=user.id%>/organisations/<%=org.id%>/remove-organisation">Remove <span class="visually-hidden"> user</span> organisation</a>
-                    </td>
-                <% } %>
+                <th scope="col" class="govuk-table__header govuk-!-font-size-16 govuk-!-padding-top-0">Permission level</th>
+                <th scope="col" class="govuk-table__header"></th>
+                <th scope="col" class="govuk-table__header"></th>
             </tr>
-        <%}%>
-    </tbody>
-</table>
-<% } else { %>
-<div class="empty-state">
-    <p><%= user.name %> is not associated with any organisations</p>
+        </thead>
+        <tbody>
+            <% for (let o = 0; o < locals.organisations.length; o++) { %>
+            <% const org = locals.organisations[o];%>
+                <% if (org.requestDate) { %>
+                <tr class="govuk-table__row pending">
+                <% } else { %>
+                <tr class="govuk-table__row">
+                <% }%>
+                    <td class="govuk-table__cell"> <%=org.name%> <br>
+                        <article class="organisation-services govuk-!-margin-bottom-0">
+                            <section class="organisation">
+                                <div class="user">
+                                    <a href="" class="info-link">Information and approvers <span class="vh">for <%=org.name%></span> </a>
+                                </div>
+                                <div class="meta js-hidden">
+                                    <div class="approvers">
+                                        <dl class="inline condensed small-dt">
+                                            <% if (org.LegalName) { %>
+                                            <dt class="govuk-summary-list__key"><abbr title="Registered legal name">Legal name: </abbr></dt>
+                                            <dd class="govuk-summary-list__value"><%=org.LegalName%></dd>
+                                            <% } %>
+                                            <% if (org.urn) { %>
+                                                <dt class="govuk-summary-list__key"><abbr title="Unique Reference Number">URN: </abbr></dt>
+                                                <% if (org.status && org.status.id === 4) { %>
+                                                    <dd class="govuk-summary-list__value"><%=org.urn%></dd>
+                                                <%}else {%>
+                                                    <dd class="govuk-summary-list__value"><a href="https://get-information-schools.service.gov.uk/Establishments/Establishment/Details/<%=org.urn%>" target="_blank"><%=org.urn%></a></dd>
+                                                    <%}%>
+                                            <%}else if(org.uid) {%>
+                                                <dt class="govuk-summary-list__key"><abbr title="Unique Identifier">UID: </abbr></dt>
+                                                <% if (org.status && org.status.id === 2) { %>
+                                                    <dd class="govuk-summary-list__value"><%=org.uid%></dd>
+                                                <%}else {%>
+                                                    <dd class="govuk-summary-list__value"><a href="https://get-information-schools.service.gov.uk/Groups/Group/Details/<%=org.uid%>" target="_blank"><%=org.uid%></a></dd>
+                                                <%}%>
+                                            <%}%>
+                                            <% if (org.ukprn) { %>
+                                            <dt class="govuk-summary-list__key"><abbr title="UK Provider Reference Number">UKPRN: </abbr></dt>
+                                            <dd class="govuk-summary-list__value"><%=org.ukprn%></dd>
+                                            <% } %>
+                                            <% if (org.upin) { %>
+                                            <dt class="govuk-summary-list__key"><abbr title="The Independent Specialist Provider's Unique Provider Identification Number">UPIN: </abbr></dt>
+                                            <dd class="govuk-summary-list__value"><%=org.upin%></dd>
+                                            <% } %>
+                                            <% if (org.status && org.status.name) { %>
+                                            <dt class="govuk-summary-list__key"><abbr title="Status">Status: </abbr></dt>
+                                            <dd class="govuk-summary-list__value"><%=org.status.name%></dd>
+                                            <% } %>
+                                            <% if (org.approvers && org.approvers.length > 0) { %>
+                                                <dt class="govuk-summary-list__key">Approvers:</dt>
+                                                <dd class="govuk-summary-list__value">
+                                                    <ul>
+                                                        <% for (let a = 0; a < org.approvers.length; a++) { %>
+                                                        <li><%=org.approvers[a].name%> <a href="mailto:<%=org.approvers[a].email%>"><%=org.approvers[a].email%></a></li>
+                                                        <% } %>
+                                                    </ul>
+                                                </dd>
+                                            <% } %>
+                                        </dl>
+                                    </div>
+                                </div>
+                            </section>
+                        </article>
+                    </td>
+                    <% if (!locals.isInvitation ) {%>
+                    <td class="govuk-table__cell"><%= org.numericIdentifier && org.textIdentifier ? `${org.numericIdentifier} / ${org.textIdentifier}` : '' -%></td>
+                    <% }%>
+                    <% if (org.role) { %>
+                    <td class="govuk-table__cell"><%=org.role.name%></td>
+                    <% } else { %>
+                        <td class="govuk-table__cell">
+                            Requested <br> <%= org.formattedRequestDate %>
+                        </td>
+                    <% } %>
+                    <% if (org.requestDate) { %>
+                    <td class="govuk-table__cell"></td>
+                    <td class="govuk-table__cell"><a href="/access-requests/<%=org.requestId%>/organisation/review">Review request</a> </td>
+                    <% } else { %>
+                        <td class="govuk-table__cell">
+                            <a class="govuk-link" href="/users/<%=user.id%>/organisations/<%=org.id%>/edit-permission">Edit <span class="visually-hidden"> user</span> permission level</a>
+                        </td>
+                        <td class="govuk-table__cell">
+                            <a class="govuk-link" href="/users/<%=user.id%>/organisations/<%=org.id%>/remove-organisation">Remove <span class="visually-hidden"> user</span> organisation</a>
+                        </td>
+                    <% } %>
+                </tr>
+            <%}%>
+        </tbody>
+    </table>
+    <% } else { %>
+    <div class="empty-state">
+        <p><%= user.name %> is not associated with any organisations</p>
+    </div>
+    <% } %>
 </div>
-<% } %>

--- a/src/app/users/views/organisations.ejs
+++ b/src/app/users/views/organisations.ejs
@@ -105,7 +105,7 @@
         </div>
     <% } else { %>
     <div class="empty-state">
-        <p><%= user.name %> is not associated with any organisations</p>
+        <p class="govuk-body"><%= user.name %> is not associated with any organisations</p>
     </div>
     <% } %>
 </div>

--- a/src/app/users/views/search.ejs
+++ b/src/app/users/views/search.ejs
@@ -246,7 +246,7 @@ if (services && services.length > 0) {
             <% } %>
             <% for (let i = 0; i < locals.users.length; i++) { %>
             <tr class="govuk-table__row govuk-body">
-                <td class="govuk-table__cell govuk-body-s"><a href="/users/<%= users[i].id %>/organisations<%= baseSortUri %>"><%= users[i].name %></a></td>
+                <td class="govuk-table__cell govuk-body-s"><a class="govuk-link" href="/users/<%= users[i].id %>/organisations<%= baseSortUri %>"><%= users[i].name %></a></td>
                 <td class="govuk-table__cell govuk-body-s"><span><%= users[i].email %></span></td>
                 <td class="govuk-table__cell govuk-body-s">
                     <% if(users[i].organisation) { %>

--- a/src/app/users/views/services.ejs
+++ b/src/app/users/views/services.ejs
@@ -1,4 +1,5 @@
-<%- include('summaryPartial', {area: 'services', user: locals.user, isInvitation: locals.isInvitation}); %>
+<div class="govuk-width-container">
+    <%- include('summaryPartial', {area: 'services', user: locals.user, isInvitation: locals.isInvitation}); %>
 
 <% let hasServices = false %>
 
@@ -10,7 +11,7 @@
     <article class="organisation-services">
         <section class="organisation">
             <header>
-                <h3 class="heading-small spacer-heading"><%=org.name%>
+                <h3 class="govuk-heading-s spacer-heading"><%=org.name%>
                     <%= org.status ? `(${org.status.name})` : '' %>
                     <% if (org.naturalIdentifiers && org.naturalIdentifiers.length !== 0) { %>
                         (<%= org.naturalIdentifiers.join(', ') %>)
@@ -20,24 +21,24 @@
         </section>
         <section class="services">
 
-            <table class="data no-borders">
-                <thead>
-                <tr>
-                    <th scope="col" class="cwp-30">Service</th>
-                    <th scope="col" class="cwp-25">User type</th>
-                    <th scope="col" class="cwp-15">Activated</th>
+            <table class="govuk-table">
+                <thead class="govuk-grid-row">
+                <tr class="govuk-table__row">
+                    <th scope="col" class="govuk-table__header govuk-!-width-one-half">Service</th>
+                    <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">User type</th>
+                    <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Activated</th>
                 </tr>
                 </thead>
                 <tbody>
                 <%for(let s = 0; s < org.services.length; s++) {%>
                 <%const service = org.services[s];%>
-                <tr>
-                    <td><a href="organisations/<%=org.id%>/services/<%=service.id%>"><%=service.name%></a></td>
-                    <td><%=service.userType.name%></td>
+                <tr class="govuk-table__row">
+                    <td class="govuk-table__cell"><a class="govuk-link" href="organisations/<%=org.id%>/services/<%=service.id%>"><%=service.name%></a></td>
+                    <td class="govuk-table__cell"><%=service.userType.name%></td>
                     <%if(service.formattedRequestDate) {%>
-                    <td><%= service.formattedRequestDate %></td>
+                    <td class="govuk-table__cell"><%= service.formattedRequestDate %></td>
                     <%} else {%>
-                    <td>Pending</td>
+                    <td class="govuk-table__cell">Pending</td>
                     <%}%>
                 </tr>
                 <%}%>
@@ -50,6 +51,9 @@
 
 <% if (!hasServices) { %>
 <div class="empty-state">
-    <p><%= user.name %> is not associated with any services</p>
+    <p class="govuk-body"><%= user.name %> is not associated with any services</p>
 </div>
 <% } %>
+
+
+</div>

--- a/src/app/users/views/services.ejs
+++ b/src/app/users/views/services.ejs
@@ -7,48 +7,44 @@
         <% const org = locals.organisations[o]; %>
         <% if (org.services.length > 0) { %>
             <% hasServices = true %>
-            <article class="organisation-services">
-                <section class="organisation">
-                    <header>
-                        <h3 class="govuk-heading-s govuk-!-margin-bottom-2">
-                            <%= org.name %>
-                            <%= org.status ? `(${org.status.name})` : '' %>
-                            <% if (org.naturalIdentifiers && org.naturalIdentifiers.length !== 0) { %>
-                                (<%= org.naturalIdentifiers.join(', ') %>)
-                            <% } %>
-                        </h3>
-                    </header>
-                </section>
-                <section class="services">
-                    <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="services">
-                        <table class="govuk-table">
-                            <thead class="govuk-grid-row">
-                                <tr class="govuk-table__row">
-                                    <th scope="col" class="govuk-table__header govuk-!-width-one-half">Service</th>
-                                    <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">User type</th>
-                                    <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Activated</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                <% for (let s = 0; s < org.services.length; s++) { %>
-                                    <% const service = org.services[s]; %>
-                                    <tr class="govuk-table__row">
-                                        <td class="govuk-table__cell">
-                                            <a class="govuk-link" href="organisations/<%= org.id %>/services/<%= service.id %>"><%= service.name %></a>
-                                        </td>
-                                        <td class="govuk-table__cell"><%= service.userType.name %></td>
-                                        <% if (service.formattedRequestDate) { %>
-                                            <td class="govuk-table__cell"><%= service.formattedRequestDate %></td>
-                                        <% } else { %>
-                                            <td class="govuk-table__cell">Pending</td>
-                                        <% } %>
-                                    </tr>
+            <div class="govuk-grid-column-full govuk-!-padding-top-2">
+                <header>
+                    <h3 class="govuk-heading-s">
+                        <%= org.name %>
+                        <%= org.status ? `(${org.status.name})` : '' %>
+                        <% if (org.naturalIdentifiers && org.naturalIdentifiers.length !== 0) { %>
+                            (<%= org.naturalIdentifiers.join(', ') %>)
+                        <% } %>
+                    </h3>
+                </header>
+            </div>
+            <div class="govuk-tabs__panel" id="services">
+                <table class="govuk-table">
+                    <thead class="govuk-grid-row">
+                        <tr class="govuk-table__row">
+                            <th scope="col" class="govuk-table__header govuk-!-width-one-half">Service</th>
+                            <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">User type</th>
+                            <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Activated</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <% for (let s = 0; s < org.services.length; s++) { %>
+                            <% const service = org.services[s]; %>
+                            <tr class="govuk-table__row">
+                                <td class="govuk-table__cell">
+                                    <a class="govuk-link" href="organisations/<%= org.id %>/services/<%= service.id %>"><%= service.name %></a>
+                                </td>
+                                <td class="govuk-table__cell"><%= service.userType.name %></td>
+                                <% if (service.formattedRequestDate) { %>
+                                    <td class="govuk-table__cell"><%= service.formattedRequestDate %></td>
+                                <% } else { %>
+                                    <td class="govuk-table__cell">Pending</td>
                                 <% } %>
-                            </tbody>
-                        </table>
-                    </div>
-                </section>
-            </article>
+                            </tr>
+                        <% } %>
+                    </tbody>
+                </table>
+            </div>
         <% } %>
     <% } %>
 

--- a/src/app/users/views/services.ejs
+++ b/src/app/users/views/services.ejs
@@ -1,59 +1,60 @@
 <div class="govuk-width-container">
     <%- include('summaryPartial', {area: 'services', user: locals.user, isInvitation: locals.isInvitation}); %>
 
-<% let hasServices = false %>
+    <% let hasServices = false %>
 
-<% for (let o = 0; o < locals.organisations.length; o++) { %>
+    <% for (let o = 0; o < locals.organisations.length; o++) { %>
+        <% const org = locals.organisations[o]; %>
+        <% if (org.services.length > 0) { %>
+            <% hasServices = true %>
+            <article class="organisation-services">
+                <section class="organisation">
+                    <header>
+                        <h3 class="govuk-heading-s govuk-!-margin-bottom-2">
+                            <%= org.name %>
+                            <%= org.status ? `(${org.status.name})` : '' %>
+                            <% if (org.naturalIdentifiers && org.naturalIdentifiers.length !== 0) { %>
+                                (<%= org.naturalIdentifiers.join(', ') %>)
+                            <% } %>
+                        </h3>
+                    </header>
+                </section>
+                <section class="services">
+                    <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="services">
+                        <table class="govuk-table">
+                            <thead class="govuk-grid-row">
+                                <tr class="govuk-table__row">
+                                    <th scope="col" class="govuk-table__header govuk-!-width-one-half">Service</th>
+                                    <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">User type</th>
+                                    <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Activated</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <% for (let s = 0; s < org.services.length; s++) { %>
+                                    <% const service = org.services[s]; %>
+                                    <tr class="govuk-table__row">
+                                        <td class="govuk-table__cell">
+                                            <a class="govuk-link" href="organisations/<%= org.id %>/services/<%= service.id %>"><%= service.name %></a>
+                                        </td>
+                                        <td class="govuk-table__cell"><%= service.userType.name %></td>
+                                        <% if (service.formattedRequestDate) { %>
+                                            <td class="govuk-table__cell"><%= service.formattedRequestDate %></td>
+                                        <% } else { %>
+                                            <td class="govuk-table__cell">Pending</td>
+                                        <% } %>
+                                    </tr>
+                                <% } %>
+                            </tbody>
+                        </table>
+                    </div>
+                </section>
+            </article>
+        <% } %>
+    <% } %>
 
-<% const org = locals.organisations[o];%>
-    <% if (org.services.length > 0) {%>
-    <% hasServices = true %>
-    <article class="organisation-services">
-        <section class="organisation">
-            <header>
-                <h3 class="govuk-heading-s spacer-heading"><%=org.name%>
-                    <%= org.status ? `(${org.status.name})` : '' %>
-                    <% if (org.naturalIdentifiers && org.naturalIdentifiers.length !== 0) { %>
-                        (<%= org.naturalIdentifiers.join(', ') %>)
-                    <% } %>
-                </h3>
-            </header>
-        </section>
-        <section class="services">
-
-            <table class="govuk-table">
-                <thead class="govuk-grid-row">
-                <tr class="govuk-table__row">
-                    <th scope="col" class="govuk-table__header govuk-!-width-one-half">Service</th>
-                    <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">User type</th>
-                    <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Activated</th>
-                </tr>
-                </thead>
-                <tbody>
-                <%for(let s = 0; s < org.services.length; s++) {%>
-                <%const service = org.services[s];%>
-                <tr class="govuk-table__row">
-                    <td class="govuk-table__cell"><a class="govuk-link" href="organisations/<%=org.id%>/services/<%=service.id%>"><%=service.name%></a></td>
-                    <td class="govuk-table__cell"><%=service.userType.name%></td>
-                    <%if(service.formattedRequestDate) {%>
-                    <td class="govuk-table__cell"><%= service.formattedRequestDate %></td>
-                    <%} else {%>
-                    <td class="govuk-table__cell">Pending</td>
-                    <%}%>
-                </tr>
-                <%}%>
-                </tbody>
-            </table>
-        </section>
-    </article>
-    <%}%>
-<%}%>
-
-<% if (!hasServices) { %>
-<div class="empty-state">
-    <p class="govuk-body"><%= user.name %> is not associated with any services</p>
-</div>
-<% } %>
-
-
+    <% if (!hasServices) { %>
+        <div class="empty-state">
+            <p class="govuk-body"><%= user.name %> is not associated with any services</p>
+        </div>
+    <% } %>
 </div>

--- a/src/app/users/views/summaryPartial.ejs
+++ b/src/app/users/views/summaryPartial.ejs
@@ -119,9 +119,9 @@
         <% } %>
     </div>
 </div>
-<div class="govuk-grid-row">
+<div class="govuk-grid-row" >
     <div class="govuk-grid-column-full">
-        <div class="govuk-tabs" data-module="govuk-tabs">
+        <div class="govuk-tabs govuk-!-margin-0" data-module="govuk-tabs">
             <ul class="govuk-tabs__list">
                 <% if(locals.area === 'organisations') { %>
                     <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
@@ -129,7 +129,7 @@
                     </li>
                 <% } else { %>
                     <li class="govuk-tabs__list-item">
-                        <a class="govuk-tabs__tab" href="organisations">Organisations</a>
+                        <a class="govuk-link" href="organisations">Organisations</a>
                     </li>
                 <% } %>
         
@@ -139,7 +139,7 @@
                     </li>
                 <% } else { %>
                     <li class="govuk-tabs__list-item">
-                        <a class="govuk-tabs__tab" href="services" >Services</a>
+                        <a class="govuk-link" href="services" >Services</a>
                     </li>
                 <% } %>
         
@@ -150,7 +150,7 @@
                         </li>
                     <% } else { %>
                         <li class="govuk-tabs__list-item">
-                            <a class="govuk-tabs__tab" href="audit">Audit</a>
+                            <a class="govuk-link" href="audit">Audit</a>
                         </li>
                     <% } %>
                 <% } %>

--- a/src/app/users/views/summaryPartial.ejs
+++ b/src/app/users/views/summaryPartial.ejs
@@ -11,148 +11,151 @@
             </p>
         </div>
     </div>
-    <% } %>
-    <% if(locals.user.status.id === -2) { %>
-        <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
-            <div class="govuk-notification-banner__header">
-                <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
-                Important
-                </h2>
-            </div>
-            <div class="govuk-notification-banner__content">
-                <p class="govuk-notification-banner__heading">
-                    This account invitation was deactivated
-                    <a class="govuk-link" href="confirm-invitation-reactivation" class="action">Reactivate invitation</a>
-                </p>
-            </div>
-        </div>
-        <% } %>
-    <% if(locals.user.pendingEmail) { %>
-    <div class="govuk-notification-banner notification-information" tabindex="0">
-        <h2>Pending email address change</h2>
-        <p class="govuk-body">Waiting for <%= user.name %> to confirm the new email address of <%= user.pendingEmail %>.</p>
-        <p class="govuk-body">
-        <form method="post" action="cancel-change-email">
-            <input type="hidden" name="_csrf" value="<%= csrfToken %>"/>
-            <button class="govuk-button">Cancel change email</button>
-        </form>
-        </p>
-    </div>
+<% } %>
+<% if(locals.user.status.id === -2) { %>
     <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
-            <div class="govuk-notification-banner__header">
-                <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
-                Pending email address change
-                </h2>
-            </div>
-            <div class="govuk-notification-banner__content">
-                <p class="govuk-body">Waiting for <%= user.name %> to confirm the new email address of <%= user.pendingEmail %>.</p>
-                <p class="govuk-body">
-                <form method="post" action="cancel-change-email">
-                    <input type="hidden" name="_csrf" value="<%= csrfToken %>"/>
-                    <button class="govuk-button">Cancel change email</button>
-                </form>
-                </p>
-            </div>
-        </div>
-    <% } %>
-    <% if (locals.flash.info) { %>
-    <div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
         <div class="govuk-notification-banner__header">
-            <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">Success</h2>
+            <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+            Important
+            </h2>
         </div>
         <div class="govuk-notification-banner__content">
-            <p class="govuk-body"><%=locals.flash.info%></p>
+            <p class="govuk-notification-banner__heading">
+                This account invitation was deactivated
+                <a class="govuk-link" href="confirm-invitation-reactivation" class="action">Reactivate invitation</a>
+            </p>
         </div>
     </div>
 <% } %>
-    
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-            <h1 class="govuk-heading-xl">
-                <span class="govuk-caption-l"><%= user.email %></span>
-                <%= user.name %>
-            </h1>
-            <dl class="govuk-summary-list govuk-summary-list--no-border">
-                <div class="govuk-summary-list__row">
-                    <dt class="govuk-summary-list__key govuk-!-padding-0">Last login:</dt>
-                    <dd class="govuk-summary-list__value govuk-!-padding-0"><%= user.formattedLastLogin ? user.formattedLastLogin : 'Never' %></dd>
-                </div>
-                <div class="govuk-summary-list__row">
-                    <dt class="govuk-summary-list__key govuk-!-padding-0">Account status:</dt>
-                    <dd class="govuk-summary-list__value govuk-!-padding-0"><%= user.status.description %></dd>
-                </div>
-                <div class="govuk-summary-list__row">
-                    <dt class="govuk-summary-list__key govuk-!-padding-0">Number of logins in last 12 months:</dt>
-                    <dd class="govuk-summary-list__value govuk-!-padding-0"><%= user.loginsInPast12Months.successful %></dd>
-                </div>
-            </dl>
+<% if(locals.user.pendingEmail) { %>
+    <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+        <div class="govuk-notification-banner__header">
+            <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+            Pending email address change
+            </h2>
         </div>
-        <div class="govuk-grid-column-one-third">
-            <% if(!locals.isInvitation) { %>
-                <aside>
-                    <h2 class="govuk-heading-m">Actions</h2>
-                    <ul class="govuk-list">
-                        <% if(locals.user.status.id !== 0) { %>
-                            <li><a class="govuk-link" href="associate-organisation">Add organisation</a></li>
-                        <% } %>
-                        <% if (locals.organisations.length > 0 && locals.user.status.id !== 0) { %>
-                            <li><a class="govuk-link" href="select-organisation">Add services</a></li>
-                        <% } %>
-                        <% if(locals.user.status.id !== 0 && showChangeEmail) { %>
-                            <li><a class="govuk-link" href="edit-email">Change user's email address</a></li>
-                        <% } %>
-                        <% if(locals.user.status.id === 0) { %>
-                            <li><a class="govuk-link" href="confirm-reactivation">Reactivate user</a></li>
-                        <% } else { %>
-                            <li><a class="govuk-link" href="confirm-deactivation">Deactivate user</a></li>
-                        <% } %>
-                        <% if(locals.user.status.id !== 0) { %>
-                            <li><a class="govuk-link" href="edit-profile">Edit user's details</a></li>
-                        <% } %>
-                            <li><a class="govuk-link" href="web-service-sync">Send WS Sync</a></li>
-                            <li><a class="govuk-link" href="manage-console-services">Manage console roles</a></li>
-                    </ul>
-                </aside>
-            <% } else if (locals.isInvitation && !locals.user.deactivated) { %>
-                <aside>
-                    <h2 class="govuk-heading-m">Actions</h2>
-                    <ul class="govuk-list">
-                        <li><a class="govuk-link" href="associate-organisation">Add organisation</a></li>
-                        <% if (locals.organisations.length > 0) { %>
-                            <li><a class="govuk-link" href="select-organisation">Add services</a></li>
-                        <% } %>
-                        <li><a class="govuk-link" href="edit-email">Change user's email address</a></li>
-                        <li><a class="govuk-link" href="edit-profile">Edit user's details</a></li>
-                        <li><a class="govuk-link" href="confirm-invitation-deactivation">Deactivate user</a></li>
-                        <li><a class="govuk-link" href="resend-invitation"> Resend invitation email</a></li>
-                    </ul>
-                </aside>
-            <% } %>
+        <div class="govuk-notification-banner__content">
+            <p class="govuk-body">Waiting for <%= user.name %> to confirm the new email address of <%= user.pendingEmail %>.</p>
+            <p class="govuk-body">
+            <form method="post" action="cancel-change-email">
+                <input type="hidden" name="_csrf" value="<%= csrfToken %>"/>
+                <button class="govuk-button">Cancel change email</button>
+            </form>
+            </p>
         </div>
     </div>
-    
-    <nav class="govuk-grid-column-full govuk-!-margin-0 govuk-!-padding-0">
+<% } %>
+<% if (locals.flash.info) { %>
+<div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+    <div class="govuk-notification-banner__header">
+        <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">Success</h2>
+    </div>
+    <div class="govuk-notification-banner__content">
+        <p class="govuk-body"><%=locals.flash.info%></p>
+    </div>
+</div>
+<% } %>
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-xl">
+            <span class="govuk-caption-l"><%= user.email %></span>
+            <%= user.name %>
+        </h1>
+        <dl class="govuk-summary-list govuk-summary-list--no-border">
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key govuk-!-padding-0">Last login:</dt>
+                <dd class="govuk-summary-list__value govuk-!-padding-0"><%= user.formattedLastLogin ? user.formattedLastLogin : 'Never' %></dd>
+            </div>
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key govuk-!-padding-0">Account status:</dt>
+                <dd class="govuk-summary-list__value govuk-!-padding-0"><%= user.status.description %></dd>
+            </div>
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key govuk-!-padding-0">Number of logins in last 12 months:</dt>
+                <dd class="govuk-summary-list__value govuk-!-padding-0"><%= user.loginsInPast12Months.successful %></dd>
+            </div>
+        </dl>
+    </div>
+    <div class="govuk-grid-column-one-third">
+        <% if(!locals.isInvitation) { %>
+            <aside>
+                <h2 class="govuk-heading-m">Actions</h2>
+                <ul class="govuk-list">
+                    <% if(locals.user.status.id !== 0) { %>
+                        <li><a class="govuk-link" href="associate-organisation">Add organisation</a></li>
+                    <% } %>
+                    <% if (locals.organisations.length > 0 && locals.user.status.id !== 0) { %>
+                        <li><a class="govuk-link" href="select-organisation">Add services</a></li>
+                    <% } %>
+                    <% if(locals.user.status.id !== 0 && showChangeEmail) { %>
+                        <li><a class="govuk-link" href="edit-email">Change user's email address</a></li>
+                    <% } %>
+                    <% if(locals.user.status.id === 0) { %>
+                        <li><a class="govuk-link" href="confirm-reactivation">Reactivate user</a></li>
+                    <% } else { %>
+                        <li><a class="govuk-link" href="confirm-deactivation">Deactivate user</a></li>
+                    <% } %>
+                    <% if(locals.user.status.id !== 0) { %>
+                        <li><a class="govuk-link" href="edit-profile">Edit user's details</a></li>
+                    <% } %>
+                        <li><a class="govuk-link" href="web-service-sync">Send WS Sync</a></li>
+                        <li><a class="govuk-link" href="manage-console-services">Manage console roles</a></li>
+                </ul>
+            </aside>
+        <% } else if (locals.isInvitation && !locals.user.deactivated) { %>
+            <aside>
+                <h2 class="govuk-heading-m">Actions</h2>
+                <ul class="govuk-list">
+                    <li><a class="govuk-link" href="associate-organisation">Add organisation</a></li>
+                    <% if (locals.organisations.length > 0) { %>
+                        <li><a class="govuk-link" href="select-organisation">Add services</a></li>
+                    <% } %>
+                    <li><a class="govuk-link" href="edit-email">Change user's email address</a></li>
+                    <li><a class="govuk-link" href="edit-profile">Edit user's details</a></li>
+                    <li><a class="govuk-link" href="confirm-invitation-deactivation">Deactivate user</a></li>
+                    <li><a class="govuk-link" href="resend-invitation"> Resend invitation email</a></li>
+                </ul>
+            </aside>
+        <% } %>
+    </div>
+</div>
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
         <div class="govuk-tabs" data-module="govuk-tabs">
-            <ul class="govuk-tabs__list" role="tablist">
+            <ul class="govuk-tabs__list">
                 <% if(locals.area === 'organisations') { %>
-                    <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">Organisations</li>
+                    <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
+                        <span class="govuk-tabs__tab" >Organisations</span>
+                    </li>
                 <% } else { %>
-                    <li class="govuk-tabs__list-item"><a href="organisations" role="tab">Organisations</a></li>
+                    <li class="govuk-tabs__list-item">
+                        <a class="govuk-tabs__tab" href="organisations">Organisations</a>
+                    </li>
                 <% } %>
         
                 <% if(locals.area === 'services') { %>
-                    <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">Services</li>
+                    <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
+                        <span class="govuk-tabs__tab">Services</span>
+                    </li>
                 <% } else { %>
-                    <li class="govuk-tabs__list-item"><a href="services" role="tab">Services</a></li>
+                    <li class="govuk-tabs__list-item">
+                        <a class="govuk-tabs__tab" href="services" >Services</a>
+                    </li>
                 <% } %>
         
                 <% if(!locals.isInvitation) { %>
                     <% if(locals.area === 'audit') { %>
-                        <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">Audit</li>
+                        <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
+                            <span class="govuk-tabs__tab">Audit</span>
+                        </li>
                     <% } else { %>
-                        <li class="govuk-tabs__list-item"><a href="audit" role="tab">Audit</a></li>
+                        <li class="govuk-tabs__list-item">
+                            <a class="govuk-tabs__tab" href="audit">Audit</a>
+                        </li>
                     <% } %>
                 <% } %>
             </ul>
         </div>
-    </nav>
+    </div>
+</div>
+    

--- a/src/app/users/views/summaryPartial.ejs
+++ b/src/app/users/views/summaryPartial.ejs
@@ -1,48 +1,70 @@
 <% if(locals.user.status.id === 0) { %>
-    <div class="row">
-        <div class="col-12">
-            <div class="notification">
-                <p>
-                    This account was deactivated
-                    <a href="confirm-reactivation" class="action">Reactivate</a>
-                </p>
-            </div>
+    <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+        <div class="govuk-notification-banner__header">
+            <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+            Important
+            </h2>
+        </div>
+        <div class="govuk-notification-banner__content">
+            <p class="govuk-notification-banner__heading">
+            This account was deactivated
+            </p>
         </div>
     </div>
     <% } %>
     <% if(locals.user.status.id === -2) { %>
-        <div class="row">
-            <div class="col-12">
-                <div class="notification">
-                    <p>
-                        This account invitation was deactivated
-                        <a href="confirm-invitation-reactivation" class="action">Reactivate invitation</a>
-                    </p>
-                </div>
+        <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+            <div class="govuk-notification-banner__header">
+                <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+                Important
+                </h2>
+            </div>
+            <div class="govuk-notification-banner__content">
+                <p class="govuk-notification-banner__heading">
+                    This account invitation was deactivated
+                    <a class="govuk-link" href="confirm-invitation-reactivation" class="action">Reactivate invitation</a>
+                </p>
             </div>
         </div>
         <% } %>
     <% if(locals.user.pendingEmail) { %>
-    <div class="notification notification-information" tabindex="0">
+    <div class="govuk-notification-banner notification-information" tabindex="0">
         <h2>Pending email address change</h2>
-        <p>Waiting for <%= user.name %> to confirm the new email address of <%= user.pendingEmail %>.</p>
-        <p>
+        <p class="govuk-body">Waiting for <%= user.name %> to confirm the new email address of <%= user.pendingEmail %>.</p>
+        <p class="govuk-body">
         <form method="post" action="cancel-change-email">
             <input type="hidden" name="_csrf" value="<%= csrfToken %>"/>
-            <button class="button-text">Cancel change email</button>
+            <button class="govuk-button">Cancel change email</button>
         </form>
         </p>
     </div>
-    <% } %>
-    <% if (locals.flash.info) { %>
-    <div class="row">
-        <div class="col-12">
-            <div class="notification notification-success">
-                <%= locals.flash.info %>
+    <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+            <div class="govuk-notification-banner__header">
+                <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+                Pending email address change
+                </h2>
+            </div>
+            <div class="govuk-notification-banner__content">
+                <p class="govuk-body">Waiting for <%= user.name %> to confirm the new email address of <%= user.pendingEmail %>.</p>
+                <p class="govuk-body">
+                <form method="post" action="cancel-change-email">
+                    <input type="hidden" name="_csrf" value="<%= csrfToken %>"/>
+                    <button class="govuk-button">Cancel change email</button>
+                </form>
+                </p>
             </div>
         </div>
-    </div>
     <% } %>
+    <% if (locals.flash.info) { %>
+    <div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+        <div class="govuk-notification-banner__header">
+            <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">Success</h2>
+        </div>
+        <div class="govuk-notification-banner__content">
+            <p class="govuk-body"><%=locals.flash.info%></p>
+        </div>
+    </div>
+<% } %>
     
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">

--- a/src/app/users/views/summaryPartial.ejs
+++ b/src/app/users/views/summaryPartial.ejs
@@ -44,87 +44,93 @@
     </div>
     <% } %>
     
-    <div class="row">
-        <div class="col-8">
-            <h1 class="heading-xlarge heading-breakable">
-                <span class="heading-secondary"><%= user.email %></span>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-heading-xl">
+                <span class="govuk-caption-l"><%= user.email %></span>
                 <%= user.name %>
             </h1>
-            <dl class="inline condensed">
-                <dt class="label">Last login:</dt>
-                <dd><%= user.formattedLastLogin ? user.formattedLastLogin : 'Never' %></dd>
-                <dt class="label">Account status:</dt>
-                <dd><%= user.status.description %></dd>
-                <dt class="label">Number of logins in last 12 months:</dt>
-                <dd><%= user.loginsInPast12Months.successful %></dd>
+            <dl class="govuk-summary-list govuk-summary-list--no-border">
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key govuk-!-padding-0">Last login:</dt>
+                    <dd class="govuk-summary-list__value govuk-!-padding-0"><%= user.formattedLastLogin ? user.formattedLastLogin : 'Never' %></dd>
+                </div>
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key govuk-!-padding-0">Account status:</dt>
+                    <dd class="govuk-summary-list__value govuk-!-padding-0"><%= user.status.description %></dd>
+                </div>
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key govuk-!-padding-0">Number of logins in last 12 months:</dt>
+                    <dd class="govuk-summary-list__value govuk-!-padding-0"><%= user.loginsInPast12Months.successful %></dd>
+                </div>
             </dl>
         </div>
-        <div class="col-4">
+        <div class="govuk-grid-column-one-third">
             <% if(!locals.isInvitation) { %>
                 <aside>
-                    <h2 class="heading-medium">Actions</h2>
-                    <ul class="list">
+                    <h2 class="govuk-heading-m">Actions</h2>
+                    <ul class="govuk-list">
                         <% if(locals.user.status.id !== 0) { %>
-                            <li><a href="associate-organisation">Add organisation</a></li>
+                            <li><a class="govuk-link" href="associate-organisation">Add organisation</a></li>
                         <% } %>
                         <% if (locals.organisations.length > 0 && locals.user.status.id !== 0) { %>
-                            <li><a href="select-organisation">Add services</a></li>
+                            <li><a class="govuk-link" href="select-organisation">Add services</a></li>
                         <% } %>
                         <% if(locals.user.status.id !== 0 && showChangeEmail) { %>
-                            <li><a href="edit-email">Change user's email address</a></li>
+                            <li><a class="govuk-link" href="edit-email">Change user's email address</a></li>
                         <% } %>
                         <% if(locals.user.status.id === 0) { %>
-                            <li><a href="confirm-reactivation">Reactivate user</a></li>
+                            <li><a class="govuk-link" href="confirm-reactivation">Reactivate user</a></li>
                         <% } else { %>
-                            <li><a href="confirm-deactivation">Deactivate user</a></li>
+                            <li><a class="govuk-link" href="confirm-deactivation">Deactivate user</a></li>
                         <% } %>
                         <% if(locals.user.status.id !== 0) { %>
-                            <li><a href="edit-profile">Edit user's details</a></li>
+                            <li><a class="govuk-link" href="edit-profile">Edit user's details</a></li>
                         <% } %>
-                            <li><a href="web-service-sync">Send WS Sync</a></li>
-                            <li><a href="manage-console-services">Manage console roles</a></li>
+                            <li><a class="govuk-link" href="web-service-sync">Send WS Sync</a></li>
+                            <li><a class="govuk-link" href="manage-console-services">Manage console roles</a></li>
                     </ul>
                 </aside>
             <% } else if (locals.isInvitation && !locals.user.deactivated) { %>
                 <aside>
-                    <h2 class="heading-medium">Actions</h2>
-                    <ul class="list">
-                        <li><a href="associate-organisation">Add organisation</a></li>
+                    <h2 class="govuk-heading-m">Actions</h2>
+                    <ul class="govuk-list">
+                        <li><a class="govuk-link" href="associate-organisation">Add organisation</a></li>
                         <% if (locals.organisations.length > 0) { %>
-                            <li><a href="select-organisation">Add services</a></li>
+                            <li><a class="govuk-link" href="select-organisation">Add services</a></li>
                         <% } %>
-                        <li><a href="edit-email">Change user's email address</a></li>
-                        <li><a href="edit-profile">Edit user's details</a></li>
-                        <li><a href="confirm-invitation-deactivation">Deactivate user</a></li>
-                        <li><a href="resend-invitation"> Resend invitation email</a></li>
+                        <li><a class="govuk-link" href="edit-email">Change user's email address</a></li>
+                        <li><a class="govuk-link" href="edit-profile">Edit user's details</a></li>
+                        <li><a class="govuk-link" href="confirm-invitation-deactivation">Deactivate user</a></li>
+                        <li><a class="govuk-link" href="resend-invitation"> Resend invitation email</a></li>
                     </ul>
                 </aside>
             <% } %>
         </div>
     </div>
     
-    <nav>
-        <ul class="tabs" role="tablist">
-    
-            <% if(locals.area === 'organisations') { %>
-            <li class="active">Organisations</li>
-            <% } else { %>
-            <li><a href="organisations" role="tab">Organisations</a></li>
-            <% } %>
-    
-            <% if(locals.area === 'services') { %>
-            <li class="active">Services</li>
-            <% } else { %>
-            <li><a href="services" role="tab">Services</a></li>
-            <% } %>
-    
-            <% if(!locals.isInvitation) { %>
-            <% if(locals.area === 'audit') { %>
-            <li class="active">Audit</li>
-            <% } else { %>
-            <li><a href="audit" role="tab">Audit</a></li>
-            <% } %>
-            <% } %>
-    
-        </ul>
+    <nav class="govuk-grid-column-full govuk-!-margin-0 govuk-!-padding-0">
+        <div class="govuk-tabs" data-module="govuk-tabs">
+            <ul class="govuk-tabs__list" role="tablist">
+                <% if(locals.area === 'organisations') { %>
+                    <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">Organisations</li>
+                <% } else { %>
+                    <li class="govuk-tabs__list-item"><a href="organisations" role="tab">Organisations</a></li>
+                <% } %>
+        
+                <% if(locals.area === 'services') { %>
+                    <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">Services</li>
+                <% } else { %>
+                    <li class="govuk-tabs__list-item"><a href="services" role="tab">Services</a></li>
+                <% } %>
+        
+                <% if(!locals.isInvitation) { %>
+                    <% if(locals.area === 'audit') { %>
+                        <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">Audit</li>
+                    <% } else { %>
+                        <li class="govuk-tabs__list-item"><a href="audit" role="tab">Audit</a></li>
+                    <% } %>
+                <% } %>
+            </ul>
+        </div>
     </nav>

--- a/test/app/users/postCancelChangeEmail.test.js
+++ b/test/app/users/postCancelChangeEmail.test.js
@@ -94,7 +94,7 @@ describe("when cancelling the change of email for a user", () => {
     await postCancelChangeEmail(req, res);
 
     expect(updateUserDetails.mock.calls).toHaveLength(1);
-    expect(updateUserDetails.mock.calls[0][0].pendingEmail).toBeUndefined();
+    expect(updateUserDetails.mock.calls[0][0].pendingEmail).toBeNull();
   });
 
   it("then it should audit cancellation", async () => {


### PR DESCRIPTION
Link to ticket: [NSA-8939](https://dfe-secureaccess.atlassian.net/browse/NSA-8939)

- Updated the pages for user orgs, services and audit, as well as orgs pp sync.
- Fixed minor bug that occurs when user cancels a email change, but the notification banner persists.
- Added a couple of missed classes to previous org and user search pages.