### PR TITLE
Feature/nsa 9625 fix client secret

### DIFF
--- a/src/app/services/postConfirmNewService.js
+++ b/src/app/services/postConfirmNewService.js
@@ -73,7 +73,8 @@ const postConfirmNewService = async (req, res) => {
     parentId: undefined,
     relyingParty: {
       clientId: model.clientId,
-      clientSecret: model.clientSecret,
+      clientSecret:
+        model.clientSecret === "" ? "regenerate__me!" : model.clientSecret,
       apiSecret: model.apiSecret ? encrypt(model.apiSecret) : model.apiSecret,
       tokenEndpointAuthMethod: tokenEndpointAuthenticationMethod,
       serviceHome: model.homeUrl,

--- a/test/app/services/postConfirmNewService.test.js
+++ b/test/app/services/postConfirmNewService.test.js
@@ -226,6 +226,28 @@ describe("when displaying the post create new service", () => {
     expect(createServiceRaw.mock.calls[0][0].relyingParty.apiSecret).toBe("");
   });
 
+  it("should use default clientSecret when clientSecret is empty", async () => {
+    req.session.createServiceData.clientSecret = "";
+    createServiceRaw.mockResolvedValue({ id: "new-service-id" });
+
+    await postConfirmNewService(req, res);
+
+    expect(createServiceRaw.mock.calls[0][0].relyingParty.clientSecret).toBe(
+      "regenerate__me!",
+    );
+  });
+
+  it("should preserve clientSecret when it is not empty", async () => {
+    req.session.createServiceData.clientSecret = "my-custom-secret";
+    createServiceRaw.mockResolvedValue({ id: "new-service-id" });
+
+    await postConfirmNewService(req, res);
+
+    expect(createServiceRaw.mock.calls[0][0].relyingParty.clientSecret).toBe(
+      "my-custom-secret",
+    );
+  });
+
   it("should not have authorization_code in grant types if code not present", async () => {
     req.session.createServiceData.responseTypesCode = undefined;
     await postConfirmNewService(req, res);


### PR DESCRIPTION
- Fixes a bug where an empty clientSecret caused validation issues when id_token is selected as the response type
- When clientSecret is empty, it now defaults to "regenerate__me!" to satisfy the minimum length requirement
- Added unit tests to verify the fix