### PR TITLE
[NSA-9036] Add validation if no response types chosen

### DIFF
--- a/src/app/services/postServiceUrlsAndResponseType.js
+++ b/src/app/services/postServiceUrlsAndResponseType.js
@@ -164,6 +164,15 @@ const validateInput = async (req) => {
       "Log out redirect urls must all be unique";
   }
 
+  // Response types validation
+  if (
+    !model.responseTypesCode &&
+    !model.responseTypesToken &&
+    !model.responseTypesIdToken
+  ) {
+    model.validationMessages.responseTypes = "Select at least 1 response type";
+  }
+
   const isCodeOrIdTokenSelected =
     model.responseTypesCode || model.responseTypesIdToken;
   if (model.responseTypesToken && !isCodeOrIdTokenSelected) {

--- a/src/app/services/views/serviceUrlsAndResponseType.ejs
+++ b/src/app/services/views/serviceUrlsAndResponseType.ejs
@@ -158,10 +158,15 @@
           });
       %>
 
-        <div class="govuk-form-group">
+        <div id="responseTypes" class="govuk-form-group <%= (locals.validationMessages.responseTypes !== undefined) ? 'govuk-form-group--error' : '' %>">
           <label class="govuk-label" for="response_types-code">
             Response Types
           </label>
+          <% if (locals.validationMessages.responseTypes !== undefined) { %>
+            <p id="name-error" class="govuk-error-message">
+              <span class="govuk-visually-hidden">Error:</span><%= locals.validationMessages.responseTypes %>
+            </p>
+            <% } %>
           <fieldset class="govuk-fieldset" id="response_types-fieldset" aria-describedby="responseTypesCode-hint">
             <div id="responseTypesCode-hint" class="govuk-hint">
               A value that determines the authentication flow. Select all that apply

--- a/src/infrastructure/applications/api.js
+++ b/src/infrastructure/applications/api.js
@@ -25,9 +25,18 @@ const createService = async (body, correlationId) => {
     );
     return client;
   } catch (e) {
-    logger.error(`An error occurred when creating a new service, ${e}`, {
-      correlationId,
-    });
+    if (e.statusCode === 400) {
+      logger.error(
+        `A 400 error occurred when creating a new service, ${e.error.reasons}`,
+        {
+          correlationId,
+        },
+      );
+    } else {
+      logger.error(`An error occurred when creating a new service, ${e}`, {
+        correlationId,
+      });
+    }
     throw e;
   }
 };

--- a/src/infrastructure/applications/api.js
+++ b/src/infrastructure/applications/api.js
@@ -1,4 +1,5 @@
 const config = require("./../config");
+const logger = require("../logger");
 
 const { fetchApi } = require("login.dfe.async-retry");
 const jwtStrategy = require("login.dfe.jwt-strategies");
@@ -10,15 +11,25 @@ const createService = async (body, correlationId) => {
     return undefined;
   }
   const token = await jwtStrategy(config.applications.service).getBearerToken();
