### PR TITLE
[NSA-8974] Fix organisations not clearing in invite journey

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
             "skipFiles": [
                 "<node_internals>/**"
             ],
-            "envFile": "${workspaceFolder}/.env",
+            "envFile": "${workspaceFolder}/../.env",
             "env": {
                 "settings": "${workspaceFolder}/config/local-config.json",
                 "NODE_TLS_REJECT_UNAUTHORIZED": "0"

--- a/src/app/users/getAssociateOrganisation.js
+++ b/src/app/users/getAssociateOrganisation.js
@@ -1,16 +1,34 @@
+const logger = require("./../../infrastructure/logger");
+
 const getAssociateOrganisation = async (req, res) => {
-  res.render("users/views/associateOrganisation", {
-    csrfToken: req.csrfToken(),
-    layout: "sharedViews/layoutNew.ejs",
-    backLink: true,
-    criteria: "",
-    results: undefined,
-    page: 1,
-    numberOfPages: 1,
-    numberOfResults: 1,
-    firstRecordNumber: 1,
-    lastRecordNumber: 1,
-    canSkip: req.params.uid ? false : true,
+  delete req.session.user.organisationId;
+  delete req.session.user.organisationName;
+  delete req.session.user.permission;
+
+  req.session.save((error) => {
+    if (error) {
+      // Simply report that the error happened but continue as it only matters in one
+      // uncommon journey (pick an org, confirm user, click back, press skip this step)
+      logger.error(
+        "Something went wrong saving the session when clearing user invite organisation details",
+        error,
+      );
+      res.flash("info", "Failed to clear invited user organisation details");
+    }
+
+    res.render("users/views/associateOrganisation", {
+      csrfToken: req.csrfToken(),
+      layout: "sharedViews/layoutNew.ejs",
+      backLink: true,
+      criteria: "",
+      results: undefined,
+      page: 1,
+      numberOfPages: 1,
+      numberOfResults: 1,
+      firstRecordNumber: 1,
+      lastRecordNumber: 1,
+      canSkip: req.params.uid ? false : true,
+    });
   });
 };
 

--- a/test/app/users/getAssociateOrganisation.test.js
+++ b/test/app/users/getAssociateOrganisation.test.js
@@ -1,0 +1,131 @@
+jest.mock("./../../../src/infrastructure/config", () =>
+  require("../../utils").configMockFactory({}),
+);
+
+const { getRequestMock } = require("../../utils");
+const getAssociateOrganisation = require("../../../src/app/users/getAssociateOrganisation");
+
+describe("When calling the getAssociateOrganisation function", () => {
+  let req;
+  let res;
+
+  beforeEach(() => {
+    req = getRequestMock({
+      session: {
+        user: {
+          email: "test@education.gov.uk",
+          firstName: "Test",
+          lastName: "User",
+        },
+        save: jest.fn((cb) => cb()),
+      },
+    });
+
+    res = {
+      render: jest.fn(),
+      flash: jest.fn(),
+    };
+  });
+
+  it("renders users/views/associateOrganisation on success", async () => {
+    await getAssociateOrganisation(req, res);
+
+    expect(res.render.mock.calls[0][0]).toBe(
+      "users/views/associateOrganisation",
+    );
+    expect(res.render.mock.calls[0][1]).toMatchObject({
+      csrfToken: "token",
+      layout: "sharedViews/layoutNew.ejs",
+      backLink: true,
+      criteria: "",
+      results: undefined,
+      page: 1,
+      numberOfPages: 1,
+      numberOfResults: 1,
+      firstRecordNumber: 1,
+      lastRecordNumber: 1,
+      canSkip: true,
+    });
+
+    expect(req.session).toMatchObject({
+      user: {
+        email: "test@education.gov.uk",
+        firstName: "Test",
+        lastName: "User",
+      },
+    });
+  });
+
+  it("deletes organisation and permission data if present", async () => {
+    ((req.session.user = {
+      email: "test@education.gov.uk",
+      firstName: "Test",
+      lastName: "User",
+      organisationName: "Test org",
+      organisationId: "Test id",
+      permission: "Test permission",
+    }),
+      await getAssociateOrganisation(req, res));
+
+    expect(res.render.mock.calls[0][0]).toBe(
+      "users/views/associateOrganisation",
+    );
+    expect(res.render.mock.calls[0][1]).toMatchObject({
+      csrfToken: "token",
+      layout: "sharedViews/layoutNew.ejs",
+      backLink: true,
+      criteria: "",
+      results: undefined,
+      page: 1,
+      numberOfPages: 1,
+      numberOfResults: 1,
+      firstRecordNumber: 1,
+      lastRecordNumber: 1,
+      canSkip: true,
+    });
+
+    expect(req.session).toMatchObject({
+      user: {
+        email: "test@education.gov.uk",
+        firstName: "Test",
+        lastName: "User",
+      },
+    });
+  });
+
+  it("renders the page with an error if an error occurs during the session.save", async () => {
+    const testReq = getRequestMock({
+      session: {
+        user: {
+          email: "test@education.gov.uk",
+          firstName: "Test",
+          lastName: "User",
+        },
+        save: jest.fn((cb) => cb("Something went wrong")),
+      },
+    });
+
+    await getAssociateOrganisation(testReq, res);
+
+    expect(res.render.mock.calls[0][0]).toBe(
+      "users/views/associateOrganisation",
+    );
+    expect(res.render.mock.calls[0][1]).toMatchObject({
+      csrfToken: "token",
+      layout: "sharedViews/layoutNew.ejs",
+      backLink: true,
+      criteria: "",
+      results: undefined,
+      page: 1,
+      numberOfPages: 1,
+      numberOfResults: 1,
+      firstRecordNumber: 1,
+      lastRecordNumber: 1,
+      canSkip: true,
+    });
+    expect(res.flash.mock.calls[0][0]).toBe("info");
+    expect(res.flash.mock.calls[0][1]).toBe(
+      "Failed to clear invited user organisation details",
+    );
+  });
+});


### PR DESCRIPTION
In the user invite journey when you did the following:
- Pick an org and permissions for user
- Get to the user confirm screen
- Click back
- Click 'skip this step'

Then on the user confirm screen, the organisation you originally picked would still be there.  This has been fixed, by always clearing the picked org if we're on the associate org screen.  The thinking is, if you're on this screen, then you're about to pick an org or skip it, so any previous choices you make should be cleared