### PR TITLE
[NSA-9013] Convert add user services pages to latest GDS style

### DIFF
--- a/src/app/organisations/views/search.ejs
+++ b/src/app/organisations/views/search.ejs
@@ -180,7 +180,18 @@ const organisationStatusesQuery = locals.organisationStatuses.filter(x => x.isSe
                                 <td class="govuk-table__cell govuk-body-s"><%= organisations[i].uid %></td>
                                 <td class="govuk-table__cell govuk-body-s"><%= organisations[i].upin %></td>
                                 <td class="govuk-table__cell govuk-body-s"><%= organisations[i].ukprn %></td>
-                                <td class="govuk-table__cell govuk-body-s"><%= organisations[i].status ? organisations[i].status.name : '' %></td>
+                                <td class="govuk-table__cell govuk-body-s">
+                                    <strong class="govuk-tag 
+                                        <%= organisations[i].status.name === "Open" ? "govuk-tag--green" : 
+                                            organisations[i].status.name === "Closed" ? "govuk-tag--red" : 
+                                            organisations[i].status.name === "Proposed to close" ? "govuk-tag--orange" : 
+                                            organisations[i].status.name === "Proposed to open" ? "govuk-tag--light-blue" : 
+                                            organisations[i].status.name === "Locked Restructure" ? "govuk-tag--yellow" : 
+                                            organisations[i].status.name === "Dissolved" ? "govuk-tag--grey" : "" %>">
+                                        <%= organisations[i].status ? organisations[i].status.name : '' %>
+                                    </strong>
+                                </td>
+
                             </tr>
                         <% } %>
                         </tbody>

