### PR TITLE
[DSI-7751] Prevent emails being sent to deactivated accounts 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2323,9 +2323,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha1-HtxFng8MVISG7Pn8mfIiE2S5oK4=",
+      "version": "2.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha1-VPxTI3phPYVMe9N0Y6rRffhyFOc=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2945,9 +2945,10 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+      "version": "1.1.12",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha1-q5tFRGblqMw6GHvqrVgEEqnFuEM=",
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -4602,9 +4603,10 @@
       }
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha1-HtxFng8MVISG7Pn8mfIiE2S5oK4=",
+      "version": "2.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha1-VPxTI3phPYVMe9N0Y6rRffhyFOc=",
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }

--- a/src/app/users/postDeleteOrganisation.js
+++ b/src/app/users/postDeleteOrganisation.js
@@ -64,8 +64,8 @@ const postDeleteOrganisation = async (req, res) => {
     }
     await deleteUserOrg(uid, req);
     if (isEmailAllowed) {
-      const getAllUserDetails = await getById(uid, req.id);
-      if (getAllUserDetails.statusId === 1) {
+      const userDetails = await getById(uid, req.id);
+      if (userDetails.statusId === 1) {
         const notificationClient = new NotificationClient({
           connectionString: config.notifications.connectionString,
         });

--- a/src/app/users/postDeleteOrganisation.js
+++ b/src/app/users/postDeleteOrganisation.js
@@ -14,6 +14,7 @@ const {
 const {
   getSearchDetailsForUserById,
   updateIndex,
+  getById,
 } = require("./../../infrastructure/search");
 const {
   isSupportEmailNotificationAllowed,
@@ -63,15 +64,18 @@ const postDeleteOrganisation = async (req, res) => {
     }
     await deleteUserOrg(uid, req);
     if (isEmailAllowed) {
-      const notificationClient = new NotificationClient({
-        connectionString: config.notifications.connectionString,
-      });
-      await notificationClient.sendUserRemovedFromOrganisation(
-        req.session.user.email,
-        req.session.user.firstName,
-        req.session.user.lastName,
-        req.session.org.name,
-      );
+      const getAllUserDetails = await getById(uid, req.id);
+      if (getAllUserDetails.statusId === 1) {
+        const notificationClient = new NotificationClient({
+          connectionString: config.notifications.connectionString,
+        });
+        await notificationClient.sendUserRemovedFromOrganisation(
+          req.session.user.email,
+          req.session.user.firstName,
+          req.session.user.lastName,
+          req.session.org.name,
+        );
+      }
     }
   }
 

--- a/src/infrastructure/search/api.js
+++ b/src/infrastructure/search/api.js
@@ -106,6 +106,24 @@ const getSearchDetailsForUserById = async (id) => {
   }
 };
 
+const getById = async (userId, correlationId) => {
+  const token = await jwtStrategy(config.search.service).getBearerToken();
+  try {
+    return await fetchApi(`${config.search.service.url}/users/${userId}`, {
+      method: "GET",
+      headers: {
+        authorization: `bearer ${token}`,
+        "x-correlation-id": correlationId,
+      },
+    });
+  } catch (e) {
+    if (e.statusCode === 404) {
+      return undefined;
+    }
+    throw e;
+  }
+};
+
 const updateUserInSearch = async (user, correlationId) => {
   const body = {
     pendingEmail: user.pendingEmail,
@@ -130,6 +148,7 @@ const createIndex = async (id, correlationId) => {
 module.exports = {
   searchForUsers,
   getSearchDetailsForUserById,
+  getById,
   updateUserInSearch,
   updateIndex,
   createIndex,


### PR DESCRIPTION
## Summary
Jira ticket: [DSI-7751](https://dfe-secureaccess.atlassian.net/browse/DSI-7751)

## Changes
- Add logic to prevent emails being sent to deactivated accounts.
- Improve test to check this condition.

## Related PRs:
- https://github.com/DFE-Digital/login.dfe.services/pull/643