### PR TITLE
[NSA-9749] Add deactivation reason to bulk user actions

### DIFF
--- a/src/app/users/getBulkUserActionsEmails.js
+++ b/src/app/users/getBulkUserActionsEmails.js
@@ -32,6 +32,9 @@ const getBulkUserActionsEmails = async (req, res) => {
     currentPage: "users",
     users,
     validationMessages: {},
+    selectReason: "Select a reason",
+    reason: "",
+    deactivateUsersTicked: false,
   };
 
   res.render("users/views/bulkUserActionsEmails", model);

--- a/src/app/users/postBulkUserActionsEmails.js
+++ b/src/app/users/postBulkUserActionsEmails.js
@@ -23,6 +23,9 @@ const validateInput = async (req) => {
     currentPage: "users",
     users: [],
     validationMessages: {},
+    selectReason: req.body["select-reason"] || "Select a reason",
+    reason: req.body.reason || "",
+    deactivateUsersTicked: !!req.body["deactivate-users"],
   };
 
   const reqBody = req.body;
@@ -36,6 +39,27 @@ const validateInput = async (req) => {
     reqBody["remove-services-and-requests"] || false;
   if (!isDeactivateTicked && !isRemoveServicesAndRequestsTicked) {
     model.validationMessages.actions = "At least 1 action needs to be ticked";
+  }
+
+  if (isDeactivateTicked) {
+    const selectReason = reqBody["select-reason"] || "Select a reason";
+    const reason = reqBody.reason || "";
+    const isDefaultDropdownReasonSelected = selectReason === "Select a reason";
+    if (isDefaultDropdownReasonSelected) {
+      if (reason.trim().length === 0) {
+        model.validationMessages.reason =
+          "Please give a reason for deactivation";
+      } else if (reason.length > 1000) {
+        model.validationMessages.reason =
+          "Reason cannot be longer than 1000 characters";
+      }
+    } else if (reason.trim().length > 0) {
+      const reasonLengthToBeTested = `${selectReason} - ${reason}`;
+      if (reasonLengthToBeTested.length > 1000) {
+        model.validationMessages.reason =
+          "Reason cannot be longer than 1000 characters";
+      }
+    }
   }
 
   return model;
@@ -65,10 +89,10 @@ const deactivateUser = async (req, user, reason) => {
   await destroyUserSession(user.id);
 };
 
-const deactivateInvitedUser = async (req, user) => {
+const deactivateInvitedUser = async (req, user, reason) => {
   await updateInvitation({
     invitationId: user.id.replace("inv-", ""),
-    reason: "Bulk user deactivation",
+    reason,
     deactivated: true,
   });
   await updateInvitedUserIndex(user);
@@ -106,7 +130,18 @@ const postBulkUserActionsEmails = async (req, res) => {
   const isDeactivateTicked = reqBody["deactivate-users"] || false;
   const isRemoveServicesAndRequestsTicked =
     reqBody["remove-services-and-requests"] || false;
-  const userDeactivationReason = "Bulk user actions - deactivation";
+
+  const selectReason = reqBody["select-reason"] || "Select a reason";
+  const reasonText = (reqBody.reason || "").trim();
+  let userDeactivationReason;
+  if (selectReason !== "Select a reason") {
+    userDeactivationReason =
+      reasonText.length === 0
+        ? selectReason
+        : `${selectReason} - ${reasonText}`;
+  } else {
+    userDeactivationReason = reasonText;
+  }
 
   // Get all the inputs and figure out which users were ticked
   const tickedUsers = Object.keys(reqBody).filter((v) => v.startsWith("user-"));
@@ -116,7 +151,7 @@ const postBulkUserActionsEmails = async (req, res) => {
     const user = await getUserDetailsById(userId, req);
     if (isDeactivateTicked) {
       if (userId.startsWith("inv-")) {
-        await deactivateInvitedUser(req, user);
+        await deactivateInvitedUser(req, user, userDeactivationReason);
         logger.audit(
           `${req.user.email} (id: ${req.user.sub}) deactivated user invitation ${user.email} (id: ${userId})`,
           {

--- a/src/app/users/views/bulkUserActionsEmails.ejs
+++ b/src/app/users/views/bulkUserActionsEmails.ejs
@@ -89,10 +89,34 @@
                         <% } %>
                         <div class="govuk-checkboxes" data-module="govuk-checkboxes">
                             <div class="govuk-checkboxes__item">
-                                <input class="govuk-checkboxes__input" id="deactivate-users" name="deactivate-users" type="checkbox" value="deactivate-users">
+                                <input class="govuk-checkboxes__input" id="deactivate-users" name="deactivate-users" type="checkbox" value="deactivate-users" data-aria-controls="conditional-deactivate-users" <%- locals.deactivateUsersTicked ? 'checked' : '' %>>
                                 <label class="govuk-label govuk-checkboxes__label" for="deactivate-users">
                                 Deactivate users
                                 </label>
+                            </div>
+                            <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden" id="conditional-deactivate-users">
+                                <div class="govuk-form-group <%= (locals.validationMessages.reason !== undefined) ? 'govuk-form-group--error' : '' %>">
+                                    <label class="govuk-label" for="select-reason">Reason for deactivation of user (mandatory)</label>
+                                    <select class="govuk-select govuk-form-group govuk-!-margin-bottom-2" style="padding: 5px 0px;" name="select-reason" id="select-reason">
+                                        <option <%= locals.selectReason === 'Select a reason' ? 'selected' : '' %> value="Select a reason">Select a reason</option>
+                                        <option <%= locals.selectReason === 'Generic email' ? 'selected' : '' %> value="Generic email">Generic email</option>
+                                        <option <%= locals.selectReason === 'Generic/shared account' ? 'selected' : '' %> value="Generic/shared account">Generic/shared account</option>
+                                        <option <%= locals.selectReason === 'Username and email mismatch' ? 'selected' : '' %> value="Username and email mismatch">Username and email mismatch</option>
+                                        <option <%= locals.selectReason === 'User has left organisation' ? 'selected' : '' %> value="User has left organisation">User has left organisation</option>
+                                        <option <%= locals.selectReason === 'Security breach' ? 'selected' : '' %> value="Security breach">Security breach</option>
+                                        <option <%= locals.selectReason === 'Account inactivity (2 years +)' ? 'selected' : '' %> value="Account inactivity (2 years +)">Account inactivity (2 years +)</option>
+                                        <option <%= locals.selectReason === 'Student, parent or general enquiry' ? 'selected' : '' %> value="Student, parent or general enquiry">Student, parent or general enquiry</option>
+                                    </select>
+                                    <% if (locals.validationMessages.reason !== undefined) { %>
+                                    <p class="govuk-error-message" id="validation-reason"><%= locals.validationMessages.reason %></p>
+                                    <% } %>
+                                    <textarea class="govuk-textarea" rows="6" id="reason" name="reason"
+                                        placeholder="Please select a reason from the dropdown menu, or type a reason here."
+                                        <% if (locals.validationMessages.reason !== undefined) { %>
+                                        aria-invalid="true" aria-describedby="validation-reason"
+                                        <% } %>
+                                    ><%= locals.reason %></textarea>
+                                </div>
                             </div>
                             <div class="govuk-checkboxes__item">
                                 <input class="govuk-checkboxes__input" id="remove-services-and-requests" name="remove-services-and-requests" type="checkbox" value="remove-services-and-requests">

--- a/test/app/users/getBulkUserActionsEmails.test.js
+++ b/test/app/users/getBulkUserActionsEmails.test.js
@@ -60,6 +60,9 @@ describe("When processing a get for a bulk user action emails request", () => {
       csrfToken: "token",
       users: userSearchResult,
       validationMessages: {},
+      selectReason: "Select a reason",
+      reason: "",
+      deactivateUsersTicked: false,
     });
   });
 

--- a/test/app/users/postBulkUserActionsEmails.test.js
+++ b/test/app/users/postBulkUserActionsEmails.test.js
@@ -39,6 +39,7 @@ describe("When processing a post for the bulk user actions emails request for us
       body: {
         "deactivate-users": "deactivate-users",
         "remove-services-and-requests": "remove-services-and-requests",
+        "select-reason": "Security breach",
         "user-34080a9c-fd79-45a6-a092-4756264d5c85":
           "34080a9c-fd79-45a6-a092-4756264d5c85",
       },
@@ -178,6 +179,116 @@ describe("When processing a post for the bulk user actions emails request for us
       validationMessages: { actions: "At least 1 action needs to be ticked" },
     });
   });
+
+  it("renders the page with an error when deactivate is ticked but no reason is provided", async () => {
+    req = getRequestMock({
+      session: {
+        emails: "user.one@unit.test",
+      },
+      body: {
+        "deactivate-users": "deactivate-users",
+        "select-reason": "Select a reason",
+        reason: "",
+        "user-34080a9c-fd79-45a6-a092-4756264d5c85":
+          "34080a9c-fd79-45a6-a092-4756264d5c85",
+      },
+    });
+    await postBulkUserActionsEmails(req, res);
+
+    expect(res.render.mock.calls[0][0]).toBe(
+      "users/views/bulkUserActionsEmails",
+    );
+    expect(res.render.mock.calls[0][1]).toMatchObject({
+      csrfToken: "token",
+      validationMessages: { reason: "Please give a reason for deactivation" },
+    });
+  });
+
+  it("renders the page with an error when reason exceeds 1000 characters", async () => {
+    req = getRequestMock({
+      session: {
+        emails: "user.one@unit.test",
+      },
+      body: {
+        "deactivate-users": "deactivate-users",
+        "select-reason": "Select a reason",
+        reason: "a".repeat(1001),
+        "user-34080a9c-fd79-45a6-a092-4756264d5c85":
+          "34080a9c-fd79-45a6-a092-4756264d5c85",
+      },
+    });
+    await postBulkUserActionsEmails(req, res);
+
+    expect(res.render.mock.calls[0][0]).toBe(
+      "users/views/bulkUserActionsEmails",
+    );
+    expect(res.render.mock.calls[0][1]).toMatchObject({
+      csrfToken: "token",
+      validationMessages: {
+        reason: "Reason cannot be longer than 1000 characters",
+      },
+    });
+  });
+
+  it("redirects to /users on success when deactivate is ticked with a typed reason", async () => {
+    req = getRequestMock({
+      session: {
+        emails: "user.one@unit.test",
+      },
+      body: {
+        "deactivate-users": "deactivate-users",
+        "select-reason": "Select a reason",
+        reason: "User requested deactivation",
+        "user-34080a9c-fd79-45a6-a092-4756264d5c85":
+          "34080a9c-fd79-45a6-a092-4756264d5c85",
+      },
+    });
+    await postBulkUserActionsEmails(req, res);
+
+    expect(res.redirect.mock.calls).toHaveLength(1);
+    expect(res.redirect.mock.calls[0][0]).toBe("/users");
+  });
+
+  it("redirects to /users on success when deactivate is ticked with a dropdown reason and additional text", async () => {
+    req = getRequestMock({
+      session: {
+        emails: "user.one@unit.test",
+      },
+      body: {
+        "deactivate-users": "deactivate-users",
+        "select-reason": "Security breach",
+        reason: "Additional context",
+        "user-34080a9c-fd79-45a6-a092-4756264d5c85":
+          "34080a9c-fd79-45a6-a092-4756264d5c85",
+      },
+    });
+    await postBulkUserActionsEmails(req, res);
+
+    expect(res.redirect.mock.calls).toHaveLength(1);
+    expect(res.redirect.mock.calls[0][0]).toBe("/users");
+  });
+
+  it("returns selectReason and reason values to the view on validation error", async () => {
+    req = getRequestMock({
+      session: {
+        emails: "user.one@unit.test",
+      },
+      body: {
+        "deactivate-users": "deactivate-users",
+        "select-reason": "Select a reason",
+        reason: "",
+        "user-34080a9c-fd79-45a6-a092-4756264d5c85":
+          "34080a9c-fd79-45a6-a092-4756264d5c85",
+      },
+    });
+    await postBulkUserActionsEmails(req, res);
+
+    expect(res.render.mock.calls[0][1]).toMatchObject({
+      selectReason: "Select a reason",
+      reason: "",
+      deactivateUsersTicked: true,
+    });
+  });
 });
 
 describe("When processing a post for the bulk user actions emails request for invited users", () => {
@@ -207,6 +318,7 @@ describe("When processing a post for the bulk user actions emails request for in
       body: {
         "deactivate-users": "deactivate-users",
         "remove-services-and-requests": "remove-services-and-requests",
+        "select-reason": "Security breach",
         "user-inv-9a44a8f1-572d-47dd-b12b-415d2f5aaa63":
           "inv-9a44a8f1-572d-47dd-b12b-415d2f5aaa63",
       },


### PR DESCRIPTION
Summary
When performing bulk user deactivation, users were not prompted to provide a reason. This change adds the same reason capture flow (dropdown + optional free-text) that already exists on the individual user deactivation page.

Changes
bulkUserActionsEmails.ejs — Added a GOV.UK conditional reveal panel beneath the "Deactivate users" checkbox. When checked, it displays a mandatory reason dropdown (Generic email, Generic/shared account, Username and email mismatch, User has left organisation, Security breach, Account inactivity (2 years +), Student, parent or general enquiry) and an optional free-text textarea. Form values are preserved on validation error.

getBulkUserActionsEmails.js — Added selectReason, reason, and deactivateUsersTicked to the initial page model.

postBulkUserActionsEmails.js — Validates that a reason is provided when "Deactivate users" is ticked (mirrors single-user deactivation validation). The resolved reason (dropdown value, free-text, or combined) is now passed to both deactivateUser and deactivateInvitedUser instead of a hardcoded string.

Tests
Updated existing tests to include a select-reason in request bodies where deactivation is ticked.
Added new tests covering: missing reason, reason exceeding 1000 characters, typed-only reason, combined dropdown + typed reason, and correct model values being returned on validation error.