### PR TITLE
[NSA-9676] Bug fix: kill active sessions after user deactivation

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,12 @@ const config = {
   testEnvironment: "node",
   collectCoverage: false,
   clearMocks: true,
+  moduleNameMapper: {
+    "^login\\.dfe\\.api-client/api$":
+      "<rootDir>/node_modules/login.dfe.api-client/dist/api/index.js",
+    "^login\\.dfe\\.api-client/api/common/ApiClient$":
+      "<rootDir>/node_modules/login.dfe.api-client/dist/api/common/ApiClient.js",
+  },
 };
 
 module.exports = config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -7506,9 +7506,9 @@
       "license": "MIT"
     },
     "node_modules/login.dfe.api-client": {
-      "version": "1.0.58",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/login.dfe.api-client/-/login.dfe.api-client-1.0.58.tgz",
-      "integrity": "sha1-0cldqLEURJxO772XNU2rhEsySow=",
+      "version": "1.0.62",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/login.dfe.api-client/-/login.dfe.api-client-1.0.62.tgz",
+      "integrity": "sha1-lvwZBvi1JKVYgonl/lo3ugJqGFw=",
       "dependencies": {
         "@azure/msal-node": "^3.1.0",
         "applicationinsights": "^2.9.6",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "helmet": "^7.2.0",
     "ioredis": "^5.6.1",
     "lodash": "^4.17.21",
-    "login.dfe.api-client": "^1.0.58",
+    "login.dfe.api-client": "^1.0.62",
     "login.dfe.async-retry": "github:DFE-Digital/login.dfe.async-retry#v2.0.3",
     "login.dfe.audit.winston-sequelize-transport": "^3.2.6",
     "login.dfe.config.schema.common": "^2.1.8",

--- a/src/app/users/postBulkUserActionsEmails.js
+++ b/src/app/users/postBulkUserActionsEmails.js
@@ -10,6 +10,7 @@ const {
   removeAllServicesForUser,
   removeAllServicesForInvitedUser,
   searchForBulkUsersPage,
+  destroyUserSession,
 } = require("./utils");
 const {
   deactivateUser: apiClientDeactivateUser,
@@ -61,6 +62,7 @@ const updateInvitedUserIndex = async (user) => {
 const deactivateUser = async (req, user, reason) => {
   await apiClientDeactivateUser({ userId: user.id, reason });
   await updateUserIndex(user);
+  await destroyUserSession(user.id);
 };
 
 const deactivateInvitedUser = async (req, user) => {

--- a/src/app/users/postConfirmDeactivate.js
+++ b/src/app/users/postConfirmDeactivate.js
@@ -6,6 +6,7 @@ const {
   removeAllServicesForUser,
   updateUserDetails,
   waitForIndexToUpdate,
+  destroyUserSession,
 } = require("./utils");
 
 const { deactivateUser } = require("login.dfe.api-client/users");
@@ -84,6 +85,7 @@ const postConfirmDeactivate = async (req, res) => {
 
   await deactivateUser({ userId: user.id, reason });
   await updateUserIndex(user.id, req);
+  await destroyUserSession(user.id);
 
   if (req.body["remove-services-and-requests"]) {
     await rejectOpenUserServiceRequestsForUser(user.id, req);

--- a/src/app/users/postConfirmInvitationReactivate.js
+++ b/src/app/users/postConfirmInvitationReactivate.js
@@ -3,6 +3,7 @@ const {
   getUserDetailsById,
   updateUserDetails,
   waitForIndexToUpdate,
+  clearUserKillSwitch,
 } = require("./utils");
 const { updateInvitation } = require("login.dfe.api-client/invitations");
 
@@ -25,6 +26,7 @@ const postConfirmReactivate = async (req, res) => {
     deactivated: false,
   });
 
+  await clearUserKillSwitch(user.id);
   await updateUserIndex(user.id, req);
 
   logger.audit(

--- a/src/app/users/postConfirmReactivate.js
+++ b/src/app/users/postConfirmReactivate.js
@@ -3,6 +3,7 @@ const {
   getUserDetailsById,
   updateUserDetails,
   waitForIndexToUpdate,
+  clearUserKillSwitch,
 } = require("./utils");
 const { activateUser } = require("login.dfe.api-client/users");
 
@@ -25,6 +26,7 @@ const postConfirmReactivate = async (req, res) => {
   const user = await getUserDetailsById(req.params.uid, req);
 
   await activateUser({ userId: req.params.uid });
+  await clearUserKillSwitch(req.params.uid);
   await updateUserIndex(req);
 
   // Audit

--- a/src/app/users/utils.js
+++ b/src/app/users/utils.js
@@ -510,6 +510,45 @@ const callServiceToUserFunc = async (
   }
 };
 
+const { getApiClient, ApiName } = require("login.dfe.api-client/api");
+const { RequestMethod } = require("login.dfe.api-client/api/common/ApiClient");
+
+const destroyUserSession = async (userId) => {
+  try {
+    const oidcClient = getApiClient(ApiName.Oidc);
+    await oidcClient.request(
+      RequestMethod.POST,
+      `/users/${userId}/destroy-session`,
+    );
+    logger.info(
+      `Successfully requested OIDC session destruction for user ${userId}`,
+    );
+  } catch (e) {
+    // Log but don't fail the deactivation if session destruction fails
+    logger.error(
+      `Failed to destroy OIDC session for user ${userId}: ${e.message}`,
+    );
+  }
+};
+
+const clearUserKillSwitch = async (userId) => {
+  try {
+    const oidcClient = getApiClient(ApiName.Oidc);
+    await oidcClient.request(
+      RequestMethod.DELETE,
+      `/users/${userId}/kill-switch`,
+    );
+    logger.info(
+      `Successfully cleared kill switch for reactivated user ${userId}`,
+    );
+  } catch (e) {
+    // Log but don't fail the reactivation if kill switch removal fails
+    logger.error(
+      `Failed to clear kill switch for user ${userId}: ${e.message}`,
+    );
+  }
+};
+
 module.exports = {
   search,
   searchForBulkUsersPage,
@@ -523,4 +562,6 @@ module.exports = {
   removeAllServicesForUser,
   removeAllServicesForInvitedUser,
   callServiceToUserFunc,
+  destroyUserSession,
+  clearUserKillSwitch,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -67,6 +67,9 @@ setupApi({
     search: {
       baseUri: config.search.service.url,
     },
+    oidcService: {
+      baseUri: config.identifyingParty.url,
+    },
   },
 });
 

--- a/src/infrastructure/oidc/index.js
+++ b/src/infrastructure/oidc/index.js
@@ -1,9 +1,22 @@
 const passport = require("passport");
 const { Strategy, Issuer, custom } = require("openid-client");
 const asyncRetry = require("login.dfe.async-retry");
+const Redis = require("ioredis");
 const logger = require("../logger");
 const config = require("../config");
 const { getUserServiceRaw } = require("login.dfe.api-client/users");
+
+// Dedicated connection to the OIDC Redis DB (DB 0, `dsi:` namespace) used
+// solely to read the per-user deactivation kill switch written by the OIDC
+// service when an admin deactivates a user.  This is intentionally separate
+// from the session-store connection (DB 3) so a DB-index mismatch cannot
+// silently skip the kill-switch check.
+const oidcRedisConnString =
+  process.env.LOCAL_REDIS_CONN || process.env.REDIS_CONN;
+const oidcKillSwitchClient = new Redis(oidcRedisConnString, {
+  tls: oidcRedisConnString?.includes("6380"),
+  lazyConnect: true,
+});
 
 custom.setHttpOptionsDefaults({
   timeout: 10000,
@@ -67,13 +80,46 @@ const init = async (app) => {
   passport.serializeUser((user, done) => {
     done(null, user);
   });
-  passport.deserializeUser((user, done) => {
-    if (hasJwtExpired(user.exp)) {
-      done(null, null);
-    } else {
-      done(null, user);
+
+  // Async deserializeUser: checks the OIDC kill switch before restoring the
+  // session.  If the OIDC service has written `dsi:KillSwitch:{userId}` to
+  // Redis (set during user deactivation), this returns null immediately,
+  // causing Passport to treat the request as unauthenticated and redirecting
+  // the user to re-authenticate — where the OIDC provider will deny access
+  // because Account.findById returns null for deactivated users.
+  //
+  // The kill switch check fails OPEN: if Redis is unreachable or the key is
+  // absent, we fall through to the normal expiry check so that a Redis hiccup
+  // does not lock out legitimate users.
+  passport.deserializeUser(async (user, done) => {
+    try {
+      if (hasJwtExpired(user.exp)) {
+        return done(null, null);
+      }
+
+      const killSwitchKey = `dsi:KillSwitch:${user.sub.toLowerCase()}`;
+      const isDeactivated = await oidcKillSwitchClient.get(killSwitchKey);
+      if (isDeactivated) {
+        logger.info(
+          `Rejecting session for deactivated user ${user.sub} (kill switch active)`,
+        );
+        return done(null, null);
+      }
+
+      return done(null, user);
+    } catch (err) {
+      // Fail open: a Redis error must not lock out active users.
+      logger.warn(
+        `Kill switch check failed for user ${user.sub}, proceeding with session`,
+        { error: err.message },
+      );
+      if (hasJwtExpired(user.exp)) {
+        return done(null, null);
+      }
+      return done(null, user);
     }
   });
+
   app.use(passport.initialize());
   app.use(passport.session());
 


### PR DESCRIPTION
When an admin deactivated a user, a KillSwitch:{userId} key was written to Redis DB 0 with an 8-hour TTL. On reactivation, nothing removed that key, so all platform services continued to reject the user's sign-in attempts via deserializeUser until the TTL expired naturally.