### PR TITLE
[DSI-7992] Bug fix for Access Api Centralisation

### DIFF
--- a/src/app/users/getManageConsoleRoles.js
+++ b/src/app/users/getManageConsoleRoles.js
@@ -26,7 +26,7 @@ const getSingleServiceForUser = async (
 
   return {
     id: serviceId,
-    roles: userService === undefined ? [] : userService.roles,
+    roles: userService?.roles ?? [],
     name: application.name,
   };
 };

--- a/test/app/users/getManageConsoleRoles.test.js
+++ b/test/app/users/getManageConsoleRoles.test.js
@@ -41,6 +41,48 @@ jest.mock("./../../../src/infrastructure/access", () => ({
 
 describe("when manage a users manage console roles", () => {
   describe("when displaying manage console role assignment options", () => {
+    it("should assign roles as an empty array when getInvitationServiceRaw returns 'undefined'", async () => {
+      const {
+        getServiceById,
+      } = require("./../../../src/infrastructure/applications");
+      const {
+        getInvitationServiceRaw,
+      } = require("login.dfe.api-client/invitations");
+      getServiceById.mockResolvedValue({ name: "Test Service" });
+      getInvitationServiceRaw.mockResolvedValue(undefined);
+      const result = await getSingleServiceForUser(
+        "inv-user-id",
+        "org-id",
+        "service-id",
+        "correlation-id",
+      );
+      expect(result).toEqual({
+        id: "service-id",
+        roles: [],
+        name: "Test Service",
+      });
+    });
+
+    it("should assign roles as an empty array when getUserServiceRaw returns 'null'", async () => {
+      const {
+        getServiceById,
+      } = require("./../../../src/infrastructure/applications");
+      const { getUserServiceRaw } = require("login.dfe.api-client/users");
+      getServiceById.mockResolvedValue({ name: "Test Service" });
+      getUserServiceRaw.mockResolvedValue(null);
+      const result = await getSingleServiceForUser(
+        "user-id",
+        "org-id",
+        "service-id",
+        "correlation-id",
+      );
+      expect(result).toEqual({
+        id: "service-id",
+        roles: [],
+        name: "Test Service",
+      });
+    });
+
     it("should return service details for a user", async () => {
       const {
         getServiceById,


### PR DESCRIPTION
### Summary
Jira ticket: https://dfe-secureaccess.atlassian.net/browse/DSI-7992?focusedCommentId=54838

### Changes
The original implementation of `getSingleServiceForUser` would return `undefined` if the Access Api returned a 404, whereas ApiClient returns `null`. Therefore, updated the code to use a `nullish coalescing operator` which resolves the issue, by ensuring that the returned role value is an allocated array.