### PR TITLE
[NSA-9377] Update checkbox label in deactivate user page

### DIFF
--- a/src/app/users/views/bulkUserActionsEmails.ejs
+++ b/src/app/users/views/bulkUserActionsEmails.ejs
@@ -88,7 +88,7 @@
                             <div class="govuk-checkboxes__item">
                                 <input class="govuk-checkboxes__input" id="remove-services-and-requests" name="remove-services-and-requests" type="checkbox" value="remove-services-and-requests">
                                 <label class="govuk-label govuk-checkboxes__label" for="remove-services-and-requests">
-                                Remove services and requests
+                                Remove services and reject requests
                                 </label>
                             </div>
                         </div>

--- a/src/app/users/views/confirmDeactivate.ejs
+++ b/src/app/users/views/confirmDeactivate.ejs
@@ -33,7 +33,7 @@
                         <div class="govuk-checkboxes__item">
                             <input class="govuk-checkboxes__input" name="remove-services-and-requests" value="remove-services-and-requests" id="remove-services-and-requests" type="checkbox">
                             <label class="govuk-label govuk-checkboxes__label govuk-!-padding-top-0" for="remove-services-and-requests">
-                                Tick this checkbox to remove <strong>all services and requests for the user</strong>
+                                Tick this checkbox to <strong>remove all services and reject requests for the user</strong>
                             </label>
                         </div>
                     </div>


### PR DESCRIPTION
Before this PR, it looked like clicking the checkbox would remove all services and remove all requests, when it only rejects the latter (no deletions).

This PR updates the label to better reflect that it's deleting the former and rejecting the latter