### PR TITLE
[NSA-9317] Update policy engine version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "login.dfe.express-helpers": "^2.0.0",
         "login.dfe.healthcheck": "^3.0.3",
         "login.dfe.jobs-client": "^6.1.3",
-        "login.dfe.policy-engine": "^3.1.4",
+        "login.dfe.policy-engine": "^4.0.1",
         "login.dfe.validation": "^2.1.5",
         "moment": "^2.30.1",
         "niceware": "^4.0.0",
@@ -2314,19 +2314,6 @@
         "@babel/types": "^7.28.2"
       }
     },
-    "node_modules/@types/body-parser": {
-      "version": "1.19.6",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/body-parser/-/body-parser-1.19.6.tgz",
-      "integrity": "sha1-GFm+u4/X2smRikXVTBlxq4ta9HQ=",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/connect": "*",
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/cacheable-request": {
       "version": "6.0.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
@@ -2337,18 +2324,6 @@
         "@types/keyv": "^3.1.4",
         "@types/node": "*",
         "@types/responselike": "^1.0.0"
-      }
-    },
-    "node_modules/@types/connect": {
-      "version": "3.4.38",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/connect/-/connect-3.4.38.tgz",
-      "integrity": "sha1-W6fzvE+73q/43e2VLl/yzFP42Fg=",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@types/debug": {
@@ -2367,36 +2342,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/express": {
-      "version": "4.17.23",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/express/-/express-4.17.23.tgz",
-      "integrity": "sha1-Na8xk8ZAv9TX/ncZHNDtQRpDO+8=",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^4.17.33",
-        "@types/qs": "*",
-        "@types/serve-static": "*"
-      }
-    },
-    "node_modules/@types/express-serve-static-core": {
-      "version": "4.19.7",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/express-serve-static-core/-/express-serve-static-core-4.19.7.tgz",
-      "integrity": "sha1-8dMG3MA7Gq+/trT+aEzOijHP/BA=",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/node": "*",
-        "@types/qs": "*",
-        "@types/range-parser": "*",
-        "@types/send": "*"
-      }
-    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
@@ -2412,15 +2357,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
       "integrity": "sha1-uXnrrTkZeZyXmxfHJiHAvAoxxsQ=",
       "license": "MIT"
-    },
-    "node_modules/@types/http-errors": {
-      "version": "2.0.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/http-errors/-/http-errors-2.0.5.tgz",
-      "integrity": "sha1-W3SasrFroRNCP+saZKldzTA5hHI=",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/@types/ioredis-mock": {
       "version": "8.2.6",
@@ -2485,15 +2421,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/mime": {
-      "version": "1.3.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/mime/-/mime-1.3.5.tgz",
-      "integrity": "sha1-HvMC4Bz30rWg+lJnkMkSO/HQZpA=",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/@types/ms": {
       "version": "2.1.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/ms/-/ms-2.1.0.tgz",
@@ -2508,24 +2435,6 @@
       "dependencies": {
         "undici-types": "~7.16.0"
       }
-    },
-    "node_modules/@types/qs": {
-      "version": "6.14.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha1-2LYM7PYvLbD7aOXgBgd7kXi4XeU=",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/@types/range-parser": {
-      "version": "1.2.7",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/range-parser/-/range-parser-1.2.7.tgz",
-      "integrity": "sha1-UK5DU+qt3AQEQnmBL1LIxlhX28s=",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/@types/readable-stream": {
       "version": "4.0.22",
@@ -2542,45 +2451,6 @@
       "integrity": "sha1-zClwbwo5fP5t+J3r/kv1zqFZ21A=",
       "license": "MIT",
       "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/send": {
-      "version": "1.2.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/send/-/send-1.2.0.tgz",
-      "integrity": "sha1-rp36DjqwMG08VmGCMkpUxL4vtFo=",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/serve-static": {
-      "version": "1.15.9",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/serve-static/-/serve-static-1.15.9.tgz",
-      "integrity": "sha1-+bCKt92LuwdvBvX5g7aDZU/goCU=",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/http-errors": "*",
-        "@types/node": "*",
-        "@types/send": "<1"
-      }
-    },
-    "node_modules/@types/serve-static/node_modules/@types/send": {
-      "version": "0.17.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/send/-/send-0.17.5.tgz",
-      "integrity": "sha1-2ZHU8rFvKx70lxMfAKkRQpB5HnQ=",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/mime": "^1",
         "@types/node": "*"
       }
     },
