### PR TITLE
[NSA-9693] Fix: Display success banner when adding organisation to invited users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,4 @@ access.log
 .DS_Store
 .vscode/
 certs/
+.vscode/launch.json

--- a/src/app/users/getConfirmAssociateOrganisation.js
+++ b/src/app/users/getConfirmAssociateOrganisation.js
@@ -95,6 +95,7 @@ const getConfirmAssociateOrganisation = async (req, res) => {
 
   if (uid.startsWith("inv-")) {
     await addOrganisationToInvitation(uid, req);
+    res.flash("info", `${req.session.user.email} added to organisation`);
   } else {
     await addOrganisationToUser(uid, req);
     if (isEmailAllowed) {

--- a/test/app/users/getConfirmAssociateOrganisation.test.js
+++ b/test/app/users/getConfirmAssociateOrganisation.test.js
@@ -111,6 +111,18 @@ describe("when confirming new organisation association", () => {
     });
   });
 
+  it("then it should display a success banner when adding org to an invited user", async () => {
+    req.params.uid = "inv-user1";
+
+    await getConfirmAssociateOrganisation(req, res);
+
+    expect(res.flash.mock.calls).toHaveLength(1);
+    expect(res.flash.mock.calls[0][0]).toBe("info");
+    expect(res.flash.mock.calls[0][1]).toBe(
+      `${expectedEmailAddress} added to organisation`,
+    );
+  });
+
   it("then it should get the users pending requests", async () => {
     await getConfirmAssociateOrganisation(req, res);
 


### PR DESCRIPTION
**Problem**
When adding an organisation to a user with "invited" status, the success banner message ("email added to organisation") was not displayed, despite the operation succeeding. This resulted in inconsistent user experience compared to adding an organisation to active users.

**Root Cause**
In **getConfirmAssociateOrganisation.js**, the res.flash("info", ...) success message was only called for regular users (in the else branch) but was missing for invited users (the if branch when uid.startsWith("inv-")).

**Changes Made**
1- **getConfirmAssociateOrganisation.js**

2- Added **res.flash("info", ...)** call in the invitation branch to display the success banner for invited users
getConfirmAssociateOrganisation.test.js

3- Added test case: "then it should display a success banner when adding org to an invited user" to verify the fix and prevent regression

**Testing**
All existing tests pass (5/5)
New test covers the invited user scenario
Flash message now displays consistently for both regular and invited users