### PR TITLE
[NSA-9630] add create role based service via UI in hidden state

### DIFF
--- a/src/app/services/postChooseServiceType.js
+++ b/src/app/services/postChooseServiceType.js
@@ -6,13 +6,14 @@ const validateInput = (req) => {
     serviceType: req.body.serviceType,
     hideFromUserServices: req.body.hideFromUserServices,
     hideFromContactUs: req.body.hideFromContactUs,
+    hideSupport: req.body.hideSupport,
+    hideApprover: req.body.hideApprover,
     validationMessages: {},
   };
 
   if (!model.serviceType) {
     model.validationMessages.serviceType = "A service type must be selected";
   }
-
   return model;
 };
 

--- a/src/app/services/postConfirmNewService.js
+++ b/src/app/services/postConfirmNewService.js
@@ -31,6 +31,9 @@ const postConfirmNewService = async (req, res) => {
   if (model.serviceType === "standardServiceType") {
     params = {
       minimumRolesRequired: 1,
+      helpHidden: model.hideFromContactUs === undefined ? false : true,
+      hideApprover: model.hideApprover === undefined ? false : true,
+      hideSupport: model.hideSupport === undefined ? false : true,
     };
   } else {
     params = {

--- a/src/app/services/views/chooseServiceType.ejs
+++ b/src/app/services/views/chooseServiceType.ejs
@@ -85,6 +85,24 @@
                     Stop users from seeing the ID-only service listed on the <a class="govuk-link" href="">contact us</a> page
                   </div>
                 </div>
+                <div class="govuk-checkboxes__item">
+                  <input class="govuk-checkboxes__input" id="hideSupport" name="hideSupport" type="checkbox" value="hideSupport" <%= (locals.hideSupport) ? 'checked' : '' %>>
+                  <label class="govuk-label govuk-checkboxes__label" for="hideSupport">
+                    Hide from support console
+                  </label>
+                  <div id="hideSupport-item-hint" class="govuk-hint govuk-checkboxes__hint">
+                    Hides <span class="govuk-!-font-weight-bold">role-based</span> services from the support console.
+                  </div>
+                </div>
+                <div class="govuk-checkboxes__item">
+                  <input class="govuk-checkboxes__input" id="hideApprover" name="hideApprover" type="checkbox" value="hideApprover" <%= (locals.hideApprover) ? 'checked' : '' %>>
+                  <label class="govuk-label govuk-checkboxes__label" for="hideApprover">
+                    Hide from approvers
+                  </label>
+                  <div id="hideApprover-item-hint" class="govuk-hint govuk-checkboxes__hint">
+                    Hides <span class="govuk-!-font-weight-bold">role-based</span> services from users so they cannot request the service, and from approvers so they cannot add the service to their account or users in their orgnisation.
+                  </div>
+                </div>
               </div>
             </fieldset>
           </div>

--- a/src/app/services/views/chooseServiceType.ejs
+++ b/src/app/services/views/chooseServiceType.ejs
@@ -100,7 +100,7 @@
                     Hide from approvers
                   </label>
                   <div id="hideApprover-item-hint" class="govuk-hint govuk-checkboxes__hint">
-                    Hides <span class="govuk-!-font-weight-bold">role-based</span> services from users so they cannot request the service, and from approvers so they cannot add the service to their account or users in their orgnisation.
+                    Hides <span class="govuk-!-font-weight-bold">role-based</span> services from users so they cannot request the service, and from approvers so they cannot add the service to their account or users in their organisation.
                   </div>
                 </div>
               </div>

--- a/src/app/services/views/confirmNewService.ejs
+++ b/src/app/services/views/confirmNewService.ejs
@@ -180,6 +180,28 @@
               <a class="govuk-link" href="choose-type">Change<span class="govuk-visually-hidden"> hide from contact us</span></a>
             </dd>
           </div>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Hide from support console
+            </dt>
+            <dd class="govuk-summary-list__value">
+              <%= (model.hideSupport !== undefined) ? 'true' : 'false' %>
+            </dd>
+            <dd class="govuk-summary-list__actions">
+              <a class="govuk-link" href="choose-type">Change<span class="govuk-visually-hidden"> hide from support console</span></a>
+            </dd>
+          </div>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Hide from approvers
+            </dt>
+            <dd class="govuk-summary-list__value">
+              <%= (model.hideApprover !== undefined) ? 'true' : 'false' %>
+            </dd>
+            <dd class="govuk-summary-list__actions">
+              <a class="govuk-link" href="choose-type">Change<span class="govuk-visually-hidden"> hide from approvers</span></a>
+            </dd>
+          </div>
         </dl>
         <form method="post">
           <input type="hidden" name="_csrf" value="<%=csrfToken%>" />

--- a/test/app/services/postChooseServiceType.test.js
+++ b/test/app/services/postChooseServiceType.test.js
@@ -37,6 +37,8 @@ describe("when displaying the post choose service type screen", () => {
       serviceType: "standardServiceType",
       hideFromUserServices: "hideFromUserServices",
       hideFromContactUs: "hideFromContactUs",
+      hideSupport: undefined,
+      hideApprover: undefined,
       validationMessages: {},
       csrfToken: "token",
       currentPage: "services",
@@ -72,6 +74,8 @@ describe("when displaying the post choose service type screen", () => {
       description: "Test description",
       hideFromUserServices: "hideFromUserServices",
       hideFromContactUs: "hideFromContactUs",
+      hideSupport: undefined,
+      hideApprover: undefined,
       validationMessages: {},
     });
     expect(res.redirect.mock.calls).toHaveLength(1);

--- a/test/app/services/postConfirmNewService.test.js
+++ b/test/app/services/postConfirmNewService.test.js
@@ -202,6 +202,9 @@ describe("when displaying the post create new service", () => {
         grantTypes: ["authorization_code", "implicit", "refresh_token"],
         params: {
           minimumRolesRequired: 1,
+          helpHidden: false,
+          hideApprover: false,
+          hideSupport: false,
         },
         postResetUrl: "https://postPasswordReseturl.com",
         postLogoutRedirectUris: ["https://logout-uri.com"],
@@ -502,6 +505,62 @@ describe("when displaying the post create new service", () => {
 
     await postConfirmNewService(req, res);
 
+    expect(res.redirect.mock.calls).toHaveLength(1);
+    expect(res.redirect.mock.calls[0][0]).toBe("/users");
+  });
+
+  it("should have hideApprover param be true if hideApprover is defined for standardServiceType", async () => {
+    req.session.createServiceData.hideApprover = "hideApprover";
+    createServiceRaw.mockResolvedValue({ id: "new-service-id" });
+
+    await postConfirmNewService(req, res);
+
+    expect(createServiceRaw.mock.calls).toHaveLength(1);
+    expect(
+      createServiceRaw.mock.calls[0][0].relyingParty.params.hideApprover,
+    ).toBe(true);
+    expect(res.redirect.mock.calls).toHaveLength(1);
+    expect(res.redirect.mock.calls[0][0]).toBe("/users");
+  });
+
+  it("should have hideSupport param be true if hideSupport is defined for standardServiceType", async () => {
+    req.session.createServiceData.hideSupport = "hideSupport";
+    createServiceRaw.mockResolvedValue({ id: "new-service-id" });
+
+    await postConfirmNewService(req, res);
+
+    expect(createServiceRaw.mock.calls).toHaveLength(1);
+    expect(
+      createServiceRaw.mock.calls[0][0].relyingParty.params.hideSupport,
+    ).toBe(true);
+    expect(res.redirect.mock.calls).toHaveLength(1);
+    expect(res.redirect.mock.calls[0][0]).toBe("/users");
+  });
+
+  it("should have hideApprover param be true if hideApprover is defined for idOnly service", async () => {
+    req.session.createServiceData.hideApprover = "hideApprover";
+    createServiceRaw.mockResolvedValue({ id: "new-service-id" });
+
+    await postConfirmNewService(req, res);
+
+    expect(createServiceRaw.mock.calls).toHaveLength(1);
+    expect(
+      createServiceRaw.mock.calls[0][0].relyingParty.params.hideApprover,
+    ).toBe(true);
+    expect(res.redirect.mock.calls).toHaveLength(1);
+    expect(res.redirect.mock.calls[0][0]).toBe("/users");
+  });
+
+  it("should have hideSupport param be true if hideSupport is defined for idOnly service", async () => {
+    req.session.createServiceData.hideSupport = "hideSupport";
+    createServiceRaw.mockResolvedValue({ id: "new-service-id" });
+
+    await postConfirmNewService(req, res);
+
+    expect(createServiceRaw.mock.calls).toHaveLength(1);
+    expect(
+      createServiceRaw.mock.calls[0][0].relyingParty.params.hideSupport,
+    ).toBe(true);
     expect(res.redirect.mock.calls).toHaveLength(1);
     expect(res.redirect.mock.calls[0][0]).toBe("/users");
   });

--- a/test/app/services/postConfirmNewService.test.js
+++ b/test/app/services/postConfirmNewService.test.js
@@ -564,4 +564,184 @@ describe("when displaying the post create new service", () => {
     expect(res.redirect.mock.calls).toHaveLength(1);
     expect(res.redirect.mock.calls[0][0]).toBe("/users");
   });
+
+  it("should mark ID-only service as hidden from users/approver and support even if hide options aren't selected", async () => {
+    createServiceRaw.mockResolvedValue({ id: "new-service-id" });
+
+    await postConfirmNewService(req, res);
+
+    expect(createServiceRaw.mock.calls[0][0]).toMatchObject({
+      isIdOnlyService: true,
+      isHiddenService: false,
+      relyingParty: {
+        params: {
+          helpHidden: false,
+          hideApprover: true,
+          hideSupport: true,
+        },
+      },
+    });
+  });
+
+  it("should not hide role-based service when no hide options are selected", async () => {
+    const testReq = getRequestMock({
+      session: {
+        createServiceData: standardServiceData,
+      },
+    });
+
+    createServiceRaw.mockResolvedValue({ id: "new-service-id" });
+
+    await postConfirmNewService(testReq, res);
+
+    expect(createServiceRaw.mock.calls[0][0]).toMatchObject({
+      isIdOnlyService: false,
+      isHiddenService: false,
+      relyingParty: {
+        params: {
+          minimumRolesRequired: 1,
+          hideApprover: false,
+          hideSupport: false,
+          helpHidden: false,
+        },
+      },
+    });
+  });
+
+  it("should hide role-based service when the hide from users/approvers option is selected", async () => {
+    const testReq = getRequestMock({
+      session: {
+        createServiceData: {
+          serviceType: "standardServiceType",
+          hideFromUserServices: undefined,
+          hideApprover: "hideApprover",
+          hideFromContactUs: undefined,
+          name: "Standard Service Hidden from Users",
+          description: "Test standard service hidden from users",
+          homeUrl: "https://homeUrl.com",
+          postPasswordResetUrl: "https://postPasswordReseturl.com",
+          clientId: "TestClientId",
+          service: {
+            redirectUris: ["https://redirect-uri.com"],
+            postLogoutRedirectUris: ["https://logout-uri.com"],
+          },
+          responseTypesCode: "code",
+          responseTypesIdToken: "id_token",
+          refreshToken: "refresh_token",
+          clientSecret: "this.is.a.client.secret",
+          tokenEndpointAuthenticationMethod: "client_secret_post",
+          apiSecret: "this.is.an.api.secret",
+        },
+      },
+    });
+
+    createServiceRaw.mockResolvedValue({ id: "new-service-id" });
+
+    await postConfirmNewService(testReq, res);
+
+    expect(createServiceRaw.mock.calls[0][0]).toMatchObject({
+      isIdOnlyService: false,
+      isHiddenService: false,
+      relyingParty: {
+        params: {
+          minimumRolesRequired: 1,
+          hideApprover: true,
+          hideSupport: false,
+          helpHidden: false,
+        },
+      },
+    });
+  });
+
+  it("should not hide role-based service when only hide from support console option is selected", async () => {
+    const testReq = getRequestMock({
+      session: {
+        createServiceData: {
+          serviceType: "standardServiceType",
+          hideFromUserServices: undefined,
+          hideApprover: undefined,
+          hideFromContactUs: undefined,
+          hideSupport: "hideSupport",
+          name: "Standard Service Hidden from Support",
+          description: "Test standard service hidden from support console",
+          homeUrl: "https://homeUrl.com",
+          postPasswordResetUrl: "https://postPasswordReseturl.com",
+          clientId: "TestClientId",
+          service: {
+            redirectUris: ["https://redirect-uri.com"],
+            postLogoutRedirectUris: ["https://logout-uri.com"],
+          },
+          responseTypesCode: "code",
+          responseTypesIdToken: "id_token",
+          refreshToken: "refresh_token",
+          clientSecret: "this.is.a.client.secret",
+          tokenEndpointAuthenticationMethod: "client_secret_post",
+          apiSecret: "this.is.an.api.secret",
+        },
+      },
+    });
+
+    createServiceRaw.mockResolvedValue({ id: "new-service-id" });
+
+    await postConfirmNewService(testReq, res);
+
+    expect(createServiceRaw.mock.calls[0][0]).toMatchObject({
+      isIdOnlyService: false,
+      isHiddenService: false,
+      relyingParty: {
+        params: {
+          minimumRolesRequired: 1,
+          helpHidden: false,
+          hideApprover: false,
+          hideSupport: true,
+        },
+      },
+    });
+  });
+
+  it("should hide role-based service when all hide options are selected", async () => {
+    const testReq = getRequestMock({
+      session: {
+        createServiceData: {
+          serviceType: "standardServiceType",
+          hideFromUserServices: "hideFromUserServices",
+          hideFromContactUs: "hideFromContactUs",
+          hideApprover: "hideApprover",
+          hideSupport: "hideSupport",
+          name: "Standard Service Fully Hidden",
+          description: "Test standard service with all hide options selected",
+          homeUrl: "https://homeUrl.com",
+          postPasswordResetUrl: "https://postPasswordReseturl.com",
+          clientId: "TestClientId",
+          service: {
+            redirectUris: ["https://redirect-uri.com"],
+            postLogoutRedirectUris: ["https://logout-uri.com"],
+          },
+          responseTypesCode: "code",
+          responseTypesIdToken: "id_token",
+          refreshToken: "refresh_token",
+          clientSecret: "this.is.a.client.secret",
+          tokenEndpointAuthenticationMethod: "client_secret_post",
+          apiSecret: "this.is.an.api.secret",
+        },
+      },
+    });
+
+    createServiceRaw.mockResolvedValue({ id: "new-service-id" });
+
+    await postConfirmNewService(testReq, res);
+
+    expect(createServiceRaw.mock.calls[0][0]).toMatchObject({
+      isIdOnlyService: false,
+      isHiddenService: true,
+      relyingParty: {
+        params: {
+          minimumRolesRequired: 1,
+          hideApprover: true,
+          hideSupport: true,
+          helpHidden: true,
+        },
+      },
+    });
+  });
 });

--- a/test/app/services/postConfirmNewService.test.js
+++ b/test/app/services/postConfirmNewService.test.js
@@ -744,4 +744,188 @@ describe("when displaying the post create new service", () => {
       },
     });
   });
+
+  it("should hide role-based service when all hide options are selected", async () => {
+    const testReq = getRequestMock({
+      session: {
+        createServiceData: {
+          serviceType: "standardServiceType",
+          hideFromUserServices: "hideFromUserServices",
+          hideFromContactUs: "hideFromContactUs",
+          hideApprover: "hideApprover",
+          hideSupport: "hideSupport",
+          name: "Standard Service Fully Hidden",
+          description: "Test standard service with all hide options selected",
+          homeUrl: "https://homeUrl.com",
+          postPasswordResetUrl: "https://postPasswordReseturl.com",
+          clientId: "TestClientId",
+          service: {
+            redirectUris: ["https://redirect-uri.com"],
+            postLogoutRedirectUris: ["https://logout-uri.com"],
+          },
+          responseTypesCode: "code",
+          responseTypesIdToken: "id_token",
+          refreshToken: "refresh_token",
+          clientSecret: "this.is.a.client.secret",
+          tokenEndpointAuthenticationMethod: "client_secret_post",
+          apiSecret: "this.is.an.api.secret",
+        },
+      },
+    });
+
+    createServiceRaw.mockResolvedValue({ id: "new-service-id" });
+
+    await postConfirmNewService(testReq, res);
+
+    expect(createServiceRaw.mock.calls[0][0]).toMatchObject({
+      isIdOnlyService: false,
+      isHiddenService: true,
+      relyingParty: {
+        params: {
+          minimumRolesRequired: 1,
+          hideApprover: true,
+          hideSupport: true,
+          helpHidden: true,
+        },
+      },
+    });
+  });
+
+  it("should have isHiddenService and hideSupport true when hideFromUserServices and hideSupport are set", async () => {
+    const testReq = getRequestMock({
+      session: {
+        createServiceData: {
+          serviceType: "standardServiceType",
+          hideFromUserServices: "hideFromUserServices",
+          hideFromContactUs: undefined,
+          hideApprover: undefined,
+          hideSupport: "hideSupport",
+          name: "Standard Service Fully Hidden",
+          description: "Test standard service with all hide options selected",
+          homeUrl: "https://homeUrl.com",
+          postPasswordResetUrl: "https://postPasswordReseturl.com",
+          clientId: "TestClientId",
+          service: {
+            redirectUris: ["https://redirect-uri.com"],
+            postLogoutRedirectUris: ["https://logout-uri.com"],
+          },
+          responseTypesCode: "code",
+          responseTypesIdToken: "id_token",
+          refreshToken: "refresh_token",
+          clientSecret: "this.is.a.client.secret",
+          tokenEndpointAuthenticationMethod: "client_secret_post",
+          apiSecret: "this.is.an.api.secret",
+        },
+      },
+    });
+
+    createServiceRaw.mockResolvedValue({ id: "new-service-id" });
+
+    await postConfirmNewService(testReq, res);
+
+    expect(createServiceRaw.mock.calls[0][0]).toMatchObject({
+      isIdOnlyService: false,
+      isHiddenService: true,
+      relyingParty: {
+        params: {
+          minimumRolesRequired: 1,
+          hideApprover: false,
+          hideSupport: true,
+          helpHidden: false,
+        },
+      },
+    });
+  });
+
+  it("should have helpHidden and hideApprover true when both hideFromContactUs and hideApprover are set", async () => {
+    const testReq = getRequestMock({
+      session: {
+        createServiceData: {
+          serviceType: "standardServiceType",
+          hideFromUserServices: undefined,
+          hideFromContactUs: "hideFromContactUs",
+          hideApprover: "hideApprover",
+          hideSupport: undefined,
+          name: "Standard Service Fully Hidden",
+          description: "Test standard service with all hide options selected",
+          homeUrl: "https://homeUrl.com",
+          postPasswordResetUrl: "https://postPasswordReseturl.com",
+          clientId: "TestClientId",
+          service: {
+            redirectUris: ["https://redirect-uri.com"],
+            postLogoutRedirectUris: ["https://logout-uri.com"],
+          },
+          responseTypesCode: "code",
+          responseTypesIdToken: "id_token",
+          refreshToken: "refresh_token",
+          clientSecret: "this.is.a.client.secret",
+          tokenEndpointAuthenticationMethod: "client_secret_post",
+          apiSecret: "this.is.an.api.secret",
+        },
+      },
+    });
+
+    createServiceRaw.mockResolvedValue({ id: "new-service-id" });
+
+    await postConfirmNewService(testReq, res);
+
+    expect(createServiceRaw.mock.calls[0][0]).toMatchObject({
+      isIdOnlyService: false,
+      isHiddenService: false,
+      relyingParty: {
+        params: {
+          minimumRolesRequired: 1,
+          hideApprover: true,
+          hideSupport: false,
+          helpHidden: true,
+        },
+      },
+    });
+  });
+
+  it("should have helpHidden true when hideFromContactUs is set for standardServiceType", async () => {
+    const testReq = getRequestMock({
+      session: {
+        createServiceData: {
+          serviceType: "standardServiceType",
+          hideFromUserServices: undefined,
+          hideFromContactUs: "hideFromContactUs",
+          hideApprover: undefined,
+          hideSupport: undefined,
+          name: "Standard Service Fully Hidden",
+          description: "Test standard service with all hide options selected",
+          homeUrl: "https://homeUrl.com",
+          postPasswordResetUrl: "https://postPasswordReseturl.com",
+          clientId: "TestClientId",
+          service: {
+            redirectUris: ["https://redirect-uri.com"],
+            postLogoutRedirectUris: ["https://logout-uri.com"],
+          },
+          responseTypesCode: "code",
+          responseTypesIdToken: "id_token",
+          refreshToken: "refresh_token",
+          clientSecret: "this.is.a.client.secret",
+          tokenEndpointAuthenticationMethod: "client_secret_post",
+          apiSecret: "this.is.an.api.secret",
+        },
+      },
+    });
+
+    createServiceRaw.mockResolvedValue({ id: "new-service-id" });
+
+    await postConfirmNewService(testReq, res);
+
+    expect(createServiceRaw.mock.calls[0][0]).toMatchObject({
+      isIdOnlyService: false,
+      isHiddenService: false,
+      relyingParty: {
+        params: {
+          minimumRolesRequired: 1,
+          hideApprover: false,
+          hideSupport: false,
+          helpHidden: true,
+        },
+      },
+    });
+  });
 });


### PR DESCRIPTION
- Add ability for role based service to 'hide from support' and 'hide from approvers' when creating a service