--- a/src/app/users/associateRoles.js
+++ b/src/app/users/associateRoles.js
@@ -70,6 +70,7 @@ const getViewModel = async (req) => {
 
   return {
     csrfToken: req.csrfToken(),
+    layout: "sharedViews/layoutNew.ejs",
     name: req.session.user
       ? `${req.session.user.firstName} ${req.session.user.lastName}`
       : "",

--- a/src/app/users/associateServices.js
+++ b/src/app/users/associateServices.js
@@ -68,6 +68,7 @@ const get = async (req, res) => {
       : "",
     user: req.session.user,
     validationMessages: {},
+    layout: "sharedViews/layoutNew.ejs",
     backLink:
       userOrganisations.length > 1
         ? `/users/${req.params.uid}/select-organisation`
@@ -103,6 +104,7 @@ const validate = async (req) => {
       : "",
     user: req.session.user,
     validationMessages: {},
+    layout: "sharedViews/layoutNew.ejs",
     backLink:
       userOrganisations.length > 1
         ? `/users/${req.params.uid}/select-organisation`

--- a/src/app/users/confirmAddService.js
+++ b/src/app/users/confirmAddService.js
@@ -56,6 +56,7 @@ const get = async (req, res) => {
 
   return res.render("users/views/confirmAddService", {
     backLink: true,
+    layout: "sharedViews/layoutNew.ejs",
     changeLink: req.session.user.isAddService
       ? `/users/${userId}/organisations/${req.params.orgId}`
       : `/users/${userId}/organisations/${req.params.orgId}/services/${req.session.user.services[0].serviceId}`,

--- a/src/app/users/selectOrganisation.js
+++ b/src/app/users/selectOrganisation.js
@@ -51,7 +51,7 @@ const get = async (req, res) => {
       `organisations/${userOrganisations[0].organisation.id}`,
     );
   }
-  console.log("userOrganisations: ", userOrganisations);
+
   return res.render("users/views/selectOrganisation", {
     selectionPrompt: getSelectionPrompt(),
     csrfToken: req.csrfToken(),

--- a/src/app/users/selectOrganisation.js
+++ b/src/app/users/selectOrganisation.js
@@ -51,9 +51,12 @@ const get = async (req, res) => {
       `organisations/${userOrganisations[0].organisation.id}`,
     );
   }
+  console.log("userOrganisations: ", userOrganisations);
   return res.render("users/views/selectOrganisation", {
     selectionPrompt: getSelectionPrompt(),
     csrfToken: req.csrfToken(),
+    layout: "sharedViews/layoutNew.ejs",
+    backLink: "organisations",
     organisations: userOrganisations,
     selectedOrganisation: null,
     validationMessages: {},
@@ -65,6 +68,7 @@ const validate = async (req) => {
   const selectedOrg = req.body.selectedOrganisation;
   const model = {
     selectedOrganisation: selectedOrg,
+    layout: "sharedViews/layoutNew.ejs",
     validationMessages: {},
     organisations: userOrganisations,
   };

--- a/src/app/users/views/associateRoles.ejs
+++ b/src/app/users/views/associateRoles.ejs
@@ -15,7 +15,7 @@
                 <%=locals.user.isAddService ? 'Select roles' : 'Edit service'%>
             </h1>
             <% if (locals.user.isAddService) { %>
-                <p>Showing service <%= locals.currentService%> of <%=locals.totalNumberOfServices%></p>
+                <p class="govuk-body">Showing service <%= locals.currentService%> of <%=locals.totalNumberOfServices%></p>
             <% } %>
             <dl class="govuk-summary-list">
                 <div class="govuk-summary-list__row">
@@ -35,47 +35,49 @@
                     </dd>
                 </div>
 
-                <div class="app-check-your-answers__contents">
-                    <dt class="app-check-your-answers__title">
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
                         Service
                     </dt>
-                    <dd class="app-check-your-answers__answer">
+                    <dd class="govuk-summary-list__value">
                         <%=locals.serviceDetails.name%>
                     </dd>
                 </div>
             </dl>
             <form method="post">
                 <input type="hidden" name="_csrf" value="<%=csrfToken%>" />
-                <div class="form-group  <%= (locals.validationMessages.roles !== undefined) ? 'form-group-error' : '' %>">
-                    <fieldset>
+                <div class="govuk-form-group  <%= (locals.validationMessages.roles !== undefined) ? 'govuk-form-group--error' : '' %>">
+                    <fieldset class="govuk-fieldset">
                         <% if (locals.validationMessages.roles !== undefined) { %>
-                        <p class="error-message" id="validation-selected-role"><%-locals.validationMessages.roles%></p>
+                        <p class="govuk-error-message" id="validation-selected-role"><%-locals.validationMessages.roles%></p>
                         <% } %>
                         <% if (locals.serviceRoles.length > 0) { %>
-                            <legend>
-                                <span class="body-text">Select all required roles</span>
+                            <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+                                Select all required roles
                             </legend>
                             <% for (let i = 0; i < locals.serviceRoles.length; i++) { %>
                                 <% const role = locals.serviceRoles[i]; %>
-                                <div class="multiple-choice">
-                                    <input id="<%=role.id%>" type="checkbox" name="role" value="<%=role.id%>"
-                                        <% if (locals.selectedRoles.roles && locals.selectedRoles.roles.length > 0) {
-                                        for(let i = 0; i < locals.selectedRoles.roles.length; i++) {
-                                            const selectedRole = locals.selectedRoles.roles[i];
-                                        %>
-                                        <%= role.id === selectedRole ? 'checked': ''%><% } }%>>
-                                    <label for="<%=role.id%>"><%=role.name%></label>
+                                <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+                                    <div class="govuk-checkboxes__item">
+                                        <input class="govuk-checkboxes__input" id="<%=role.id%>" type="checkbox" name="role" value="<%=role.id%>"
+                                            <% if (locals.selectedRoles.roles && locals.selectedRoles.roles.length > 0) {
+                                            for(let i = 0; i < locals.selectedRoles.roles.length; i++) {
+                                                const selectedRole = locals.selectedRoles.roles[i];
+                                            %>
+                                            <%= role.id === selectedRole ? 'checked': ''%><% } }%>>
+                                        <label class="govuk-label govuk-checkboxes__label" for="<%=role.id%>"><%=role.name%></label>
+                                    </div>
                                 </div>
                             <% } %>
                         <% } else { %>
-                            <legend><h2 class="heading-small">There are no available roles for <%= locals.serviceDetails.name %>.</h2></legend>
+                            <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">There are no available roles for <%= locals.serviceDetails.name %>.</legend>
                         <% } %>
                     </fieldset>
                 </div>
                 <% if (!(!locals.user.isAddService && locals.serviceRoles.length === 0)) {%>
-                <div class="form-submit submit-buttons">
-                    <button type="submit" class="button">Continue</button>
-                    <a href="<%= locals.cancelLink %>" class="button button-secondary">Cancel</a>
+                <div class="govuk-button-group">
+                    <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+                    <a href="<%= locals.cancelLink %>" class="govuk-button govuk-button--secondary" data-module="govuk-button">Cancel</a>
                 </div>
                 <% } %>
             </form>

--- a/src/app/users/views/associateRoles.ejs
+++ b/src/app/users/views/associateRoles.ejs
@@ -1,94 +1,96 @@
-<div class="row">
-    <div class="col-8">
-        <% if (locals.serviceDetails.relyingParty && locals.serviceDetails.relyingParty.params && locals.serviceDetails.relyingParty.params.serviceConfirmMessage) { %>
-            <div class="notice" style="margin-top: 1.25em;">
-                <i class="icon icon-important">
-                    <span class="visually-hidden">Warning</span>
-                </i>
-                <strong class="bold-small">
-                    <%- locals.serviceDetails.relyingParty.params.serviceConfirmMessage %>
-                </strong>
-            </div>
-        <% } %>
-        <h1 class="heading-xlarge">
-            <%=locals.user.isAddService ? 'Select roles' : 'Edit service'%>
-        </h1>
-        <% if (locals.user.isAddService) { %>
-            <p>Showing service <%= locals.currentService%> of <%=locals.totalNumberOfServices%></p>
-        <% } %>
-        <dl class="app-check-your-answers app-check-your-answers--short">
-
-            <div class="app-check-your-answers__contents">
-                <dt class="app-check-your-answers__title">
-                    User
-                </dt>
-                <dd class="app-check-your-answers__answer">
-                    <%= locals.name%>
-                </dd>
-            </div>
-
-            <div class="app-check-your-answers__contents">
-                <dt class="app-check-your-answers__title">
-                    Organisation
-                </dt>
-                <dd class="app-check-your-answers__answer">
-                    <%=locals.organisationDetails.organisation.name%>
-                </dd>
-            </div>
-
-            <div class="app-check-your-answers__contents">
-                <dt class="app-check-your-answers__title">
-                    Service
-                </dt>
-                <dd class="app-check-your-answers__answer">
-                    <%=locals.serviceDetails.name%>
-                </dd>
-            </div>
-        </dl>
-        <form method="post">
-            <input type="hidden" name="_csrf" value="<%=csrfToken%>" />
-            <div class="form-group  <%= (locals.validationMessages.roles !== undefined) ? 'form-group-error' : '' %>">
-                <fieldset>
-                    <% if (locals.validationMessages.roles !== undefined) { %>
-                    <p class="error-message" id="validation-selected-role"><%-locals.validationMessages.roles%></p>
-                    <% } %>
-                    <% if (locals.serviceRoles.length > 0) { %>
-                        <legend>
-                            <span class="body-text">Select all required roles</span>
-                        </legend>
-                        <% for (let i = 0; i < locals.serviceRoles.length; i++) { %>
-                            <% const role = locals.serviceRoles[i]; %>
-                            <div class="multiple-choice">
-                                <input id="<%=role.id%>" type="checkbox" name="role" value="<%=role.id%>"
-                                    <% if (locals.selectedRoles.roles && locals.selectedRoles.roles.length > 0) {
-                                    for(let i = 0; i < locals.selectedRoles.roles.length; i++) {
-                                        const selectedRole = locals.selectedRoles.roles[i];
-                                    %>
-                                    <%= role.id === selectedRole ? 'checked': ''%><% } }%>>
-                                <label for="<%=role.id%>"><%=role.name%></label>
-                            </div>
-                        <% } %>
-                    <% } else { %>
-                        <legend><h2 class="heading-small">There are no available roles for <%= locals.serviceDetails.name %>.</h2></legend>
-                    <% } %>
-                </fieldset>
-            </div>
-            <% if (!(!locals.user.isAddService && locals.serviceRoles.length === 0)) {%>
-            <div class="form-submit submit-buttons">
-                <button type="submit" class="button">Continue</button>
-                <a href="<%= locals.cancelLink %>" class="button button-secondary">Cancel</a>
-            </div>
+<div class="govuk-width-container">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <% if (locals.serviceDetails.relyingParty && locals.serviceDetails.relyingParty.params && locals.serviceDetails.relyingParty.params.serviceConfirmMessage) { %>
+                <div class="notice" style="margin-top: 1.25em;">
+                    <i class="icon icon-important">
+                        <span class="visually-hidden">Warning</span>
+                    </i>
+                    <strong class="bold-small">
+                        <%- locals.serviceDetails.relyingParty.params.serviceConfirmMessage %>
+                    </strong>
+                </div>
             <% } %>
-        </form>
+            <h1 class="govuk-heading-xl">
+                <%=locals.user.isAddService ? 'Select roles' : 'Edit service'%>
+            </h1>
+            <% if (locals.user.isAddService) { %>
+                <p>Showing service <%= locals.currentService%> of <%=locals.totalNumberOfServices%></p>
+            <% } %>
+            <dl class="govuk-summary-list">
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                        User
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                        <%= locals.name%>
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                        Organisation
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                        <%=locals.organisationDetails.organisation.name%>
+                    </dd>
+                </div>
+
+                <div class="app-check-your-answers__contents">
+                    <dt class="app-check-your-answers__title">
+                        Service
+                    </dt>
+                    <dd class="app-check-your-answers__answer">
+                        <%=locals.serviceDetails.name%>
+                    </dd>
+                </div>
+            </dl>
+            <form method="post">
+                <input type="hidden" name="_csrf" value="<%=csrfToken%>" />
+                <div class="form-group  <%= (locals.validationMessages.roles !== undefined) ? 'form-group-error' : '' %>">
+                    <fieldset>
+                        <% if (locals.validationMessages.roles !== undefined) { %>
+                        <p class="error-message" id="validation-selected-role"><%-locals.validationMessages.roles%></p>
+                        <% } %>
+                        <% if (locals.serviceRoles.length > 0) { %>
+                            <legend>
+                                <span class="body-text">Select all required roles</span>
+                            </legend>
+                            <% for (let i = 0; i < locals.serviceRoles.length; i++) { %>
+                                <% const role = locals.serviceRoles[i]; %>
+                                <div class="multiple-choice">
+                                    <input id="<%=role.id%>" type="checkbox" name="role" value="<%=role.id%>"
+                                        <% if (locals.selectedRoles.roles && locals.selectedRoles.roles.length > 0) {
+                                        for(let i = 0; i < locals.selectedRoles.roles.length; i++) {
+                                            const selectedRole = locals.selectedRoles.roles[i];
+                                        %>
+                                        <%= role.id === selectedRole ? 'checked': ''%><% } }%>>
+                                    <label for="<%=role.id%>"><%=role.name%></label>
+                                </div>
+                            <% } %>
+                        <% } else { %>
+                            <legend><h2 class="heading-small">There are no available roles for <%= locals.serviceDetails.name %>.</h2></legend>
+                        <% } %>
+                    </fieldset>
+                </div>
+                <% if (!(!locals.user.isAddService && locals.serviceRoles.length === 0)) {%>
+                <div class="form-submit submit-buttons">
+                    <button type="submit" class="button">Continue</button>
+                    <a href="<%= locals.cancelLink %>" class="button button-secondary">Cancel</a>
+                </div>
+                <% } %>
+            </form>
+        </div>
+        <% if (!locals.user.isAddService) { %>
+        <div class="col-4">
+            <aside>
+                <h2 class="heading-medium">Actions</h2>
+                <ul class="list">
+                    <li><a href="<%=locals.serviceDetails.id%>/remove-service">Remove service</a> </li>
+                </ul>
+            </aside>
+        </div>
+        <% }%>
     </div>
-    <% if (!locals.user.isAddService) { %>
-    <div class="col-4">
-        <aside>
-            <h2 class="heading-medium">Actions</h2>
-            <ul class="list">
-                <li><a href="<%=locals.serviceDetails.id%>/remove-service">Remove service</a> </li>
-            </ul>
-        </aside>
-    </div>
-    <% }%>
 </div>
+
+

--- a/src/app/users/views/associateServices.ejs
+++ b/src/app/users/views/associateServices.ejs
@@ -1,63 +1,67 @@
-<div class="row">
-    <div class="col-8">
-        <h1 class="heading-xlarge">
-            Select services
-        </h1>
-        <dl class="app-check-your-answers app-check-your-answers--short">
+<div class="govuk-width-container">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <h1 class="govuk-heading-xl">
+                Select services
+            </h1>
+            <dl class="govuk-summary-list">
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                        User
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                        <%= locals.name%>
+                    </dd>
+                </div>
 
-            <div class="app-check-your-answers__contents">
-                <dt class="app-check-your-answers__title">
-                    User
-                </dt>
-                <dd class="app-check-your-answers__answer">
-                    <%= locals.name%>
-                </dd>
-            </div>
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                        Organisation
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                        <%=locals.organisationDetails.organisation.name%>
+                    </dd>
+                </div>
+            </dl>
+            <% if (locals.services.length > 0) { %>
+            <form method="post">
+                <input type="hidden" name="_csrf" value="<%=csrfToken%>" />
+                <div class="govuk-form-group  <%= (locals.validationMessages.services !== undefined) ? 'govuk-form-group--error' : '' %>">
+                    <fieldset class="govuk-fieldset" aria-describedby="validation-selected-organisation">
+                        <% if (locals.validationMessages.services !== undefined) { %>
+                        <p class="govuk-error-message" id="validation-selected-organisation"><%=locals.validationMessages.services%></p>
+                        <% } %>
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+                            Select all required services
+                        </legend>
 
-            <div class="app-check-your-answers__contents">
-                <dt class="app-check-your-answers__title">
-                    Organisation
-                </dt>
-                <dd class="app-check-your-answers__answer">
-                    <%=locals.organisationDetails.organisation.name%>
-                </dd>
-            </div>
-        </dl>
-        <% if (locals.services.length > 0) { %>
-        <form method="post">
-            <input type="hidden" name="_csrf" value="<%=csrfToken%>" />
-            <div class="form-group  <%= (locals.validationMessages.services !== undefined) ? 'form-group-error' : '' %>">
-                <fieldset class="govuk-fieldset" aria-describedby="validation-selected-organisation">
-                    <% if (locals.validationMessages.services !== undefined) { %>
-                    <p class="error-message" id="validation-selected-organisation"><%=locals.validationMessages.services%></p>
-                    <% } %>
-                    <legend>
-                        <span class="body-text">Select all required services</span>
-                    </legend>
+                        <% for (let i = 0; i < locals.services.length; i++) { %>
+                            <% const service = locals.services[i]; %>
+                            <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+                                <div class="govuk-checkboxes__item">
+                                    <input class="govuk-checkboxes__input" id="<%=service.id%>" type="checkbox" name="service" value="<%=service.id%>"
+                                            <% if (locals.selectedServices && locals.selectedServices.length > 0) {
+                                            for(let i = 0; i < locals.selectedServices.length; i++) {
+                                                const selectedService = locals.selectedServices[i].serviceId;
+                                            %>
+                                            <%= service.id === selectedService ? 'checked': ''%><% } }%>>
+                                    <label class="govuk-label govuk-checkboxes__label" for="<%=service.id%>"><%=service.name%></label>
+                                </div>
+                            </div>
+                        <% } %>
 
-                    <% for (let i = 0; i < locals.services.length; i++) { %>
-                        <% const service = locals.services[i]; %>
-                        <div class="multiple-choice">
-
-                            <input id="<%=service.id%>" type="checkbox" name="service" value="<%=service.id%>"
-                                    <% if (locals.selectedServices && locals.selectedServices.length > 0) {
-                                    for(let i = 0; i < locals.selectedServices.length; i++) {
-                                        const selectedService = locals.selectedServices[i].serviceId;
-                                    %>
-                                    <%= service.id === selectedService ? 'checked': ''%><% } }%>>
-                            <label for="<%=service.id%>"><%=service.name%></label>
-                        </div>
-                    <% } %>
-
-                </fieldset>
-            </div>
-            <div class="form-submit submit-buttons">
-                <button type="submit" class="button">Continue</button>
-                <a href= "./../" class="button button-secondary">Cancel</a>
-            </div>
-        </form>
-        <% } else { %>
-            <p> No services available </p>
-        <% } %>
+                    </fieldset>
+                </div>
+                <div class="govuk-button-group">
+                    <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+                    <a href= "./../" class="govuk-button govuk-button--secondary" data-module="govuk-button">Cancel</a>
+                </div>
+            </form>
+            <% } else { %>
+                <p> No services available </p>
+            <% } %>
+        </div>
     </div>
 </div>
+
+

--- a/src/app/users/views/confirmAddService.ejs
+++ b/src/app/users/views/confirmAddService.ejs
@@ -1,113 +1,116 @@
-<div class="grid-row">
-    <div class="col-8">
-
-            <h1 class="heading-xlarge">
+<div class="govuk-width-container">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-row">
+            <h1 class="govuk-heading-xl">
                 <%=locals.user.isAddService ? 'Review new services' : 'Review service changes' %>
             </h1>
-            <p><%=locals.user.isAddService ? 'Please review these details before granting access.' : 'Please review these details before saving.'%></p>
+            <p class="govuk-body"><%=locals.user.isAddService ? 'Please review these details before granting access.' : 'Please review these details before saving.'%></p>
 
-        <dl class="app-check-your-answers app-check-your-answers--short">
-            <div class="app-check-your-answers__contents">
-                <dt class="app-check-your-answers__title">
-                    Personal details
-                </dt>
-                <dd class="app-check-your-answers__change ">
-                </dd>
-            </div>
-            <div class="app-check-your-answers__contents">
-                <dt class="app-check-your-answers__question">
-                    First name
-                </dt>
-                <dd class="app-check-your-answers__answer">
-                    <%=locals.user.firstName%>
-                </dd>
-            </div>
+            <dl class="govuk-summary-list">
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                        Personal details
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                        First name
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                        <%=locals.user.firstName%>
+                    </dd>
+                </div>
 
-            <div class="app-check-your-answers__contents">
-                <dt class="app-check-your-answers__question">
-                    Last name
-                </dt>
-                <dd class="app-check-your-answers__answer">
-                    <%=locals.user.lastName%>
-                </dd>
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                        Last name
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                        <%=locals.user.lastName%>
+                    </dd>
 
-            </div>
+                </div>
 
-            <div class="app-check-your-answers__contents">
-                <dt class="app-check-your-answers__question">
-                    Email Address
-                </dt>
-                <dd class="app-check-your-answers__answer">
-                    <%=locals.user.email%>
-                </dd>
-            </div>
-        </dl>
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                        Email Address
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                        <%=locals.user.email%>
+                    </dd>
+                </div>
+            </dl>
 
 
-        <dl class="app-check-your-answers app-check-your-answers--short">
-            <div class="app-check-your-answers__contents">
-                <dt class="app-check-your-answers__title">
-                    Organisation
-                </dt>
-                <dd class="app-check-your-answers__answer"></dd>
-            </div>
-            <div class="app-check-your-answers__contents">
-                <dt class="app-check-your-answers__question">
-                    Name
-                </dt>
-                <dd class="app-check-your-answers__answer">
-                    <%=locals.organisationDetails.organisation.name%>
-                </dd>
-            </div>
-        </dl>
+            <dl class="govuk-summary-list">
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                        Organisation
+                    </dt>
+                    <dd class="govuk-summary-list__value"></dd>
+                </div>
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                        Name
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                        <%=locals.organisationDetails.organisation.name%>
+                    </dd>
+                </div>
+            </dl>
 
-        <dl class="app-check-your-answers app-check-your-answers--short">
-            <div class="app-check-your-answers__contents">
-                <dt class="app-check-your-answers__title">
-                    Services
-                </dt>
-                <dd class="app-check-your-answers__change ">
-                    <a href= "<%=locals.changeLink%>" >
-                        Change
-                    </a>
-                </dd>
-            </div>
+            <dl class="govuk-summary-list">
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                        Services
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                        <a class="govuk-link" href= "<%=locals.changeLink%>" >
+                            Change
+                        </a>
+                    </dd>
+                </div>
 
-            <% if (locals.services.length > 0) { %>
-                <% for (let i = 0; i< locals.services.length; i++) { %>
-                    <% const service = locals.services[i]; %>
-                    <div class="app-check-your-answers__contents__group">
-                        <dt class="app-check-your-answers__group__title">
-                            Service
-                        </dt>
-                        <dd class="app-check-your-answers__group">
-                            <%= service.name%>
-                        </dd>
-                    </div>
-                    <div class="app-check-your-answers__contents">
-                        <dt class="app-check-your-answers__question">
-                            Roles
-                        </dt>
-                        <dd class="app-check-your-answers__answer">
-                            <% if (locals.services[i].roles.length > 0) { %>
-                                <% for (let x = 0; x < locals.services[i].roles.length; x++) { %>
-                                    <% const role = locals.services[i].roles[x]; %>
-                                    <%= role.name %> <br>
+                <% if (locals.services.length > 0) { %>
+                    <% for (let i = 0; i< locals.services.length; i++) { %>
+                        <% const service = locals.services[i]; %>
+                        <div class="govuk-summary-list__row">
+                            <dt class="govuk-summary-list__key">
+                                Service
+                            </dt>
+                            <dd class="govuk-summary-list__value">
+                                <%= service.name%>
+                            </dd>
+                        </div>
+                        <div class="govuk-summary-list__row">
+                            <dt class="govuk-summary-list__key">
+                                Roles
+                            </dt>
+                            <dd class="govuk-summary-list__value">
+                                <% if (locals.services[i].roles.length > 0) { %>
+                                    <% for (let x = 0; x < locals.services[i].roles.length; x++) { %>
+                                        <% const role = locals.services[i].roles[x]; %>
+                                        <%= role.name %> <br>
+                                    <% } %>
+                                <% } else { %>
+                                    No roles selected
                                 <% } %>
-                            <% } else { %>
-                                No roles selected
-                            <% } %>
-                        </dd>
-                    </div>
+                            </dd>
+                        </div>
+                    <% } %>
                 <% } %>
-            <% } %>
-        </dl>
-        <form method="post">
-            <input type="hidden" name="_csrf" value="<%= csrfToken %>"/>
-            <div class="form-submit submit-buttons">
-                <button type="submit" class="button"><%=locals.user.isAddService ? "Submit" : "Save"%></button>
-                <a href="<%=locals.user.isAddService ? "/users/" + locals.user.uid + "/organisations" : "/users/" + locals.user.uid + "/services"%>" class="button button-secondary">Cancel</a>
-            </div>
-        </form>
+            </dl>
+            <form method="post">
+                <input type="hidden" name="_csrf" value="<%= csrfToken %>"/>
+                <div class="govuk-button-group">
+                    <button type="submit" class="govuk-button" data-module="govuk-button"><%=locals.user.isAddService ? "Submit" : "Save"%></button>
+                    <a href="<%=locals.user.isAddService ? "/users/" + locals.user.uid + "/organisations" : "/users/" + locals.user.uid + "/services"%>" class="govuk-button govuk-button--secondary" data-module="govuk-button">Cancel</a>
+                </div>
+            </form>
+        </div>
     </div>
 </div>
+
+

--- a/src/app/users/views/search.ejs
+++ b/src/app/users/views/search.ejs
@@ -35,18 +35,29 @@ if (services && services.length > 0) {
 
 %>
 
-<% if (locals.flash.info) { %>
-<div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
-  <div class="govuk-notification-banner__header">
-    <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">Success</h2>
-  </div>
-  <div class="govuk-notification-banner__content">
-    <p class="govuk-body"><%=locals.flash.info%></p>
-  </div>
-</div>
-<% } %>
-
 <div class="govuk-width-container">
+
+    <% if (locals.flash.info) { %>
+    <div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-top-5" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+      <div class="govuk-notification-banner__header">
+        <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">Success</h2>
+      </div>
+      <div class="govuk-notification-banner__content">
+        <p class="govuk-body"><%=locals.flash.info%></p>
+      </div>
+    </div>
+    <% } %>
+    <% if (locals.flash.rejected) { %>
+    <div class="govuk-notification-banner" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+        <div class="govuk-notification-banner__header">
+            <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">Rejected</h2>
+        </div>
+        <div class="govuk-notification-banner__content">
+            <p class="govuk-body"><%= locals.flash.rejected %></p>
+        </div>
+    </div>
+    <% } %>
+
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-xl">Users</h1>

--- a/src/app/users/views/selectOrganisation.ejs
+++ b/src/app/users/views/selectOrganisation.ejs
@@ -20,7 +20,7 @@
                         <% for(let i= 0; i < locals.organisations.length; i++) {
                             const org = locals.organisations[i];
                         %>
-                        <div class="govuk-radios" data-module="govuk-radios">
+                        <div class="govuk-radios govuk-!-width-three-quarters" data-module="govuk-radios">
                             <div class="govuk-radios__item">
                                 <input class="govuk-radios__input" id="<%= org.organisation.id %>" type="radio" name="selectedOrganisation" value="<%= org.organisation.id %>">
                                 <label class="govuk-label govuk-radios__label govuk-!-font-weight-bold" for="<%= org.organisation.id %>">
@@ -30,7 +30,9 @@
                                 <div id="<%= org.organisation.id %>" class="govuk-hint govuk-radios__hint">
                                     <% if (org.naturalIdentifiers) { %>
                                             <%= org.naturalIdentifiers.join(', ') %>
+                                        <br>
                                     <% } %>
+
                                     <% if (org.organisation.LegalName) { %>
                                             Legal Name: <%= org.organisation.LegalName %>
                                     <% } %>

--- a/src/app/users/views/selectOrganisation.ejs
+++ b/src/app/users/views/selectOrganisation.ejs
@@ -1,57 +1,54 @@
-<a href="organisations" class="link-back">Back</a>
-<div class="grid-row">
-    <div class="col-8">
-        <h1 class="heading-xlarge">
-            Select your Organisation
-        </h1>
-        <p>You are associated with more than one organisation. Select the organisation associated with the service you would like to access.</p>
+<div class="govuk-width-container">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <h1 class="govuk-heading-xl">
+                Select your Organisation
+            </h1>
+            <p class="govuk-body">You are associated with more than one organisation. Select the organisation associated with the service you would like to access.</p>
 
-        <h2 class="heading-medium">
-            Your Organisations
-        </h2>
+            <h2 class="govuk-heading-m">
+                Your Organisations
+            </h2>
 
-        <form method="post">
-            <input type="hidden" name="_csrf" value="<%=csrfToken%>"/>
-            <div class="form-group <%= (locals.validationMessages.selectedOrganisation !== undefined) ? 'form-group-error' : '' %>">
-                <fieldset class="govuk-fieldset" aria-describedby="validation-selected-organisation">
-                    <% if (locals.validationMessages.selectedOrganisation !== undefined) { %>
-                    <p class="error-message" id="validation-selected-organisation"><%=locals.validationMessages.selectedOrganisation %></p>
-                    <% } %>
-                    <legend class="vh">Select the organisation </legend>
-                    <% for(let i= 0; i < locals.organisations.length; i++) {
-                        const org = locals.organisations[i];
-                    %>
-                    <div class="multiple-choice">
-                        <input id="<%= org.organisation.id %>" type="radio" name="selectedOrganisation" value="<%= org.organisation.id %>">
-                        <label for="<%= org.organisation.id %>">
-                            <span class="form-label-bold">
-                                <%= org.organisation.name %>
-                                <%= org.organisation.status ? `(${org.organisation.status.name})` : ''%>
-                            </span>
-                            <% if (org.naturalIdentifiers) { %>
-                                <span class="form-hint">
-                                    <%= org.naturalIdentifiers.join(', ') %>
-                                </span>
-                            <% } %>
-                            <% if (org.organisation.LegalName) { %>
-                                <span class="form-hint">
-                                    Legal Name: <%= org.organisation.LegalName %>
-                                </span>
-                            <% } %>
-                            <% if (org.organisation.address && org.organisation.address !== 'Not recorded') { %>
-                                <span class="form-hint">
-                                    <%= org.organisation.address %>
-                                </span>
-                            <% } %>
-                        </label>
-                    </div>
-                    <% } %>
-                </fieldset>
-            </div>
-            <div class="form-submit submit-buttons">
-                <button class="button">Continue</button>
-                <a href="./" class="button button-secondary">Cancel</a>
-            </div>
-        </form>
+            <form method="post">
+                <input type="hidden" name="_csrf" value="<%=csrfToken%>"/>
+                <div class="govuk-form-group <%= (locals.validationMessages.selectedOrganisation !== undefined) ? 'govuk-form-group--error' : '' %>">
+                    <fieldset class="govuk-fieldset" aria-describedby="validation-selected-organisation">
+                        <% if (locals.validationMessages.selectedOrganisation !== undefined) { %>
+                        <p class="govuk-error-message" id="validation-selected-organisation"><%=locals.validationMessages.selectedOrganisation %></p>
+                        <% } %>
+                        <% for(let i= 0; i < locals.organisations.length; i++) {
+                            const org = locals.organisations[i];
+                        %>
+                        <div class="govuk-radios" data-module="govuk-radios">
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="<%= org.organisation.id %>" type="radio" name="selectedOrganisation" value="<%= org.organisation.id %>">
+                                <label class="govuk-label govuk-radios__label govuk-!-font-weight-bold" for="<%= org.organisation.id %>">
+                                    <%= org.organisation.name %>
+                                    <%= org.organisation.status ? `(${org.organisation.status.name})` : ''%>
+                                </label>
+                                <div id="<%= org.organisation.id %>" class="govuk-hint govuk-radios__hint">
+                                    <% if (org.naturalIdentifiers) { %>
+                                            <%= org.naturalIdentifiers.join(', ') %>
+                                    <% } %>
+                                    <% if (org.organisation.LegalName) { %>
+                                            Legal Name: <%= org.organisation.LegalName %>
+                                    <% } %>
+                                    <% if (org.organisation.address && org.organisation.address !== 'Not recorded') { %>
+                                            <%= org.organisation.address %>
+                                    <% } %>
+                                </div>
+                            </div>
+                        </div>
+                        <% } %>
+                    </fieldset>
+                </div>
+                <div class="govuk-button-group">
+                    <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+                    <a href="./" class="govuk-button govuk-button--secondary">Cancel</a>
+                </div>
+            </form>
+        </div>
     </div>
 </div>
+

--- a/src/app/users/views/selectOrganisation.ejs
+++ b/src/app/users/views/selectOrganisation.ejs
@@ -35,6 +35,7 @@
 
                                     <% if (org.organisation.LegalName) { %>
                                             Legal Name: <%= org.organisation.LegalName %>
+                                        <br>
                                     <% } %>
                                     <% if (org.organisation.address && org.organisation.address !== 'Not recorded') { %>
                                             <%= org.organisation.address %>

--- a/src/app/users/views/summaryPartial.ejs
+++ b/src/app/users/views/summaryPartial.ejs
@@ -55,6 +55,16 @@
     </div>
 </div>
 <% } %>
+<% if (locals.flash.rejected) { %>
+<div class="govuk-notification-banner" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+    <div class="govuk-notification-banner__header">
+        <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">Rejected</h2>
+    </div>
+    <div class="govuk-notification-banner__content">
+        <p class="govuk-body"><%=locals.flash.rejected%></p>
+    </div>
+</div>
+<% } %>
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-xl">

--- a/test/app/users/associateServices.post.test.js
+++ b/test/app/users/associateServices.post.test.js
@@ -115,6 +115,7 @@ describe("when adding services to a user", () => {
     expect(res.render.mock.calls[0][0]).toBe("users/views/associateServices");
     expect(res.render.mock.calls[0][1]).toEqual({
       csrfToken: "token",
+      layout: "sharedViews/layoutNew.ejs",
       name: "test name",
       backLink: "/users/user1/select-organisation",
       organisationDetails: {
@@ -187,6 +188,7 @@ describe("when adding services to a user", () => {
     expect(res.render.mock.calls[0][0]).toBe("users/views/associateServices");
     expect(res.render.mock.calls[0][1]).toEqual({
       csrfToken: "token",
+      layout: "sharedViews/layoutNew.ejs",
       name: "test name",
       backLink: "/users/user1/select-organisation",
       organisationDetails: {

--- a/test/app/users/postSelectOrganisation.test.js
+++ b/test/app/users/postSelectOrganisation.test.js
@@ -66,6 +66,7 @@ describe("when selecting an organisation", () => {
     expect(res.render.mock.calls[0][0]).toBe(`users/views/selectOrganisation`);
     expect(res.render.mock.calls[0][1]).toEqual({
       csrfToken: "token",
+      layout: "sharedViews/layoutNew.ejs",
       selectedOrganisation: undefined,
       organisations: [
         {


### PR DESCRIPTION
Link to ticket: [NSA-9013](https://dfe-secureaccess.atlassian.net/browse/NSA-9013)

The 'Add services' journey comprising of the following pages that use the old GDS style and need to be updated to use the new GDS style.Pages to be updated:
-  `/users/<uid>/select-organisation`
-  `/users/<uid>/organisations/<oid>`
 - `/users/<uid>/organisations/<oid>/services/<sid>`
 - `/users/<uid>/organisations/<oid>/confirm`
 
- Updated the status tags in `/organisations` to have colour coded status tags
- Fixed success banner width in /users
 -Added org requested rejection banner from user view