-  const client = await fetchApi(`${config.applications.service.url}/services`, {
-    method: "POST",
-    headers: {
-      authorization: `bearer ${token}`,
-      "x-correlation-id": correlationId,
-    },
-    body,
-  });
-  return client;
+  try {
+    const client = await fetchApi(
+      `${config.applications.service.url}/services`,
+      {
+        method: "POST",
+        headers: {
+          authorization: `bearer ${token}`,
+          "x-correlation-id": correlationId,
+        },
+        body,
+      },
+    );
+    return client;
+  } catch (e) {
+    logger.error(`An error occurred when creating a new service, ${e}`, {
+      correlationId,
+    });
+    throw e;
+  }
 };
 
 const getServiceById = async (id) => {

--- a/test/app/services/postServiceUrlsAndResponseType.test.js
+++ b/test/app/services/postServiceUrlsAndResponseType.test.js
@@ -124,39 +124,6 @@ describe("when displaying the post choose service type screen", () => {
     expect(sendResult).toHaveBeenCalledTimes(0);
   });
 
-  it("should discard client_secret, refresh_token and tokenEndpointAuthenticationMethod if response type code is not selected", async () => {
-    req.body["response_types-code"] = "";
-    req.body.refreshToken = "refresh_token";
-    req.body.clientSecret = "Test secret";
-    req.body.tokenEndpointAuthenticationMethod =
-      "tokenEndpointAuthenticationMethod";
-    await postServiceUrlsAndResponseType(req, res);
-
-    expect(res.redirect.mock.calls).toHaveLength(1);
-    expect(res.redirect.mock.calls[0][0]).toBe("confirm-new-service");
-    expect(req.session.createServiceData).toStrictEqual({
-      serviceType: "idOnlyServiceType",
-      name: "Test name",
-      description: "Test description",
-      homeUrl: "https://test-url.com/home",
-      postPasswordResetUrl: "https://test-url.com/post-password-reset",
-      clientId: "test-client-id",
-      service: {
-        postLogoutRedirectUris: ["https://test-url.com/log-out-redirect"],
-        redirectUris: ["https://test-url.com/redirect"],
-      },
-      responseTypesCode: "",
-      responseTypesIdToken: "",
-      responseTypesToken: "",
-      refreshToken: undefined,
-      clientSecret: "",
-      tokenEndpointAuthenticationMethod: undefined,
-      apiSecret: "api-secret",
-      validationMessages: {},
-    });
-    expect(sendResult).toHaveBeenCalledTimes(0);
-  });
-
   it("should render the page if there is an error saving to the session", async () => {
     req.session = {
       createServiceData: {
@@ -503,6 +470,26 @@ describe("when displaying the post choose service type screen", () => {
 
     exampleErrorResponse.validationMessages.responseTypesToken =
       "Select more than 1 response type when 'token' is selected as a response type";
+
+    await postServiceUrlsAndResponseType(req, res);
+
+    expect(sendResult).toHaveBeenCalledTimes(1);
+    expect(sendResult.mock.calls[0][3]).toStrictEqual(exampleErrorResponse);
+  });
+
+  it("should render an the page with an error in validationMessages if no response types selected", async () => {
+    req.body["response_types-code"] = "";
+    req.body["response_types-id_token"] = "";
+    req.body["response_types-token"] = "";
+
+    // These 3 aren't part of the test, but modifying these elements makes the test shorter in length
+    exampleErrorResponse.responseTypesCode = "";
+    exampleErrorResponse.responseTypesToken = "";
+    exampleErrorResponse.refreshToken = undefined;
+    exampleErrorResponse.clientSecret = "";
+
+    exampleErrorResponse.validationMessages.responseTypes =
+      "Select at least 1 response type";
 
     await postServiceUrlsAndResponseType(req, res);
 

--- a/test/app/services/postServiceUrlsAndResponseType.test.js
+++ b/test/app/services/postServiceUrlsAndResponseType.test.js
@@ -124,6 +124,40 @@ describe("when displaying the post choose service type screen", () => {
     expect(sendResult).toHaveBeenCalledTimes(0);
   });
 
+  it("should discard client_secret, refresh_token and tokenEndpointAuthenticationMethod if response type code is not selected", async () => {
+    req.body["response_types-code"] = "";
+    req.body["response_types-id_token"] = "response_types-idToken";
+    req.body.refreshToken = "refresh_token";
+    req.body.clientSecret = "Test secret";
+    req.body.tokenEndpointAuthenticationMethod =
+      "tokenEndpointAuthenticationMethod";
+    await postServiceUrlsAndResponseType(req, res);
+
+    expect(res.redirect.mock.calls).toHaveLength(1);
+    expect(res.redirect.mock.calls[0][0]).toBe("confirm-new-service");
+    expect(req.session.createServiceData).toStrictEqual({
+      serviceType: "idOnlyServiceType",
+      name: "Test name",
+      description: "Test description",
+      homeUrl: "https://test-url.com/home",
+      postPasswordResetUrl: "https://test-url.com/post-password-reset",
+      clientId: "test-client-id",
+      service: {
+        postLogoutRedirectUris: ["https://test-url.com/log-out-redirect"],
+        redirectUris: ["https://test-url.com/redirect"],
+      },
+      responseTypesCode: "",
+      responseTypesIdToken: "response_types-idToken",
+      responseTypesToken: "",
+      refreshToken: undefined,
+      clientSecret: "",
+      tokenEndpointAuthenticationMethod: undefined,
+      apiSecret: "api-secret",
+      validationMessages: {},
+    });
+    expect(sendResult).toHaveBeenCalledTimes(0);
+  });
+
   it("should render the page if there is an error saving to the session", async () => {
     req.session = {
       createServiceData: {


### PR DESCRIPTION
Previously, if you created a new service and didn't select a response type it would take you to the confirmation page.  Then when you confirmed you wanted to create the service, it would break with a generic error message.
With this PR, it validates that a response type is chosen, and if an error does occur during the service creation, it's a bit more verbose about what is actually the matter.