### PR TITLE
[NSA-9588] Improve output when sync error happens

### DIFF
--- a/src/app/organisations/views/_organisationSummary.ejs
+++ b/src/app/organisations/views/_organisationSummary.ejs
@@ -8,6 +8,16 @@
         </div>
     </div>
 <% } %>
+<% if (locals.flash.error) { %>
+     <div class="govuk-notification-banner govuk-notification-banner" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+        <div class="govuk-notification-banner__header">
+            <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">Error</h2>
+        </div>
+        <div class="govuk-notification-banner__content">
+            <p class="govuk-body"><%= locals.flash.error %></p>
+        </div>
+    </div>
+<% } %>
 
 <div class="govuk-grid-column-two-thirds">
 <h1 class="govuk-heading-xl">

--- a/src/app/organisations/views/_organisationSummary.ejs
+++ b/src/app/organisations/views/_organisationSummary.ejs
@@ -14,7 +14,7 @@
             <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">Error</h2>
         </div>
         <div class="govuk-notification-banner__content">
-            <p class="govuk-body"><%= locals.flash.error %></p>
+            <p class="govuk-notification-banner__heading"><%= locals.flash.error %></p>
         </div>
     </div>
 <% } %>

--- a/src/app/organisations/webServiceSync.js
+++ b/src/app/organisations/webServiceSync.js
@@ -19,9 +19,7 @@ const post = async (req, res) => {
     const result = await wsSyncCall(req.params.id);
     if (result === undefined) {
       res.flash("info", "No sync was performed, please check logs for details");
-      logger.info(
-        `Sync call returned undefined for org [${req.params.id}]. Organisation either not found or undefined id`,
-      );
+      logger.info(`Sync call returned undefined for org [${req.params.id}].`);
     }
   } catch (e) {
     res.flash("error", "Something went wrong during web service sync");

--- a/src/app/organisations/webServiceSync.js
+++ b/src/app/organisations/webServiceSync.js
@@ -18,8 +18,10 @@ const post = async (req, res) => {
   try {
     const result = await wsSyncCall(req.params.id);
     if (result === undefined) {
-      res.flash("info", "Organisation was not found when performing sync");
-      logger.info(`Sync returned 404 status for org [${req.params.id}].`);
+      res.flash("info", "No sync was performed, please check logs for details");
+      logger.info(
+        `Sync call returned undefined for org [${req.params.id}]. Organisation either not found or undefined id`,
+      );
     }
   } catch (e) {
     res.flash("error", "Something went wrong during web service sync");

--- a/src/app/organisations/webServiceSync.js
+++ b/src/app/organisations/webServiceSync.js
@@ -1,5 +1,7 @@
 const { sendResult } = require("../../infrastructure/utils");
+const logger = require("../../infrastructure/logger");
 const { getOrganisationRaw } = require("login.dfe.api-client/organisations");
+
 const { wsSyncCall } = require("./wsSynchFunCall");
 
 const get = async (req, res) => {
@@ -13,11 +15,18 @@ const get = async (req, res) => {
   });
 };
 const post = async (req, res) => {
-  await wsSyncCall(req.params.id);
-  const organisation = await getOrganisationRaw({
-    by: { organisationId: req.params.id },
-  });
-  return res.redirect(`/organisations/${organisation.id}/users`);
+  try {
+    const result = await wsSyncCall(req.params.id);
+    if (result === undefined) {
+      res.flash("info", "Organisation was not found when performing sync");
+      logger.info(`Sync returned 404 status for org [${req.params.id}].`);
+    }
+  } catch (e) {
+    res.flash("error", "Something went wrong during web service sync");
+    logger.error("Something went wrong during web service sync", e);
+  }
+
+  return res.redirect(`/organisations/${req.params.id}/users`);
 };
 module.exports = {
   get,


### PR DESCRIPTION
This PR:
- No longer does an extra call to the organisations API after it's finished POSTing.  It wasn't doing anything with the data it got so there is no need to call it.
- Shows an error banner saying something went wrong if the ws org sync fails.  Previously it would show the generic 'There has been an error' page that was quite jarring and made for a horrible UI experience.
- If the organisation isn't found, it now shows a banner saying it wasn't found.  It also logs out a line saying the same thing.  In terms of functionality, it's basically the same as it was before, but it outputs something instead of silently failing.