### PR TITLE
[NSA-9198] Fix new service validation 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2323,9 +2323,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha1-HtxFng8MVISG7Pn8mfIiE2S5oK4=",
+      "version": "2.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha1-VPxTI3phPYVMe9N0Y6rRffhyFOc=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2945,9 +2945,10 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+      "version": "1.1.12",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha1-q5tFRGblqMw6GHvqrVgEEqnFuEM=",
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -4602,9 +4603,10 @@
       }
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha1-HtxFng8MVISG7Pn8mfIiE2S5oK4=",
+      "version": "2.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha1-VPxTI3phPYVMe9N0Y6rRffhyFOc=",
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }

--- a/src/app/services/postServiceUrlsAndResponseType.js
+++ b/src/app/services/postServiceUrlsAndResponseType.js
@@ -3,12 +3,11 @@ const { URL } = require("url");
 const logger = require("../../infrastructure/logger");
 const { getAllServices } = require("../../infrastructure/applications/api");
 
-// TODO maybe put this somewhere else?  was in a utils.js folder in manage
 /**
  * Determines if the url has an http: or https: protocol
  *
  * @param {URL} url A URL object
- * @returns true if the protocol is http: or https:.  False otherwise
+ * @returns true if the protocol is http: or https:.  false otherwise.
  */
 const isCorrectProtocol = (url) => {
   if (url && url.protocol !== "http:" && url.protocol !== "https:") {
@@ -167,50 +166,58 @@ const validateInput = async (req) => {
   }
 
   // Logout redirect urls validation
-  // TODO The form can be submitted when Logout redirect URL is blank (it should be mandatory)
   const logoutRedirectUris = model.service.postLogoutRedirectUris;
-  await Promise.all(
-    logoutRedirectUris.map(async (url) => {
-      if (url.length > 200) {
-        if (model.validationMessages.post_logout_redirect_uris !== undefined) {
-          model.validationMessages.post_logout_redirect_uris +=
-            "<br/>Log out redirect url must be 200 characters or less";
-        } else {
-          model.validationMessages.post_logout_redirect_uris =
-            "Log out redirect url must be 200 characters or less";
-        }
-      }
-      try {
-        const postLogoutRedirectUrl = new URL(url);
-        if (!isCorrectProtocol(postLogoutRedirectUrl)) {
+  if (!logoutRedirectUris || logoutRedirectUris.length === 0) {
+    model.validationMessages.post_logout_redirect_uris =
+      "Enter at least 1 logout redirect URL";
+  } else {
+    await Promise.all(
+      logoutRedirectUris.map(async (url) => {
+        if (url.length > 200) {
           if (
             model.validationMessages.post_logout_redirect_uris !== undefined
           ) {
             model.validationMessages.post_logout_redirect_uris +=
-              "<br/>Log out redirect url protocol can only be http or https";
+              "<br/>Log out redirect url must be 200 characters or less";
           } else {
             model.validationMessages.post_logout_redirect_uris =
-              "Log out redirect url protocol can only be http or https";
+              "Log out redirect url must be 200 characters or less";
           }
         }
-      } catch {
-        if (model.validationMessages.post_logout_redirect_uris !== undefined) {
-          model.validationMessages.post_logout_redirect_uris +=
-            "<br/>Log out redirect url must be a valid url";
-        } else {
-          model.validationMessages.post_logout_redirect_uris =
-            "Log out redirect url must be a valid url";
+        try {
+          const postLogoutRedirectUrl = new URL(url);
+          if (!isCorrectProtocol(postLogoutRedirectUrl)) {
+            if (
+              model.validationMessages.post_logout_redirect_uris !== undefined
+            ) {
+              model.validationMessages.post_logout_redirect_uris +=
+                "<br/>Log out redirect url protocol can only be http or https";
+            } else {
+              model.validationMessages.post_logout_redirect_uris =
+                "Log out redirect url protocol can only be http or https";
+            }
+          }
+        } catch {
+          if (
+            model.validationMessages.post_logout_redirect_uris !== undefined
+          ) {
+            model.validationMessages.post_logout_redirect_uris +=
+              "<br/>Log out redirect url must be a valid url";
+          } else {
+            model.validationMessages.post_logout_redirect_uris =
+              "Log out redirect url must be a valid url";
+          }
         }
-      }
-    }),
-  );
-  if (
-    logoutRedirectUris.some(
-      (value, i) => logoutRedirectUris.indexOf(value) !== i,
-    )
-  ) {
-    model.validationMessages.post_logout_redirect_uris =
-      "Log out redirect urls must all be unique";
+      }),
+    );
+    if (
+      logoutRedirectUris.some(
+        (value, i) => logoutRedirectUris.indexOf(value) !== i,
+      )
+    ) {
+      model.validationMessages.post_logout_redirect_uris =
+        "Log out redirect urls must all be unique";
+    }
   }
 
   // Response types validation

--- a/src/app/services/postServiceUrlsAndResponseType.js
+++ b/src/app/services/postServiceUrlsAndResponseType.js
@@ -81,22 +81,24 @@ const validateInput = async (req) => {
     }
   }
 
-  // TODO The maximum length of the URLs is not verified (max length should be 200 chars)
-  // TODO URLs should start with http
+  // Home url validation
   if (!model.homeUrl) {
     model.validationMessages.homeUrl = "Enter a home url";
-  } else if (model.homeUrl.length > 1024) {
+  } else if (model.homeUrl.length > 200) {
     model.validationMessages.homeUrl =
-      "Home url must be 1024 characters or less";
+      "Home url must be 200 characters or less";
   } else {
     try {
-      new URL(model.homeUrl);
+      const homeUrl = new URL(model.homeUrl);
+      if (!isCorrectProtocol(homeUrl)) {
+        model.validationMessages.homeUrl =
+          "Home url protocol can only be http or https";
+      }
     } catch {
       model.validationMessages.homeUrl = "Home url must be a valid url";
     }
   }
 
-  // TODO Client ID must only contain letters a to z, hyphens and numbers
   if (!model.clientId) {
     model.validationMessages.clientId = "Enter a client id";
   } else if (model.clientId.length > 50) {
@@ -117,8 +119,6 @@ const validateInput = async (req) => {
   }
 
   // Redirect url validation
-  // TODO The maximum length of the URLs is not verified (max length should be 200 chars)
-  // TODO URLs should start with http
   const redirectUris = model.service.redirectUris;
   const areRedirectUrisNotPopulated =
     !redirectUris ||
@@ -130,17 +130,26 @@ const validateInput = async (req) => {
   } else {
     await Promise.all(
       redirectUris.map(async (url) => {
-        if (url.length > 1024) {
+        if (url.length > 200) {
           if (model.validationMessages.redirect_uris !== undefined) {
             model.validationMessages.redirect_uris +=
-              "<br/>Redirect url must be 1024 characters or less";
+              "<br/>Redirect url must be 200 characters or less";
           } else {
             model.validationMessages.redirect_uris =
-              "Redirect url must be 1024 characters or less";
+              "Redirect url must be 200 characters or less";
           }
         }
         try {
-          new URL(url);
+          const redirectUri = new URL(url);
+          if (!isCorrectProtocol(redirectUri)) {
+            if (model.validationMessages.redirect_uris !== undefined) {
+              model.validationMessages.redirect_uris +=
+                "<br/>Redirect uri protocol can only be http or https";
+            } else {
+              model.validationMessages.redirect_uris =
+                "Redirect uri protocol can only be http or https";
+            }
+          }
         } catch {
           if (model.validationMessages.redirect_uris !== undefined) {
             model.validationMessages.redirect_uris +=
@@ -158,23 +167,32 @@ const validateInput = async (req) => {
   }
 
   // Logout redirect urls validation
-  //The form can be submitted when Logout redirect URL is blank (it should be mandatory)
-  // TODO The maximum length of the URLs is not verified (max length should be 200 chars)
-  // TODO URLs should start with http
+  // TODO The form can be submitted when Logout redirect URL is blank (it should be mandatory)
   const logoutRedirectUris = model.service.postLogoutRedirectUris;
   await Promise.all(
     logoutRedirectUris.map(async (url) => {
-      if (url.length > 1024) {
+      if (url.length > 200) {
         if (model.validationMessages.post_logout_redirect_uris !== undefined) {
           model.validationMessages.post_logout_redirect_uris +=
-            "<br/>Log out redirect url must be 1024 characters or less";
+            "<br/>Log out redirect url must be 200 characters or less";
         } else {
           model.validationMessages.post_logout_redirect_uris =
-            "Log out redirect url must be 1024 characters or less";
+            "Log out redirect url must be 200 characters or less";
         }
       }
       try {
-        new URL(url);
+        const postLogoutRedirectUrl = new URL(url);
+        if (!isCorrectProtocol(postLogoutRedirectUrl)) {
+          if (
+            model.validationMessages.post_logout_redirect_uris !== undefined
+          ) {
+            model.validationMessages.post_logout_redirect_uris +=
+              "<br/>Log out redirect url protocol can only be http or https";
+          } else {
+            model.validationMessages.post_logout_redirect_uris =
+              "Log out redirect url protocol can only be http or https";
+          }
+        }
       } catch {
         if (model.validationMessages.post_logout_redirect_uris !== undefined) {
           model.validationMessages.post_logout_redirect_uris +=

--- a/test/app/services/postServiceUrlsAndResponseType.test.js
+++ b/test/app/services/postServiceUrlsAndResponseType.test.js
@@ -226,11 +226,13 @@ describe("when displaying the post choose service type screen", () => {
     expect(sendResult.mock.calls[0][3]).toStrictEqual(exampleErrorResponse);
   });
 
-  it("should render an the page with an error in validationMessages if postPasswordResetUrl over 1024 characters", async () => {
-    req.body.postPasswordResetUrl = "Test123456".repeat(125); // 1250 character length string
-    exampleErrorResponse.postPasswordResetUrl = "Test123456".repeat(125); // 1250 character length string
+  it("should render an the page with an error in validationMessages if postPasswordResetUrl over 200 characters", async () => {
+    req.body.postPasswordResetUrl =
+      "https://" + "Test123456".repeat(30) + ".com"; // 300+ character length string
+    exampleErrorResponse.postPasswordResetUrl =
+      "https://" + "Test123456".repeat(30) + ".com"; // 300+ character length string
     exampleErrorResponse.validationMessages.postPasswordResetUrl =
-      "Post password reset url must be 1024 characters or less";
+      "Post password reset url must be 200 characters or less";
 
     await postServiceUrlsAndResponseType(req, res);
 
@@ -243,6 +245,18 @@ describe("when displaying the post choose service type screen", () => {
     exampleErrorResponse.postPasswordResetUrl = "anInvalidUrl@slbsh!!!$$%";
     exampleErrorResponse.validationMessages.postPasswordResetUrl =
       "Post password reset url must be a valid url";
+
+    await postServiceUrlsAndResponseType(req, res);
+
+    expect(sendResult).toHaveBeenCalledTimes(1);
+    expect(sendResult.mock.calls[0][3]).toStrictEqual(exampleErrorResponse);
+  });
+
+  it("should render an the page with an error in validationMessages if a postPasswordResetUrl with an invalid protocol is entered", async () => {
+    req.body.postPasswordResetUrl = "ftp://a-valid-url.com/valid";
+    exampleErrorResponse.postPasswordResetUrl = "ftp://a-valid-url.com/valid";
+    exampleErrorResponse.validationMessages.postPasswordResetUrl =
+      "Post password reset url protocol can only be http or https";
 
     await postServiceUrlsAndResponseType(req, res);
 
@@ -301,6 +315,18 @@ describe("when displaying the post choose service type screen", () => {
     exampleErrorResponse.clientId = "Test123456".repeat(6); // 60 character length string
     exampleErrorResponse.validationMessages.clientId =
       "Client id must be 50 characters or less";
+
+    await postServiceUrlsAndResponseType(req, res);
+
+    expect(sendResult).toHaveBeenCalledTimes(1);
+    expect(sendResult.mock.calls[0][3]).toStrictEqual(exampleErrorResponse);
+  });
+
+  it("should render an the page with an error in validationMessages if clientId contains non-hypen and non-alphanumeric characters", async () => {
+    req.body.clientId = "Test123!&^%*";
+    exampleErrorResponse.clientId = "Test123!&^%*";
+    exampleErrorResponse.validationMessages.clientId =
+      "Client ID must only contain letters a to z, hyphens and numbers";
 
     await postServiceUrlsAndResponseType(req, res);
 

--- a/test/app/services/postServiceUrlsAndResponseType.test.js
+++ b/test/app/services/postServiceUrlsAndResponseType.test.js
@@ -114,16 +114,6 @@ describe("when displaying the post choose service type screen", () => {
     expect(sendResult).toHaveBeenCalledTimes(0);
   });
 
-  it("should redirect to the service urls and response type page on success with no logout redirect urls", async () => {
-    req.body.post_logout_redirect_uris = undefined;
-
-    await postServiceUrlsAndResponseType(req, res);
-
-    expect(res.redirect.mock.calls).toHaveLength(1);
-    expect(res.redirect.mock.calls[0][0]).toBe("confirm-new-service");
-    expect(sendResult).toHaveBeenCalledTimes(0);
-  });
-
   it("should discard client_secret, refresh_token and tokenEndpointAuthenticationMethod if response type code is not selected", async () => {
     req.body["response_types-code"] = "";
     req.body["response_types-id_token"] = "response_types-idToken";
@@ -359,6 +349,7 @@ describe("when displaying the post choose service type screen", () => {
     expect(sendResult.mock.calls[0][3]).toStrictEqual(exampleErrorResponse);
   });
 
+  // redirectUrl tests
   it("should render an the page with an error in validationMessages if no redirectUrl is entered", async () => {
     req.body.redirect_uris = "";
     exampleErrorResponse.service.redirectUris = [];
@@ -465,6 +456,19 @@ describe("when displaying the post choose service type screen", () => {
     ];
     exampleErrorResponse.validationMessages.redirect_uris =
       "Redirect urls must all be unique";
+
+    await postServiceUrlsAndResponseType(req, res);
+
+    expect(sendResult).toHaveBeenCalledTimes(1);
+    expect(sendResult.mock.calls[0][3]).toStrictEqual(exampleErrorResponse);
+  });
+
+  // logOutRedirectUrl tests
+  it("should render an the page with an error in validationMessages if logOutRedirectUrl is empty", async () => {
+    req.body.post_logout_redirect_uris = undefined;
+    exampleErrorResponse.service.postLogoutRedirectUris = [];
+    exampleErrorResponse.validationMessages.post_logout_redirect_uris =
+      "Enter at least 1 logout redirect URL";
 
     await postServiceUrlsAndResponseType(req, res);
 

--- a/test/app/services/postServiceUrlsAndResponseType.test.js
+++ b/test/app/services/postServiceUrlsAndResponseType.test.js
@@ -276,10 +276,11 @@ describe("when displaying the post choose service type screen", () => {
   });
 
   it("should render an the page with an error in validationMessages if homeUrl over 1024 characters", async () => {
-    req.body.homeUrl = "Test123456".repeat(125); // 1250 character length string
-    exampleErrorResponse.homeUrl = "Test123456".repeat(125); // 1250 character length string
+    req.body.homeUrl = "https://" + "Test123456".repeat(30) + ".com"; // 300+ character length string
+    exampleErrorResponse.homeUrl =
+      "https://" + "Test123456".repeat(30) + ".com"; // 300+ character length string
     exampleErrorResponse.validationMessages.homeUrl =
-      "Home url must be 1024 characters or less";
+      "Home url must be 200 characters or less";
 
     await postServiceUrlsAndResponseType(req, res);
 
@@ -292,6 +293,18 @@ describe("when displaying the post choose service type screen", () => {
     exampleErrorResponse.homeUrl = "anInvalidUrl@slbsh!$$%";
     exampleErrorResponse.validationMessages.homeUrl =
       "Home url must be a valid url";
+
+    await postServiceUrlsAndResponseType(req, res);
+
+    expect(sendResult).toHaveBeenCalledTimes(1);
+    expect(sendResult.mock.calls[0][3]).toStrictEqual(exampleErrorResponse);
+  });
+
+  it("should render an the page with an error in validationMessages if a homeUrl with an invalid protocol is entered", async () => {
+    req.body.homeUrl = "ftp://a-valid-url.com/valid";
+    exampleErrorResponse.homeUrl = "ftp://a-valid-url.com/valid";
+    exampleErrorResponse.validationMessages.homeUrl =
+      "Home url protocol can only be http or https";
 
     await postServiceUrlsAndResponseType(req, res);
 
@@ -358,13 +371,13 @@ describe("when displaying the post choose service type screen", () => {
     expect(sendResult.mock.calls[0][3]).toStrictEqual(exampleErrorResponse);
   });
 
-  it("should render an the page with an error in validationMessages if redirectUrl over 1024 characters", async () => {
-    req.body.redirect_uris = "https://" + "Test123456".repeat(125) + ".com"; // 1250 character length string
+  it("should render an the page with an error in validationMessages if redirectUrl over 200 characters", async () => {
+    req.body.redirect_uris = "https://" + "Test123456".repeat(30) + ".com"; // 300+ character length string
     exampleErrorResponse.service.redirectUris = [
-      "https://" + "Test123456".repeat(125) + ".com",
-    ]; // 1250 character length string
+      "https://" + "Test123456".repeat(30) + ".com",
+    ]; // 300+ character length string
     exampleErrorResponse.validationMessages.redirect_uris =
-      "Redirect url must be 1024 characters or less";
+      "Redirect url must be 200 characters or less";
 
     await postServiceUrlsAndResponseType(req, res);
 
@@ -372,17 +385,17 @@ describe("when displaying the post choose service type screen", () => {
     expect(sendResult.mock.calls[0][3]).toStrictEqual(exampleErrorResponse);
   });
 
-  it("should render an the page with multiple errors in validationMessages if redirectUrl over 1024 characters", async () => {
+  it("should render an the page with multiple errors in validationMessages if redirectUrl over 200 characters", async () => {
     req.body.redirect_uris = [
       "invalidurl123",
-      "https://" + "Test123456".repeat(125) + ".com",
-    ]; // 1250 character length string
+      "https://" + "Test123456".repeat(30) + ".com",
+    ]; // 300+ character length string
     exampleErrorResponse.service.redirectUris = [
       "invalidurl123",
-      "https://" + "Test123456".repeat(125) + ".com",
-    ]; // 1250 character length string
+      "https://" + "Test123456".repeat(30) + ".com",
+    ]; // 300+ character length string
     exampleErrorResponse.validationMessages.redirect_uris =
-      "Redirect url must be a valid url<br/>Redirect url must be 1024 characters or less";
+      "Redirect url must be a valid url<br/>Redirect url must be 200 characters or less";
 
     await postServiceUrlsAndResponseType(req, res);
 
@@ -417,6 +430,33 @@ describe("when displaying the post choose service type screen", () => {
     expect(sendResult.mock.calls[0][3]).toStrictEqual(exampleErrorResponse);
   });
 
+  it("should render an the page with an error in validationMessages if redirectUrl with an invalid protocol is entered", async () => {
+    req.body.redirect_uris = "ftp://valid-url-com/valid";
+    exampleErrorResponse.service.redirectUris = ["ftp://valid-url-com/valid"];
+    exampleErrorResponse.validationMessages.redirect_uris =
+      "Redirect uri protocol can only be http or https";
+
+    await postServiceUrlsAndResponseType(req, res);
+
+    expect(sendResult).toHaveBeenCalledTimes(1);
+    expect(sendResult.mock.calls[0][3]).toStrictEqual(exampleErrorResponse);
+  });
+
+  it("should render an the page with multiple errors in validationMessages if redirectUrl with an invalid protocol is entered", async () => {
+    req.body.redirect_uris = ["invalidurl123", "ftp://valid-url-com/valid"];
+    exampleErrorResponse.service.redirectUris = [
+      "invalidurl123",
+      "ftp://valid-url-com/valid",
+    ];
+    exampleErrorResponse.validationMessages.redirect_uris =
+      "Redirect url must be a valid url<br/>Redirect uri protocol can only be http or https";
+
+    await postServiceUrlsAndResponseType(req, res);
+
+    expect(sendResult).toHaveBeenCalledTimes(1);
+    expect(sendResult.mock.calls[0][3]).toStrictEqual(exampleErrorResponse);
+  });
+
   it("should render an the page with an error in validationMessages if a multiple identical redirectUrl are entered", async () => {
     req.body.redirect_uris = ["https://validurl.com", "https://validurl.com"];
     exampleErrorResponse.service.redirectUris = [
@@ -434,12 +474,12 @@ describe("when displaying the post choose service type screen", () => {
 
   it("should render an the page with an error in validationMessages if logOutRedirectUrl over 1024 characters", async () => {
     req.body.post_logout_redirect_uris =
-      "https://" + "Test123456".repeat(125) + ".com"; // 1250 character length string
+      "https://" + "Test123456".repeat(30) + ".com"; // 300+ character length string
     exampleErrorResponse.service.postLogoutRedirectUris = [
-      "https://" + "Test123456".repeat(125) + ".com",
-    ]; // 1250 character length string
+      "https://" + "Test123456".repeat(30) + ".com",
+    ]; // 300+ character length string
     exampleErrorResponse.validationMessages.post_logout_redirect_uris =
-      "Log out redirect url must be 1024 characters or less";
+      "Log out redirect url must be 200 characters or less";
 
     await postServiceUrlsAndResponseType(req, res);
 
@@ -450,14 +490,14 @@ describe("when displaying the post choose service type screen", () => {
   it("should render an the page with an error in validationMessages if multiple errors, including logOutRedirectUrl over 1024 characters", async () => {
     req.body.post_logout_redirect_uris = [
       "invalidurl123",
-      "https://" + "Test123456".repeat(125) + ".com",
-    ]; // 1250 character length string
+      "https://" + "Test123456".repeat(30) + ".com",
+    ]; // 300+ character length string
     exampleErrorResponse.service.postLogoutRedirectUris = [
       "invalidurl123",
-      "https://" + "Test123456".repeat(125) + ".com",
-    ]; // 1250 character length string
+      "https://" + "Test123456".repeat(30) + ".com",
+    ]; // 300+ character length string
     exampleErrorResponse.validationMessages.post_logout_redirect_uris =
-      "Log out redirect url must be a valid url<br/>Log out redirect url must be 1024 characters or less";
+      "Log out redirect url must be a valid url<br/>Log out redirect url must be 200 characters or less";
 
     await postServiceUrlsAndResponseType(req, res);
 
@@ -490,6 +530,38 @@ describe("when displaying the post choose service type screen", () => {
     ];
     exampleErrorResponse.validationMessages.post_logout_redirect_uris =
       "Log out redirect url must be a valid url";
+
+    await postServiceUrlsAndResponseType(req, res);
+
+    expect(sendResult).toHaveBeenCalledTimes(1);
+    expect(sendResult.mock.calls[0][3]).toStrictEqual(exampleErrorResponse);
+  });
+
+  it("should render an the page with an error in validationMessages if logOutRedirectUrl with an invalid protocol is entered", async () => {
+    req.body.post_logout_redirect_uris = "ftp://valid-url-com/valid";
+    exampleErrorResponse.service.postLogoutRedirectUris = [
+      "ftp://valid-url-com/valid",
+    ];
+    exampleErrorResponse.validationMessages.post_logout_redirect_uris =
+      "Log out redirect url protocol can only be http or https";
+
+    await postServiceUrlsAndResponseType(req, res);
+
+    expect(sendResult).toHaveBeenCalledTimes(1);
+    expect(sendResult.mock.calls[0][3]).toStrictEqual(exampleErrorResponse);
+  });
+
+  it("should render an the page with multiple errors in validationMessages if logOutRedirectUrl with an invalid protocol is entered", async () => {
+    req.body.post_logout_redirect_uris = [
+      "invalidurl123",
+      "ftp://valid-url-com/valid",
+    ];
+    exampleErrorResponse.service.postLogoutRedirectUris = [
+      "invalidurl123",
+      "ftp://valid-url-com/valid",
+    ];
+    exampleErrorResponse.validationMessages.post_logout_redirect_uris =
+      "Log out redirect url must be a valid url<br/>Log out redirect url protocol can only be http or https";
 
     await postServiceUrlsAndResponseType(req, res);
 


### PR DESCRIPTION
Fixes the following:

- The form can be submitted when Logout redirect URL is blank (it should be mandatory)
- The maximum length of the URLs is not verified (max length should be 200 chars)
- URLs should start with http
- Client ID must only contain letters a to z, hyphens and numbers