### PR TITLE
[NSA-9530] Add unit tests to getAudit.js

### DIFF
--- a/src/app/users/getAudit.js
+++ b/src/app/users/getAudit.js
@@ -229,7 +229,7 @@ const getAudit = async (req, res) => {
   });
   req.session.type = "audit";
   const pageNumber = req.query && req.query.page ? parseInt(req.query.page) : 1;
-  if (isNaN(pageNumber)) {
+  if (isNaN(pageNumber) || pageNumber < 1) {
     return res.status(400).send();
   }
   const pageOfAudits = await getPageOfUserAudits(user.id, pageNumber);

--- a/test/app/users/getAudit.test.js
+++ b/test/app/users/getAudit.test.js
@@ -83,7 +83,7 @@ describe("when getting users audit details", () => {
     });
 
     getUserDetailsById.mockReset();
-    getUserDetailsById.mockImplementation((userId) => {
+    getUserDetailsById.mockImplementation(async (userId) => {
       return {
         id: userId,
         firstName: "Test",
@@ -95,10 +95,16 @@ describe("when getting users audit details", () => {
       };
     });
 
+    getOrganisationLegacyRaw.mockReset();
+    getOrganisationLegacyRaw.mockResolvedValue({
+      id: "org-1",
+      name: "Test Organisation",
+    });
+
     sendResult.mockReset();
 
     getPageOfUserAudits.mockReset();
-    getPageOfUserAudits.mockReturnValue({
+    getPageOfUserAudits.mockResolvedValue({
       audits: [
         {
           type: "sign-in",
@@ -250,7 +256,10 @@ describe("when getting users audit details", () => {
               "some.user@test.tester added service Test Service for user another.user@example.com",
           },
           service: null,
-          organisation: undefined,
+          organisation: {
+            id: "org-1",
+            name: "Test Organisation",
+          },
           result: true,
           user: {
             id: "user1",
@@ -266,7 +275,7 @@ describe("when getting users audit details", () => {
   });
 
   it("should return the message as the type, if the type is Sign-out", async () => {
-    getPageOfUserAudits.mockReturnValue({
+    getPageOfUserAudits.mockResolvedValue({
       audits: [
         createSimpleAuditRecord("Sign-out", undefined, "User logged out"),
       ],
@@ -280,7 +289,7 @@ describe("when getting users audit details", () => {
   });
 
   it("should leave a number of subtypes of message unchanged", async () => {
-    getPageOfUserAudits.mockReturnValue({
+    getPageOfUserAudits.mockResolvedValue({
       audits: [
         createSimpleAuditRecord(
           "manage",
@@ -407,7 +416,7 @@ describe("when getting users audit details", () => {
   });
 
   it("should pass full req object when getting user", async () => {
-    getPageOfUserAudits.mockReturnValue({
+    getPageOfUserAudits.mockResolvedValue({
       audits: [],
       numberOfPages: 1,
       numberOfRecords: 0,
@@ -423,13 +432,7 @@ describe("when getting users audit details", () => {
   });
 
   it("should pass full req object for support user-org-deleted event", async () => {
-    getOrganisationLegacyRaw.mockReset();
-    getOrganisationLegacyRaw.mockResolvedValue({
-      id: "org-1",
-      name: "Test Organisation",
-    });
-
-    getPageOfUserAudits.mockReturnValue({
+    getPageOfUserAudits.mockResolvedValue({
       audits: [
         {
           type: "support",
@@ -458,13 +461,7 @@ describe("when getting users audit details", () => {
   });
 
   it("should pass full req object for support user-org event", async () => {
-    getOrganisationLegacyRaw.mockReset();
-    getOrganisationLegacyRaw.mockResolvedValue({
-      id: "org-1",
-      name: "Test Organisation",
-    });
-
-    getPageOfUserAudits.mockReturnValue({
+    getPageOfUserAudits.mockResolvedValue({
       audits: [
         {
           type: "support",
@@ -492,13 +489,7 @@ describe("when getting users audit details", () => {
   });
 
   it("should pass full req object for support user-org-permission-edited event", async () => {
-    getOrganisationLegacyRaw.mockReset();
-    getOrganisationLegacyRaw.mockResolvedValue({
-      id: "org-1",
-      name: "Test Organisation",
-    });
-
-    getPageOfUserAudits.mockReturnValue({
+    getPageOfUserAudits.mockResolvedValue({
       audits: [
         {
           type: "support",
@@ -532,13 +523,7 @@ describe("when getting users audit details", () => {
   });
 
   it("should pass full req object for approver user-org-deleted event", async () => {
-    getOrganisationLegacyRaw.mockReset();
-    getOrganisationLegacyRaw.mockResolvedValue({
-      id: "org-1",
-      name: "Test Organisation",
-    });
-
-    getPageOfUserAudits.mockReturnValue({
+    getPageOfUserAudits.mockResolvedValue({
       audits: [
         {
           type: "approver",
@@ -569,7 +554,7 @@ describe("when getting users audit details", () => {
   });
 
   it("should pass full req object when fetching different audit user", async () => {
-    getPageOfUserAudits.mockReturnValue({
+    getPageOfUserAudits.mockResolvedValue({
       audits: [
         {
           type: "sign-in",

--- a/test/app/users/getAudit.test.js
+++ b/test/app/users/getAudit.test.js
@@ -21,6 +21,9 @@ const {
 const { getServiceRaw } = require("login.dfe.api-client/services");
 const getAudit = require("./../../../src/app/users/getAudit");
 const { getUserStatusRaw } = require("login.dfe.api-client/users");
+const {
+  getOrganisationLegacyRaw,
+} = require("login.dfe.api-client/organisations");
 
 const organisationId = "org-1";
 
@@ -396,5 +399,252 @@ describe("when getting users audit details", () => {
       },
       statusChangeReasons: [],
     });
+  });
+
+  it("should pass full req object when getting user", async () => {
+    getUserDetailsById.mockReset();
+    getUserDetailsById.mockImplementation((userId) => {
+      return {
+        id: userId,
+        firstName: "Test",
+        lastName: "User",
+        status: { id: 1 },
+      };
+    });
+
+    getPageOfUserAudits.mockReturnValue({
+      audits: [],
+      numberOfPages: 1,
+      numberOfRecords: 0,
+    });
+
+    await getAudit(req, res);
+
+    expect(getUserDetailsById.mock.calls).toHaveLength(1);
+    expect(getUserDetailsById.mock.calls[0][0]).toBe("user1");
+    expect(getUserDetailsById.mock.calls[0][1]).toBe(req);
+    expect(getUserDetailsById.mock.calls[0][1]).toHaveProperty("id");
+    expect(getUserDetailsById.mock.calls[0][1]).toHaveProperty("params");
+  });
+
+  it("should pass full req object for support user-org-deleted event", async () => {
+    getUserDetailsById.mockReset();
+    getUserDetailsById.mockImplementation((userId) => {
+      return {
+        id: userId,
+        firstName: "Test",
+        lastName: "User",
+        status: { id: 1 },
+      };
+    });
+
+    getOrganisationLegacyRaw.mockReset();
+    getOrganisationLegacyRaw.mockResolvedValue({
+      id: "org-1",
+      name: "Test Organisation",
+    });
+
+    getPageOfUserAudits.mockReturnValue({
+      audits: [
+        {
+          type: "support",
+          subType: "user-org-deleted",
+          userId: "user1",
+          editedUser: "edited-user1",
+          editedFields: [{ name: "new_organisation", oldValue: "org-1" }],
+          numericIdentifier: "12345",
+          textIdentifier: "ABC123",
+          timestamp: "2018-01-30T10:30:53.987Z",
+        },
+      ],
+      numberOfPages: 1,
+      numberOfRecords: 1,
+    });
+
+    await getAudit(req, res);
+
+    const editedUserCall = getUserDetailsById.mock.calls.find(
+      (call) => call[0] === "edited-user1",
+    );
+    expect(editedUserCall).toBeDefined();
+    expect(editedUserCall[1]).toBe(req);
+    expect(editedUserCall[1]).toHaveProperty("id");
+    expect(editedUserCall[1]).toHaveProperty("params");
+  });
+
+  it("should pass full req object for support user-org event", async () => {
+    getUserDetailsById.mockReset();
+    getUserDetailsById.mockImplementation((userId) => {
+      return {
+        id: userId,
+        firstName: "Test",
+        lastName: "User",
+        status: { id: 1 },
+      };
+    });
+
+    getOrganisationLegacyRaw.mockReset();
+    getOrganisationLegacyRaw.mockResolvedValue({
+      id: "org-1",
+      name: "Test Organisation",
+    });
+
+    getPageOfUserAudits.mockReturnValue({
+      audits: [
+        {
+          type: "support",
+          subType: "user-org",
+          userId: "user1",
+          editedUser: "edited-user1",
+          editedFields: [{ name: "new_organisation", newValue: "org-1" }],
+          timestamp: "2018-01-30T10:30:53.987Z",
+        },
+      ],
+      numberOfPages: 1,
+      numberOfRecords: 1,
+    });
+
+    await getAudit(req, res);
+
+    const editedUserCall = getUserDetailsById.mock.calls.find(
+      (call) => call[0] === "edited-user1",
+    );
+
+    expect(editedUserCall).toBeDefined();
+    expect(editedUserCall[1]).toBe(req);
+    expect(editedUserCall[1]).toHaveProperty("id");
+    expect(editedUserCall[1]).toHaveProperty("params");
+  });
+
+  it("should pass full req object for support user-org-permission-edited event", async () => {
+    getUserDetailsById.mockReset();
+    getUserDetailsById.mockImplementation((userId) => {
+      return {
+        id: userId,
+        firstName: "Test",
+        lastName: "User",
+        status: { id: 1 },
+      };
+    });
+
+    getOrganisationLegacyRaw.mockReset();
+    getOrganisationLegacyRaw.mockResolvedValue({
+      id: "org-1",
+      name: "Test Organisation",
+    });
+
+    getPageOfUserAudits.mockReturnValue({
+      audits: [
+        {
+          type: "support",
+          subType: "user-org-permission-edited",
+          userId: "user1",
+          editedUser: "edited-user1",
+          editedFields: [
+            {
+              name: "edited_permission",
+              oldValue: 0,
+              newValue: 10000,
+              organisation: "Test Organisation",
+            },
+          ],
+          timestamp: "2018-01-30T10:30:53.987Z",
+        },
+      ],
+      numberOfPages: 1,
+      numberOfRecords: 1,
+    });
+
+    await getAudit(req, res);
+
+    const editedUserCall = getUserDetailsById.mock.calls.find(
+      (call) => call[0] === "edited-user1",
+    );
+    expect(editedUserCall).toBeDefined();
+    expect(editedUserCall[1]).toBe(req);
+    expect(editedUserCall[1]).toHaveProperty("id");
+    expect(editedUserCall[1]).toHaveProperty("params");
+  });
+
+  it("should pass full req object for approver user-org-deleted event", async () => {
+    getUserDetailsById.mockReset();
+    getUserDetailsById.mockImplementation((userId) => {
+      return {
+        id: userId,
+        firstName: "Test",
+        lastName: "User",
+        status: { id: 1 },
+      };
+    });
+
+    getOrganisationLegacyRaw.mockReset();
+    getOrganisationLegacyRaw.mockResolvedValue({
+      id: "org-1",
+      name: "Test Organisation",
+    });
+
+    getPageOfUserAudits.mockReturnValue({
+      audits: [
+        {
+          type: "approver",
+          subType: "user-org-deleted",
+          userId: "user1",
+          editedUser: "edited-user1",
+          meta: JSON.stringify({
+            editedFields: [{ name: "new_organisation", oldValue: "org-1" }],
+          }),
+          numericIdentifier: "12345",
+          textIdentifier: "ABC123",
+          timestamp: "2018-01-30T10:30:53.987Z",
+        },
+      ],
+      numberOfPages: 1,
+      numberOfRecords: 1,
+    });
+
+    await getAudit(req, res);
+
+    const editedUserCall = getUserDetailsById.mock.calls.find(
+      (call) => call[0] === "edited-user1",
+    );
+    expect(editedUserCall).toBeDefined();
+    expect(editedUserCall[1]).toBe(req);
+    expect(editedUserCall[1]).toHaveProperty("id");
+    expect(editedUserCall[1]).toHaveProperty("params");
+  });
+
+  it("should pass full req object when fetching different audit user", async () => {
+    getUserDetailsById.mockReset();
+    getUserDetailsById.mockImplementation((userId) => {
+      return {
+        id: userId,
+        firstName: "Test",
+        lastName: "User",
+        status: { id: 1 },
+      };
+    });
+
+    getPageOfUserAudits.mockReturnValue({
+      audits: [
+        {
+          type: "sign-in",
+          subType: "username-password",
+          userId: "different-user",
+          timestamp: "2018-01-30T10:30:53.987Z",
+        },
+      ],
+      numberOfPages: 1,
+      numberOfRecords: 1,
+    });
+
+    await getAudit(req, res);
+
+    const differentUserCall = getUserDetailsById.mock.calls.find(
+      (call) => call[0] === "DIFFERENT-USER",
+    );
+    expect(differentUserCall).toBeDefined();
+    expect(differentUserCall[1]).toBe(req);
+    expect(differentUserCall[1]).toHaveProperty("id");
+    expect(differentUserCall[1]).toHaveProperty("params");
   });
 });

--- a/test/app/users/getAudit.test.js
+++ b/test/app/users/getAudit.test.js
@@ -528,6 +528,15 @@ describe("when getting users audit details", () => {
     expect(editedUserCall[1]).toHaveProperty("params");
   });
 
+  it("should return 400 for negative page numbers", async () => {
+    req.query.page = "-1";
+    await getAudit(req, res);
+
+    expect(res.status.mock.calls).toHaveLength(1);
+    expect(res.status.mock.calls[0][0]).toBe(400);
+    expect(res.send.mock.calls).toHaveLength(1);
+  });
+
   it("should pass full req object for approver user-org-deleted event", async () => {
     getPageOfUserAudits.mockResolvedValue({
       audits: [

--- a/test/app/users/getAudit.test.js
+++ b/test/app/users/getAudit.test.js
@@ -83,12 +83,16 @@ describe("when getting users audit details", () => {
     });
 
     getUserDetailsById.mockReset();
-    getUserDetailsById.mockReturnValue({
-      id: "user1",
-      status: {
-        id: 1,
-        description: "Activated",
-      },
+    getUserDetailsById.mockImplementation((userId) => {
+      return {
+        id: userId,
+        firstName: "Test",
+        lastName: "User",
+        status: {
+          id: 1,
+          description: "Activated",
+        },
+      };
     });
 
     sendResult.mockReset();
@@ -189,6 +193,7 @@ describe("when getting users audit details", () => {
       backLink: "/organisations",
     });
   });
+
   it("should set the backlink to /users if the search type session param is not organisations", async () => {
     req.session.params.searchType = "/users";
     await getAudit(req, res);
@@ -402,16 +407,6 @@ describe("when getting users audit details", () => {
   });
 
   it("should pass full req object when getting user", async () => {
-    getUserDetailsById.mockReset();
-    getUserDetailsById.mockImplementation((userId) => {
-      return {
-        id: userId,
-        firstName: "Test",
-        lastName: "User",
-        status: { id: 1 },
-      };
-    });
-
     getPageOfUserAudits.mockReturnValue({
       audits: [],
       numberOfPages: 1,
@@ -428,16 +423,6 @@ describe("when getting users audit details", () => {
   });
 
   it("should pass full req object for support user-org-deleted event", async () => {
-    getUserDetailsById.mockReset();
-    getUserDetailsById.mockImplementation((userId) => {
-      return {
-        id: userId,
-        firstName: "Test",
-        lastName: "User",
-        status: { id: 1 },
-      };
-    });
-
     getOrganisationLegacyRaw.mockReset();
     getOrganisationLegacyRaw.mockResolvedValue({
       id: "org-1",
@@ -473,16 +458,6 @@ describe("when getting users audit details", () => {
   });
 
   it("should pass full req object for support user-org event", async () => {
-    getUserDetailsById.mockReset();
-    getUserDetailsById.mockImplementation((userId) => {
-      return {
-        id: userId,
-        firstName: "Test",
-        lastName: "User",
-        status: { id: 1 },
-      };
-    });
-
     getOrganisationLegacyRaw.mockReset();
     getOrganisationLegacyRaw.mockResolvedValue({
       id: "org-1",
@@ -517,16 +492,6 @@ describe("when getting users audit details", () => {
   });
 
   it("should pass full req object for support user-org-permission-edited event", async () => {
-    getUserDetailsById.mockReset();
-    getUserDetailsById.mockImplementation((userId) => {
-      return {
-        id: userId,
-        firstName: "Test",
-        lastName: "User",
-        status: { id: 1 },
-      };
-    });
-
     getOrganisationLegacyRaw.mockReset();
     getOrganisationLegacyRaw.mockResolvedValue({
       id: "org-1",
@@ -567,16 +532,6 @@ describe("when getting users audit details", () => {
   });
 
   it("should pass full req object for approver user-org-deleted event", async () => {
-    getUserDetailsById.mockReset();
-    getUserDetailsById.mockImplementation((userId) => {
-      return {
-        id: userId,
-        firstName: "Test",
-        lastName: "User",
-        status: { id: 1 },
-      };
-    });
-
     getOrganisationLegacyRaw.mockReset();
     getOrganisationLegacyRaw.mockResolvedValue({
       id: "org-1",
@@ -614,16 +569,6 @@ describe("when getting users audit details", () => {
   });
 
   it("should pass full req object when fetching different audit user", async () => {
-    getUserDetailsById.mockReset();
-    getUserDetailsById.mockImplementation((userId) => {
-      return {
-        id: userId,
-        firstName: "Test",
-        lastName: "User",
-        status: { id: 1 },
-      };
-    });
-
     getPageOfUserAudits.mockReturnValue({
       audits: [
         {


### PR DESCRIPTION
- Add unit tests to cover each specific call to the getUserDetailsById/ getCachedUserById function  in getAudit, ensuring the full req object is passed in. 