@@ -7799,9 +7669,9 @@
       }
     },
     "node_modules/login.dfe.policy-engine": {
-      "version": "3.1.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/login.dfe.policy-engine/-/login.dfe.policy-engine-3.1.4.tgz",
-      "integrity": "sha1-Rp8+JKRMHxLIyBfiLa0WXDMyaF4=",
+      "version": "4.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/login.dfe.policy-engine/-/login.dfe.policy-engine-4.0.1.tgz",
+      "integrity": "sha1-W23aDLGAELTahrMwXN3/A1RP66w=",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.20",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "login.dfe.express-helpers": "^2.0.0",
     "login.dfe.healthcheck": "^3.0.3",
     "login.dfe.jobs-client": "^6.1.3",
-    "login.dfe.policy-engine": "^3.1.4",
+    "login.dfe.policy-engine": "^4.0.1",
     "login.dfe.validation": "^2.1.5",
     "moment": "^2.30.1",
     "niceware": "^4.0.0",

--- a/src/app/users/associateRoles.js
+++ b/src/app/users/associateRoles.js
@@ -51,10 +51,10 @@ const getViewModel = async (req) => {
     await policyEngine.getPolicyApplicationResultsForUser(
       userId.startsWith("inv-") ? undefined : userId,
       req.params.orgId,
-      req.params.sid,
+      [req.params.sid],
       req.id,
     );
-  const serviceRoles = policyEngineResult.rolesAvailableToUser;
+  const serviceRoles = policyEngineResult[0].rolesAvailableToUser;
   const selectedRoles = req.session.user.services
     ? req.session.user.services.find((x) => x.serviceId === req.params.sid)
     : [];

--- a/src/app/users/associateServices.js
+++ b/src/app/users/associateServices.js
@@ -30,22 +30,22 @@ const getAllAvailableServices = async (req) => {
       (ex) => !allUserServicesInOrg.find((as) => as.id === ex.id),
     );
   }
-  const servicesNotAvailableThroughPolicies = [];
-  for (let i = 0; i < externalServices.length; i++) {
-    const policyResult = await policyEngine.getPolicyApplicationResultsForUser(
-      !req.params.uid || req.params.uid.startsWith("inv-")
-        ? undefined
-        : req.params.uid,
-      req.params.orgId,
-      externalServices[i].id,
-      req.id,
-    );
-    if (!policyResult.serviceAvailableToUser) {
-      servicesNotAvailableThroughPolicies.push(externalServices[i].id);
-    }
-  }
-  return externalServices.filter(
-    (x) => !servicesNotAvailableThroughPolicies.find((y) => x.id === y),
+
+  const policyResults = await policyEngine.getPolicyApplicationResultsForUser(
+    !req.params.uid || req.params.uid.startsWith("inv-")
+      ? undefined
+      : req.params.uid,
+    req.params.orgId,
+    externalServices.map((x) => x.id),
+    req.id,
+  );
+
+  return externalServices.filter((service) =>
+    policyResults.find(
+      (result) =>
+        service.id.toLowerCase() === result.id.toLowerCase() &&
+        result.serviceAvailableToUser === true,
+    ),
   );
 };
 

--- a/test/app/users/associateRoles.get.test.js
+++ b/test/app/users/associateRoles.get.test.js
@@ -110,9 +110,12 @@ describe("when displaying the associate roles view", () => {
 
     policyEngine.getPolicyApplicationResultsForUser
       .mockReset()
-      .mockReturnValue({
-        rolesAvailableToUser: [],
-      });
+      .mockReturnValue([
+        {
+          id: "service1",
+          rolesAvailableToUser: [],
+        },
+      ]);
     PolicyEngine.mockReset().mockImplementation(() => policyEngine);
 
     getAssociateRoles = require("./../../../src/app/users/associateRoles").get;

--- a/test/app/users/associateServices.get.test.js
+++ b/test/app/users/associateServices.get.test.js
@@ -55,11 +55,14 @@ describe("when displaying the associate service view", () => {
 
     policyEngine.getPolicyApplicationResultsForUser
       .mockReset()
-      .mockReturnValue({
-        policiesAppliedForUser: [],
-        rolesAvailableToUser: [],
-        serviceAvailableToUser: true,
-      });
+      .mockReturnValue([
+        {
+          id: "service1",
+          policiesAppliedForUser: [],
+          rolesAvailableToUser: [],
+          serviceAvailableToUser: true,
+        },
+      ]);
     PolicyEngine.mockReset().mockImplementation(() => policyEngine);
 
     getAllServices.mockReset();
@@ -208,32 +211,26 @@ describe("when displaying the associate service view", () => {
     });
     getAllServicesForUserInOrg.mockReturnValue([]);
     policyEngine.getPolicyApplicationResultsForUser.mockImplementation(
-      (userId, organisationId, serviceId) => ({
-        policiesAppliedForUser: [],
-        rolesAvailableToUser: [],
-        serviceAvailableToUser: serviceId === "service2",
-      }),
+      (userId, organisationId, serviceIds) =>
+        serviceIds.map((id) => ({
+          id,
+          policiesAppliedForUser: [],
+          rolesAvailableToUser: [],
+          serviceAvailableToUser: id === "service2",
+        })),
     );
 
     await getAssociateServices(req, res);
 
     expect(
       policyEngine.getPolicyApplicationResultsForUser,
-    ).toHaveBeenCalledTimes(2);
+    ).toHaveBeenCalledTimes(1);
     expect(
       policyEngine.getPolicyApplicationResultsForUser,
     ).toHaveBeenCalledWith(
       "user1",
       "88a1ed39-5a98-43da-b66e-78e564ea72b0",
-      "service1",
-      req.id,
-    );
-    expect(
-      policyEngine.getPolicyApplicationResultsForUser,
-    ).toHaveBeenCalledWith(
-      "user1",
-      "88a1ed39-5a98-43da-b66e-78e564ea72b0",
-      "service2",
+      ["service1", "service2"],
       req.id,
     );
     expect(res.render.mock.calls[0][1]).toMatchObject({

--- a/test/app/users/associateServices.post.test.js
+++ b/test/app/users/associateServices.post.test.js
@@ -51,11 +51,14 @@ describe("when adding services to a user", () => {
 
     policyEngine.getPolicyApplicationResultsForUser
       .mockReset()
-      .mockReturnValue({
-        policiesAppliedForUser: [],
-        rolesAvailableToUser: [],
-        serviceAvailableToUser: true,
-      });
+      .mockReturnValue([
+        {
+          id: "service1",
+          policiesAppliedForUser: [],
+          rolesAvailableToUser: [],
+          serviceAvailableToUser: true,
+        },
+      ]);
     PolicyEngine.mockReset().mockImplementation(() => policyEngine);
 
     getAllServices.mockReset();
@@ -173,11 +176,13 @@ describe("when adding services to a user", () => {
       ],
     });
     policyEngine.getPolicyApplicationResultsForUser.mockImplementation(
-      (userId, organisationId, serviceId) => ({
-        policiesAppliedForUser: [],
-        rolesAvailableToUser: [],
-        serviceAvailableToUser: serviceId === "service3",
-      }),
+      (userId, organisationId, serviceIds) =>
+        serviceIds.map((id) => ({
+          id,
+          policiesAppliedForUser: [],
+          rolesAvailableToUser: [],
+          serviceAvailableToUser: id === "service3",
+        })),
     );
 
     await postAssociateServices(req, res);

--- a/tools/giasRolesCheck.js
+++ b/tools/giasRolesCheck.js
@@ -26,9 +26,9 @@ const getPolicyApplicationResult = async (
     await policyEngine.getPolicyApplicationResultsForUser(
       userId.startsWith("inv-") ? undefined : userId,
       organisationId,
-      serviceId,
+      [serviceId],
     );
-  return policyEngineResult.rolesAvailableToUser;
+  return policyEngineResult[0].rolesAvailableToUser;
 };
 
 const connection = new Connection(config.db);


### PR DESCRIPTION
_This change is documented in far greater detail in the associated work item as well as the linked Confluence page in the work item._

As part of this work item, the policy engine has been rewritten to take an array of service IDs for `getPolicyApplicationResultsForUser` and it then returns an array of policy results with each service's ID.

These breaking changes mean the calls to that function need to be re-written in this application to accommodate the change, and to improve performance across the application.

Changes made:
- For multiple services I have passed in all the IDs and then filtered them the same way the old version did, just instead of using the order they’re passed in, `getPolicyApplicationResultsForUser` returns the service ID which I use for matching.
- For single services I have passed the ID in as an array and retrieved the first returned value from the `getPolicyApplicationResultsForUser` function as it is the only service being passed in.
- Updated unit tests for the above to cover these changes.