### PR TITLE
[NSA-9283] Add new subtype to audit

### DIFF
--- a/src/app/services/postServiceNameAndDescription.js
+++ b/src/app/services/postServiceNameAndDescription.js
@@ -26,9 +26,9 @@ const validateInput = async (req) => {
 
   if (!model.description) {
     model.validationMessages.description = "Enter a description";
-  } else if (model.description.length > 200) {
+  } else if (model.description.length > 400) {
     model.validationMessages.description =
-      "Description must be 200 characters or less";
+      "Description must be 400 characters or less";
   }
 
   return model;

--- a/src/app/services/views/serviceNameAndDescription.ejs
+++ b/src/app/services/views/serviceNameAndDescription.ejs
@@ -45,7 +45,7 @@
           <textarea class="govuk-textarea govuk-js-character-count <%= (locals.validationMessages.description !== undefined) ? 'govuk-textarea--error' : '' %>"
             id="description" name="description" rows="5" aria-describedby="description-info <%= (locals.validationMessages.description !== undefined) ? 'description-error' : '' %>"><%= locals.description %></textarea>
           <div id="description-info" class="govuk-hint govuk-character-count__message">
-            You can enter up to 350 characters
+            You can enter up to 400 characters
           </div>
         </div>
         <div class="govuk-button-group">

--- a/src/app/users/getAudit.js
+++ b/src/app/users/getAudit.js
@@ -49,6 +49,7 @@ const describeAuditEvent = async (audit, req) => {
   }
 
   if (
+    audit.subType === "service-info-edit" ||
     audit.subType === "user-service-deleted" ||
     audit.subType === "user-service-added" ||
     audit.subType === "user-services-added" ||

--- a/test/app/services/postServiceNameAndDescription.test.js
+++ b/test/app/services/postServiceNameAndDescription.test.js
@@ -137,11 +137,11 @@ describe("when displaying the post choose service type screen", () => {
     expect(sendResult.mock.calls[0][3]).toStrictEqual(exampleErrorResponse);
   });
 
-  it("should render an the page with an error in validationMessages if description over 200 characters", async () => {
-    req.body.description = "Test123456".repeat(21); // 210 character length string
-    exampleErrorResponse.description = "Test123456".repeat(21); // 210 character length string
+  it("should render an the page with an error in validationMessages if description over 400 characters", async () => {
+    req.body.description = "Test123456".repeat(41); // 410 character length string
+    exampleErrorResponse.description = "Test123456".repeat(41); // 410 character length string
     exampleErrorResponse.validationMessages.description =
-      "Description must be 200 characters or less";
+      "Description must be 400 characters or less";
 
     await postServiceNameAndDescription(req, res);
 

--- a/test/app/users/getAudit.test.js
+++ b/test/app/users/getAudit.test.js
@@ -161,19 +161,28 @@ describe("when getting users audit details", () => {
   it("then it should send result using audit view", async () => {
     await getAudit(req, res);
 
+    expect(getUserDetailsById.mock.calls).toHaveLength(1);
+    expect(getUserDetailsById.mock.calls[0][0]).toBe(req.params.uid);
+
     expect(sendResult.mock.calls).toHaveLength(1);
     expect(sendResult.mock.calls[0][0]).toBe(req);
     expect(sendResult.mock.calls[0][1]).toBe(res);
     expect(sendResult.mock.calls[0][2]).toBe("users/views/audit");
-  });
-
-  it("then it should include csrf token in model", async () => {
-    await getAudit(req, res);
 
     expect(sendResult.mock.calls[0][3]).toMatchObject({
       csrfToken: "token",
+      numberOfPages: 3,
+      totalNumberOfResults: 56,
+      user: {
+        id: "user1",
+        status: {
+          id: 1,
+          description: "Activated",
+        },
+      },
     });
   });
+
   it("should set the backlink to /organisations if the search type session param is organisations", async () => {
     await getAudit(req, res);
 
@@ -187,28 +196,6 @@ describe("when getting users audit details", () => {
 
     expect(sendResult.mock.calls[0][3]).toMatchObject({
       backLink: "/users",
-    });
-  });
-
-  it("then it should include user details in model", async () => {
-    await getAudit(req, res);
-
-    expect(sendResult.mock.calls[0][3]).toMatchObject({
-      user: {
-        id: "user1",
-        status: {
-          id: 1,
-          description: "Activated",
-        },
-      },
-    });
-  });
-
-  it("then it should include number of pages of audits in model", async () => {
-    await getAudit(req, res);
-
-    expect(sendResult.mock.calls[0][3]).toMatchObject({
-      numberOfPages: 3,
     });
   });
 
@@ -322,21 +309,6 @@ describe("when getting users audit details", () => {
     expect(sendResult.mock.calls[0][3]).toMatchObject({
       page: 3,
     });
-  });
-
-  it("then it should include total number of records in model", async () => {
-    await getAudit(req, res);
-
-    expect(sendResult.mock.calls[0][3]).toMatchObject({
-      totalNumberOfResults: 56,
-    });
-  });
-
-  it("then it should get user details", async () => {
-    await getAudit(req, res);
-
-    expect(getUserDetailsById.mock.calls).toHaveLength(1);
-    expect(getUserDetailsById.mock.calls[0][0]).toBe(req.params.uid);
   });
 
   it("then it should get page of audits using page 1 if page not specified", async () => {


### PR DESCRIPTION
Also updated description length to 400.  This card was about adding the ability to edit name and description for a service and we found there was one that had 394 characters for a description, so we set a number near that as the limit.
While we were modifying it in manage, we also figured we should align it in support as well to make sure they're not saying different things.