### PR TITLE
[NSA-9197] Fix config schema validation by using common schemas directly

### DIFF
--- a/DevOps/pipeline/azure-pipeline.yml
+++ b/DevOps/pipeline/azure-pipeline.yml
@@ -6,7 +6,7 @@ resources:
       type: github
       endpoint: DfE-Digital
       name: DFE-Digital/login.dfe.devops
-      ref: temp/nsa-9197-schema-validation-test
+      ref: main
 
 trigger:
   branches:

--- a/DevOps/pipeline/azure-pipeline.yml
+++ b/DevOps/pipeline/azure-pipeline.yml
@@ -6,7 +6,7 @@ resources:
       type: github
       endpoint: DfE-Digital
       name: DFE-Digital/login.dfe.devops
-      ref: main
+      ref: temp/nsa-9197-schema-validation-test
 
 trigger:
   branches:

--- a/src/infrastructure/config/schema.js
+++ b/src/infrastructure/config/schema.js
@@ -61,7 +61,7 @@ const auditSchema = new SimpleSchema({
     allowedValues: ['static', 'sequelize']
   },
   params: {
-    type: new SimpleSchema({ ...schemas.sequelizeConnection }),
+    type: schemas.sequelizeConnection,
     optional: true,
     custom: function () {
       if (this.siblingField('type').value === 'sequelize' && !this.isSet) {
@@ -174,21 +174,21 @@ const encryptionSchema = new SimpleSchema({
 });
 
 const schema = new SimpleSchema({
-  loggerSettings: new SimpleSchema({ ...schemas.loggerSettings }),
+  loggerSettings: schemas.loggerSettings,
   hostingEnvironment: schemas.hostingEnvironment,
   identifyingParty: identifyingPartySchema,
   cache: cacheSchema,
   claims: claimsSchema,
-  directories: new SimpleSchema({ ...schemas.apiClient }),
-  organisations: new SimpleSchema({ ...schemas.apiClient }),
-  applications: new SimpleSchema({ ...schemas.apiClient }),
+  directories: schemas.apiClient,
+  organisations: schemas.apiClient,
+  applications: schemas.apiClient,
   access: accessIdentifiers,
-  search: new SimpleSchema({ ...schemas.apiClient }),
+  search: schemas.apiClient,
   audit: auditSchema,
   serviceMapping: serviceMappingSchema,
   toggles: togglesSchema,
   notifications: notificationsSchema,
-  assets: new SimpleSchema({ ...schemas.assets }),
+  assets: schemas.assets,
   adapter: adapterSchema,
   entra: entraSchema,
   encryption: encryptionSchema,


### PR DESCRIPTION
Replace new SimpleSchema({ ...schemas.xxx }) with schemas.xxx directly so custom validator functions run correctly and missing env vars raise errors at startup.