### PR TITLE
NSA-8157: Update Requests page filter to GDS style and add Type filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ access.log
 .vscode/
 certs/
 .vscode/launch.json
+.npmrc

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "helmet": "^7.2.0",
         "ioredis": "^5.6.1",
         "lodash": "^4.17.21",
-        "login.dfe.api-client": "^1.0.62",
+        "login.dfe.api-client": "^1.0.65",
         "login.dfe.async-retry": "github:DFE-Digital/login.dfe.async-retry#v2.0.3",
         "login.dfe.audit.winston-sequelize-transport": "^3.2.6",
         "login.dfe.config.schema.common": "^2.1.8",
@@ -7538,9 +7538,9 @@
       "license": "MIT"
     },
     "node_modules/login.dfe.api-client": {
-      "version": "1.0.64",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/login.dfe.api-client/-/login.dfe.api-client-1.0.64.tgz",
-      "integrity": "sha1-Na/zn0jpCnE1D8coAGWMvqjZnck=",
+      "version": "1.0.66",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/login.dfe.api-client/-/login.dfe.api-client-1.0.66.tgz",
+      "integrity": "sha1-oE9fYsUYWQBtAUOqnYcjAyGUHOk=",
       "dependencies": {
         "@azure/msal-node": "^3.1.0",
         "applicationinsights": "^2.9.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "helmet": "^7.2.0",
         "ioredis": "^5.6.1",
         "lodash": "^4.17.21",
-        "login.dfe.api-client": "^1.0.65",
+        "login.dfe.api-client": "^1.0.67",
         "login.dfe.async-retry": "github:DFE-Digital/login.dfe.async-retry#v2.0.3",
         "login.dfe.audit.winston-sequelize-transport": "^3.2.6",
         "login.dfe.config.schema.common": "^2.1.8",
@@ -7538,9 +7538,9 @@
       "license": "MIT"
     },
     "node_modules/login.dfe.api-client": {
-      "version": "1.0.66",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/login.dfe.api-client/-/login.dfe.api-client-1.0.66.tgz",
-      "integrity": "sha1-oE9fYsUYWQBtAUOqnYcjAyGUHOk=",
+      "version": "1.0.67",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/login.dfe.api-client/-/login.dfe.api-client-1.0.67.tgz",
+      "integrity": "sha1-R5gSTIGwwzHL3jgAxCXCjmxJUpA=",
       "dependencies": {
         "@azure/msal-node": "^3.1.0",
         "applicationinsights": "^2.9.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "helmet": "^7.2.0",
         "ioredis": "^5.6.1",
         "lodash": "^4.17.21",
-        "login.dfe.api-client": "^1.0.58",
+        "login.dfe.api-client": "^1.0.62",
         "login.dfe.async-retry": "github:DFE-Digital/login.dfe.async-retry#v2.0.3",
         "login.dfe.audit.winston-sequelize-transport": "^3.2.6",
         "login.dfe.config.schema.common": "^2.1.8",
@@ -1973,6 +1973,18 @@
         "win32"
       ]
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha1-9UPlxkRnINTPnkmKgwGd0VmXO8I=",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2622,9 +2634,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha1-VPxTI3phPYVMe9N0Y6rRffhyFOc=",
+      "version": "2.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha1-T0GkEZAhbuNgZ+w4FSb+lTnE8K4=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3287,9 +3299,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha1-q5tFRGblqMw6GHvqrVgEEqnFuEM=",
+      "version": "1.1.14",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha1-2d5gI3DZE0fNndrRIk1P1wHrNIs=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3407,9 +3419,9 @@
       }
     },
     "node_modules/bullmq/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha1-lUkCi+F1O7k0/JbivKCbtBBa6RI=",
+      "version": "11.1.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha1-9tgdLhxl0Adi5eKbFsXS2ZXiCK0=",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -4981,9 +4993,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/fast-xml-builder/-/fast-xml-builder-1.1.2.tgz",
-      "integrity": "sha1-UqH31jntLcxcFE1sWDdyluUuat0=",
+      "version": "1.2.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha1-q9I2MUWnYl2Xia2W2jdfq+PP8ow=",
       "funding": [
         {
           "type": "github",
@@ -4992,13 +5004,14 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/fast-xml-parser/-/fast-xml-parser-5.5.3.tgz",
-      "integrity": "sha1-IWau+K4dPZ0PFln0KIK1xbk75/s=",
+      "version": "5.8.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
+      "integrity": "sha1-ZNcfD41L8jYh3/12Ku9+mMGIT8E=",
       "funding": [
         {
           "type": "github",
@@ -5007,9 +5020,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.1.2",
-        "path-expression-matcher": "^1.1.3",
-        "strnum": "^2.1.2"
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.2.0",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.3.0",
+        "xml-naming": "^0.1.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -5086,9 +5101,9 @@
       }
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha1-VPxTI3phPYVMe9N0Y6rRffhyFOc=",
+      "version": "2.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha1-T0GkEZAhbuNgZ+w4FSb+lTnE8K4=",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -5169,9 +5184,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha1-Z8j62VRUp8er6/dLt47nSkQCM1g=",
+      "version": "3.4.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha1-9cI8EH8PN96NvfJPE3IrO5jVJyY=",
       "dev": true,
       "license": "ISC"
     },
@@ -7322,9 +7337,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha1-8ROwN4OGEDvk9okziMc9C95/LFo=",
+      "version": "4.18.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha1-/ytmwfYybVlRPeJAe/iBQ5gSdxw=",
       "license": "MIT"
     },
     "node_modules/lodash.defaults": {
@@ -7523,9 +7538,9 @@
       "license": "MIT"
     },
     "node_modules/login.dfe.api-client": {
-      "version": "1.0.62",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/login.dfe.api-client/-/login.dfe.api-client-1.0.62.tgz",
-      "integrity": "sha1-lvwZBvi1JKVYgonl/lo3ugJqGFw=",
+      "version": "1.0.64",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/login.dfe.api-client/-/login.dfe.api-client-1.0.64.tgz",
+      "integrity": "sha1-Na/zn0jpCnE1D8coAGWMvqjZnck=",
       "dependencies": {
         "@azure/msal-node": "^3.1.0",
         "applicationinsights": "^2.9.6",
@@ -8459,9 +8474,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.1.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/path-expression-matcher/-/path-expression-matcher-1.1.3.tgz",
-      "integrity": "sha1-i/fGKdwbEU5CtjPAcfBtFGJbTg0=",
+      "version": "1.5.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha1-O5hUXciP/rtZPi2EWNCSnaknX0o=",
       "funding": [
         {
           "type": "github",
@@ -8500,9 +8515,9 @@
       "license": "MIT"
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha1-1eGhLkeKl21DLvPFjVNLmSMWS7c=",
+      "version": "0.1.13",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha1-myLsFrw6uI0FoMfjaYaUIUAasX0=",
       "license": "MIT"
     },
     "node_modules/pause": {
@@ -8606,9 +8621,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha1-O6ODNzNkbZ0+SZWUbBNlpn+wekI=",
+      "version": "2.3.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha1-WpQpFeJrNy3A8OZ1MUmhbmscVgE=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10013,9 +10028,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.1.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/strnum/-/strnum-2.1.2.tgz",
-      "integrity": "sha1-peALpmqyX5yvo3JrVnznpJFwk3o=",
+      "version": "2.3.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha1-gb+/71PbjDIX6mKpjAJohuxKJ2E=",
       "funding": [
         {
           "type": "github",
@@ -10346,9 +10361,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "13.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/uuid/-/uuid-13.0.0.tgz",
-      "integrity": "sha1-Jj3DQbGbTXVeuP42t42VprZXB+g=",
+      "version": "13.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/uuid/-/uuid-13.0.2.tgz",
+      "integrity": "sha1-QbycB7EvZlCJwgX2UHl2rb34T/g=",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -10652,6 +10667,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha1-ircQbFuNI8qi+rrByt8XE2N5+9g=",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/xtend/-/xtend-4.0.2.tgz",
@@ -10679,9 +10709,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/yaml/-/yaml-2.8.1.tgz",
-      "integrity": "sha1-GHCqArYx9+gyi5P4vFdPrF1sTXk=",
+      "version": "2.9.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha1-eCdK/ZNZih391hMN9qVm3vy/mqQ=",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -10689,6 +10719,9 @@
       },
       "engines": {
         "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "helmet": "^7.2.0",
     "ioredis": "^5.6.1",
     "lodash": "^4.17.21",
-    "login.dfe.api-client": "^1.0.65",
+    "login.dfe.api-client": "^1.0.66",
     "login.dfe.async-retry": "github:DFE-Digital/login.dfe.async-retry#v2.0.3",
     "login.dfe.audit.winston-sequelize-transport": "^3.2.6",
     "login.dfe.config.schema.common": "^2.1.8",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "helmet": "^7.2.0",
     "ioredis": "^5.6.1",
     "lodash": "^4.17.21",
-    "login.dfe.api-client": "^1.0.66",
+    "login.dfe.api-client": "^1.0.67",
     "login.dfe.async-retry": "github:DFE-Digital/login.dfe.async-retry#v2.0.3",
     "login.dfe.audit.winston-sequelize-transport": "^3.2.6",
     "login.dfe.config.schema.common": "^2.1.8",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "helmet": "^7.2.0",
     "ioredis": "^5.6.1",
     "lodash": "^4.17.21",
-    "login.dfe.api-client": "^1.0.64",
+    "login.dfe.api-client": "^1.0.65",
     "login.dfe.async-retry": "github:DFE-Digital/login.dfe.async-retry#v2.0.3",
     "login.dfe.audit.winston-sequelize-transport": "^3.2.6",
     "login.dfe.config.schema.common": "^2.1.8",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "helmet": "^7.2.0",
     "ioredis": "^5.6.1",
     "lodash": "^4.17.21",
-    "login.dfe.api-client": "^1.0.62",
+    "login.dfe.api-client": "^1.0.64",
     "login.dfe.async-retry": "github:DFE-Digital/login.dfe.async-retry#v2.0.3",
     "login.dfe.audit.winston-sequelize-transport": "^3.2.6",
     "login.dfe.config.schema.common": "^2.1.8",

--- a/src/app/accessRequests/approveServiceRequest.js
+++ b/src/app/accessRequests/approveServiceRequest.js
@@ -1,0 +1,65 @@
+const { NotificationClient } = require("login.dfe.jobs-client");
+const { getAndMapServiceRequest } = require("./utils");
+const logger = require("../../infrastructure/logger");
+const config = require("../../infrastructure/config");
+const { updateServiceRequest } = require("login.dfe.api-client/services");
+const { addServiceToUser } = require("login.dfe.api-client/users");
+
+const post = async (req, res) => {
+  const request = await getAndMapServiceRequest(req);
+  if (!request) {
+    return res.status(404).render("errors/notFound");
+  }
+
+  const roleIds = request.role_ids
+    ? request.role_ids
+        .split(",")
+        .map((r) => r.trim())
+        .filter(Boolean)
+    : [];
+
+  await addServiceToUser({
+    userId: request.user_id,
+    serviceId: request.service_id,
+    organisationId: request.org_id,
+    serviceRoleIds: roleIds,
+  });
+
+  await updateServiceRequest({
+    serviceRequestId: request.id,
+    status: 1,
+    actionedByUserId: req.user.sub,
+    actionedAt: new Date(),
+    reason: "",
+  });
+
+  const notificationClient = new NotificationClient({
+    connectionString: config.notifications.connectionString,
+  });
+  await notificationClient.sendAccessRequest(
+    request.usersEmail,
+    request.usersName,
+    request.org_name,
+    true,
+    null,
+  );
+
+  logger.audit(
+    `${req.user.email} approved service request for ${request.usersEmail}`,
+    {
+      type: "approver",
+      subType: "service-request-approved",
+      userId: req.user.sub,
+      serviceId: request.service_id,
+      editedUser: request.user_id,
+    },
+  );
+
+  res.flash(
+    "info",
+    `Request approved - an email has been sent to ${request.usersEmail}.`,
+  );
+  return res.redirect("/access-requests");
+};
+
+module.exports = { post };

--- a/src/app/accessRequests/index.js
+++ b/src/app/accessRequests/index.js
@@ -22,6 +22,15 @@ const {
   get: getSelectPermissionLevel,
   post: postSelectPermissionLevel,
 } = require("./selectPermissionLevel");
+const {
+  get: getReviewServiceRequest,
+  post: postReviewServiceRequest,
+} = require("./reviewServiceRequest");
+const {
+  get: getRejectServiceRequest,
+  post: postRejectServiceRequest,
+} = require("./rejectServiceRequest");
+const { post: postApproveServiceRequest } = require("./approveServiceRequest");
 
 const router = express.Router({ mergeParams: true });
 
@@ -64,6 +73,32 @@ const users = (csrf) => {
     "/:rid/:from?/approve",
     csrf,
     asyncWrapper(postSelectPermissionLevel),
+  );
+
+  router.get(
+    "/:rid/service-request/review",
+    csrf,
+    asyncWrapper(getReviewServiceRequest),
+  );
+  router.post(
+    "/:rid/service-request/review",
+    csrf,
+    asyncWrapper(postReviewServiceRequest),
+  );
+  router.get(
+    "/:rid/service-request/reject",
+    csrf,
+    asyncWrapper(getRejectServiceRequest),
+  );
+  router.post(
+    "/:rid/service-request/reject",
+    csrf,
+    asyncWrapper(postRejectServiceRequest),
+  );
+  router.post(
+    "/:rid/service-request/approve",
+    csrf,
+    asyncWrapper(postApproveServiceRequest),
   );
 
   return router;

--- a/src/app/accessRequests/index.js
+++ b/src/app/accessRequests/index.js
@@ -45,6 +45,32 @@ const users = (csrf) => {
   router.post("/", csrf, asyncWrapper(postOrganisationRequests));
 
   router.get(
+    "/:rid/service-request/review",
+    csrf,
+    asyncWrapper(getReviewServiceRequest),
+  );
+  router.post(
+    "/:rid/service-request/review",
+    csrf,
+    asyncWrapper(postReviewServiceRequest),
+  );
+  router.get(
+    "/:rid/service-request/reject",
+    csrf,
+    asyncWrapper(getRejectServiceRequest),
+  );
+  router.post(
+    "/:rid/service-request/reject",
+    csrf,
+    asyncWrapper(postRejectServiceRequest),
+  );
+  router.post(
+    "/:rid/service-request/approve",
+    csrf,
+    asyncWrapper(postApproveServiceRequest),
+  );
+
+  router.get(
     "/:rid/:from?/review",
     csrf,
     asyncWrapper(getReviewOrganisationRequest),
@@ -73,32 +99,6 @@ const users = (csrf) => {
     "/:rid/:from?/approve",
     csrf,
     asyncWrapper(postSelectPermissionLevel),
-  );
-
-  router.get(
-    "/:rid/service-request/review",
-    csrf,
-    asyncWrapper(getReviewServiceRequest),
-  );
-  router.post(
-    "/:rid/service-request/review",
-    csrf,
-    asyncWrapper(postReviewServiceRequest),
-  );
-  router.get(
-    "/:rid/service-request/reject",
-    csrf,
-    asyncWrapper(getRejectServiceRequest),
-  );
-  router.post(
-    "/:rid/service-request/reject",
-    csrf,
-    asyncWrapper(postRejectServiceRequest),
-  );
-  router.post(
-    "/:rid/service-request/approve",
-    csrf,
-    asyncWrapper(postApproveServiceRequest),
   );
 
   return router;

--- a/src/app/accessRequests/organisationRequests.js
+++ b/src/app/accessRequests/organisationRequests.js
@@ -5,6 +5,7 @@ const { dateFormat } = require("../helpers/dateFormatterHelper");
 const {
   mapStatusForSupport,
   userStatusMap,
+  requestTypeMap,
   unpackMultiSelect,
   search,
 } = require("./utils");
@@ -30,6 +31,7 @@ const getFiltersModel = async (req) => {
   }
 
   let requestStatuses = [];
+  let requestTypes = [];
 
   if (showFilters) {
     const selectedRequestStatuses = unpackMultiSelect(paramsSource.status);
@@ -42,11 +44,22 @@ const getFiltersModel = async (req) => {
           undefined,
       };
     });
+
+    const selectedRequestTypes = unpackMultiSelect(paramsSource.requestType);
+    requestTypes = requestTypeMap.map((type) => {
+      return {
+        id: type.id,
+        name: type.name,
+        isSelected:
+          selectedRequestTypes.find((x) => x === type.id) !== undefined,
+      };
+    });
   }
 
   return {
     showFilters,
     requestStatuses,
+    requestTypes,
   };
 };
 

--- a/src/app/accessRequests/organisationRequests.js
+++ b/src/app/accessRequests/organisationRequests.js
@@ -30,31 +30,25 @@ const getFiltersModel = async (req) => {
     showFilters = true;
   }
 
-  let requestStatuses = [];
-  let requestTypes = [];
+  const selectedRequestStatuses = unpackMultiSelect(paramsSource.status);
+  const requestStatuses = userStatusMap.map((status) => {
+    return {
+      id: status.id,
+      name: status.name,
+      isSelected:
+        selectedRequestStatuses.find((x) => x === status.id.toString()) !==
+        undefined,
+    };
+  });
 
-  if (showFilters) {
-    const selectedRequestStatuses = unpackMultiSelect(paramsSource.status);
-    requestStatuses = userStatusMap.map((status) => {
-      return {
-        id: status.id,
-        name: status.name,
-        isSelected:
-          selectedRequestStatuses.find((x) => x === status.id.toString()) !==
-          undefined,
-      };
-    });
-
-    const selectedRequestTypes = unpackMultiSelect(paramsSource.requestType);
-    requestTypes = requestTypeMap.map((type) => {
-      return {
-        id: type.id,
-        name: type.name,
-        isSelected:
-          selectedRequestTypes.find((x) => x === type.id) !== undefined,
-      };
-    });
-  }
+  const selectedRequestTypes = unpackMultiSelect(paramsSource.requestType);
+  const requestTypes = requestTypeMap.map((type) => {
+    return {
+      id: type.id,
+      name: type.name,
+      isSelected: selectedRequestTypes.find((x) => x === type.id) !== undefined,
+    };
+  });
 
   return {
     showFilters,

--- a/src/app/accessRequests/rejectServiceRequest.js
+++ b/src/app/accessRequests/rejectServiceRequest.js
@@ -1,0 +1,84 @@
+const { NotificationClient } = require("login.dfe.jobs-client");
+const { getAndMapServiceRequest } = require("./utils");
+const logger = require("../../infrastructure/logger");
+const config = require("../../infrastructure/config");
+const { updateServiceRequest } = require("login.dfe.api-client/services");
+
+const notificationClient = new NotificationClient({
+  connectionString: config.notifications.connectionString,
+});
+
+const get = async (req, res) => {
+  return res.render("accessRequests/views/rejectServiceRequest", {
+    csrfToken: req.csrfToken(),
+    title: "Reason for rejection - DfE Sign-in",
+    backLink: true,
+    layout: "sharedViews/layout.ejs",
+    cancelLink: `/access-requests/${req.params.rid}/service-request/review`,
+    reason: "",
+    validationMessages: {},
+  });
+};
+
+const validate = async (req) => {
+  const request = await getAndMapServiceRequest(req);
+  const model = {
+    title: "Reason for rejection - DfE Sign-in",
+    layout: "sharedViews/layout.ejs",
+    backLink: true,
+    cancelLink: `/access-requests/${req.params.rid}/service-request/review`,
+    reason: req.body.reason,
+    request,
+    validationMessages: {},
+  };
+  if (model.reason.length > 1000) {
+    model.validationMessages.reason =
+      "Reason cannot be longer than 1000 characters";
+  }
+  return model;
+};
+
+const post = async (req, res) => {
+  const model = await validate(req);
+
+  if (Object.keys(model.validationMessages).length > 0) {
+    model.csrfToken = req.csrfToken();
+    return res.render("accessRequests/views/rejectServiceRequest", model);
+  }
+
+  await updateServiceRequest({
+    serviceRequestId: model.request.id,
+    status: -1,
+    actionedByUserId: req.user.sub,
+    actionedAt: new Date(),
+    reason: model.reason,
+  });
+
+  await notificationClient.sendAccessRequest(
+    model.request.usersEmail,
+    model.request.usersName,
+    model.request.org_name,
+    false,
+    model.reason,
+  );
+
+  logger.audit(
+    `${req.user.email} rejected service request for ${model.request.usersEmail}`,
+    {
+      type: "approver",
+      subType: "service-request-rejected",
+      userId: req.user.sub,
+      serviceId: model.request.service_id,
+      editedUser: model.request.user_id,
+      reason: model.reason,
+    },
+  );
+
+  res.flash(
+    "rejected",
+    `Request rejected - an email has been sent to ${model.request.usersEmail}.`,
+  );
+  return res.redirect("/access-requests");
+};
+
+module.exports = { get, post };

--- a/src/app/accessRequests/rejectServiceRequest.js
+++ b/src/app/accessRequests/rejectServiceRequest.js
@@ -4,10 +4,6 @@ const logger = require("../../infrastructure/logger");
 const config = require("../../infrastructure/config");
 const { updateServiceRequest } = require("login.dfe.api-client/services");
 
-const notificationClient = new NotificationClient({
-  connectionString: config.notifications.connectionString,
-});
-
 const get = async (req, res) => {
   return res.render("accessRequests/views/rejectServiceRequest", {
     csrfToken: req.csrfToken(),
@@ -54,6 +50,9 @@ const post = async (req, res) => {
     reason: model.reason,
   });
 
+  const notificationClient = new NotificationClient({
+    connectionString: config.notifications.connectionString,
+  });
   await notificationClient.sendAccessRequest(
     model.request.usersEmail,
     model.request.usersName,

--- a/src/app/accessRequests/reviewServiceRequest.js
+++ b/src/app/accessRequests/reviewServiceRequest.js
@@ -24,6 +24,9 @@ const get = async (req, res) => {
 
 const validate = async (req) => {
   const request = await getAndMapServiceRequest(req);
+  if (!request) {
+    return null;
+  }
   request.formattedCreatedDate = request.created_date
     ? dateFormat(request.created_date, "longDateFormat")
     : "";
@@ -46,15 +49,23 @@ const validate = async (req) => {
 const post = async (req, res) => {
   const model = await validate(req);
 
+  if (!model) {
+    return res.status(404).render("errors/notFound");
+  }
+
   if (Object.keys(model.validationMessages).length > 0) {
     model.csrfToken = req.csrfToken();
     return res.render("accessRequests/views/reviewServiceRequest", model);
   }
 
   if (model.selectedResponse === "reject") {
-    return res.redirect("service-request/reject");
+    return res.redirect(
+      `/access-requests/${req.params.rid}/service-request/reject`,
+    );
   } else if (model.selectedResponse === "approve") {
-    return res.redirect("service-request/approve");
+    return res.redirect(
+      `/access-requests/${req.params.rid}/service-request/approve`,
+    );
   }
 };
 

--- a/src/app/accessRequests/reviewServiceRequest.js
+++ b/src/app/accessRequests/reviewServiceRequest.js
@@ -1,0 +1,61 @@
+const { getAndMapServiceRequest } = require("./utils");
+const { dateFormat } = require("../helpers/dateFormatterHelper");
+
+const get = async (req, res) => {
+  const request = await getAndMapServiceRequest(req);
+  if (!request) {
+    return res.status(404).render("errors/notFound");
+  }
+  request.formattedCreatedDate = request.created_date
+    ? dateFormat(request.created_date, "longDateFormat")
+    : "";
+
+  return res.render("accessRequests/views/reviewServiceRequest", {
+    csrfToken: req.csrfToken(),
+    title: "Review request - DfE Sign-in",
+    layout: "sharedViews/layout.ejs",
+    backLink: true,
+    cancelLink: "/access-requests",
+    request,
+    selectedResponse: null,
+    validationMessages: {},
+  });
+};
+
+const validate = async (req) => {
+  const request = await getAndMapServiceRequest(req);
+  request.formattedCreatedDate = request.created_date
+    ? dateFormat(request.created_date, "longDateFormat")
+    : "";
+  const model = {
+    title: "Review request - DfE Sign-in",
+    layout: "sharedViews/layout.ejs",
+    backLink: true,
+    cancelLink: "/access-requests",
+    request,
+    selectedResponse: req.body.selectedResponse,
+    validationMessages: {},
+  };
+  if (!model.selectedResponse) {
+    model.validationMessages.selectedResponse =
+      "Approve or Reject must be selected";
+  }
+  return model;
+};
+
+const post = async (req, res) => {
+  const model = await validate(req);
+
+  if (Object.keys(model.validationMessages).length > 0) {
+    model.csrfToken = req.csrfToken();
+    return res.render("accessRequests/views/reviewServiceRequest", model);
+  }
+
+  if (model.selectedResponse === "reject") {
+    return res.redirect("service-request/reject");
+  } else if (model.selectedResponse === "approve") {
+    return res.redirect("service-request/approve");
+  }
+};
+
+module.exports = { get, post };

--- a/src/app/accessRequests/utils.js
+++ b/src/app/accessRequests/utils.js
@@ -10,7 +10,9 @@ const {
 const {
   getOrganisationRaw,
   getOrganisationRequestsRaw,
+  getServiceRequestRaw,
 } = require("login.dfe.api-client/organisations");
+const { getServiceRaw } = require("login.dfe.api-client/services");
 
 const unpackMultiSelect = (parameter) => {
   if (!parameter) {
@@ -156,6 +158,30 @@ const getAndMapOrgRequest = async (req) => {
   return mappedRequest;
 };
 
+const getAndMapServiceRequest = async (req) => {
+  const request = await getServiceRequestRaw({
+    serviceRequestId: req.params.rid,
+  });
+
+  if (!request) {
+    return null;
+  }
+
+  const [user, service] = await Promise.all([
+    getUserRaw({ by: { id: request.user_id } }),
+    getServiceRaw({ by: { serviceId: request.service_id } }),
+  ]);
+
+  return Object.assign(
+    {
+      usersName: user ? `${user.given_name} ${user.family_name}` : "",
+      usersEmail: user ? user.email : "",
+      serviceName: service ? service.name : "",
+    },
+    request,
+  );
+};
+
 const mapStatusForSupport = (status) => {
   switch (status.id) {
     case 0:
@@ -186,6 +212,7 @@ module.exports = {
   getById,
   putUserInOrganisation,
   getAndMapOrgRequest,
+  getAndMapServiceRequest,
   mapStatusForSupport,
   unpackMultiSelect,
   userStatusMap,

--- a/src/app/accessRequests/utils.js
+++ b/src/app/accessRequests/utils.js
@@ -30,9 +30,11 @@ const search = async (req) => {
     page = 1;
   }
   const filterStatus = unpackMultiSelect(paramsSource.status);
+  const filterType = unpackMultiSelect(paramsSource.requestType);
   const results = await getOrganisationRequestsRaw({
     pageNumber: page,
     filterStatus,
+    filterType,
   });
 
   return {
@@ -173,6 +175,12 @@ const userStatusMap = [
   { id: 3, name: "No Approvers - Escalated to support" },
 ];
 
+const requestTypeMap = [
+  { id: "organisation", name: "Organisation" },
+  { id: "service", name: "Service" },
+  { id: "subService", name: "Sub-service" },
+];
+
 module.exports = {
   search,
   getById,
@@ -181,4 +189,5 @@ module.exports = {
   mapStatusForSupport,
   unpackMultiSelect,
   userStatusMap,
+  requestTypeMap,
 };

--- a/src/app/accessRequests/views/organisationRequests.ejs
+++ b/src/app/accessRequests/views/organisationRequests.ejs
@@ -66,7 +66,7 @@
             </form>
             <form method="post" class="show-filters">
                 <input type="hidden" name="_csrf" value="<%= csrfToken %>"/>
-                <input type="hidden" name="page" value="1"/>
+                <input type="hidden" name="page" value="<%= page %>"/>
                 <input type="hidden" name="showFilters" value="<%= !showFilters %>"/>
                 <% for (let i = 0; i < requestStatuses.length; i++) { %>
                     <% if (requestStatuses[i].isSelected) { %>

--- a/src/app/accessRequests/views/organisationRequests.ejs
+++ b/src/app/accessRequests/views/organisationRequests.ejs
@@ -66,8 +66,18 @@
             </form>
             <form method="post" class="show-filters">
                 <input type="hidden" name="_csrf" value="<%= csrfToken %>"/>
-                <input type="hidden" name="page" value="<%= page %>"/>
+                <input type="hidden" name="page" value="1"/>
                 <input type="hidden" name="showFilters" value="<%= !showFilters %>"/>
+                <% for (let i = 0; i < requestStatuses.length; i++) { %>
+                    <% if (requestStatuses[i].isSelected) { %>
+                    <input type="hidden" name="status" value="<%= requestStatuses[i].id %>"/>
+                    <% } %>
+                <% } %>
+                <% for (let i = 0; i < requestTypes.length; i++) { %>
+                    <% if (requestTypes[i].isSelected) { %>
+                    <input type="hidden" name="requestType" value="<%= requestTypes[i].id %>"/>
+                    <% } %>
+                <% } %>
                 <button type="submit" class="govuk-button govuk-button--secondary filter-link govuk-!-margin-top-4 govuk-!-margin-padding-2"><%= (showFilters ? 'Hide' : 'Show') %> filters</button>
             </form>
         </div>
@@ -78,7 +88,7 @@
             <div class="govuk-grid-column-one-third">
                 <form method="post">
                     <input type="hidden" name="_csrf" value="<%= csrfToken %>"/>
-                    <input type="hidden" name="page" value="<%= page %>"/>
+                    <input type="hidden" name="page" value="1"/>
                     <input type="hidden" name="showFilters" value="true"/>
 
                     <div class="govuk-form-group">

--- a/src/app/accessRequests/views/organisationRequests.ejs
+++ b/src/app/accessRequests/views/organisationRequests.ejs
@@ -39,6 +39,12 @@
                     }
                     return result;
                 }, [])},
+            { key: 'requestType', value: locals.requestTypes.reduce((result, element) => {
+                    if(element.isSelected) {
+                        result.push(element.id);
+                    }
+                    return result;
+                }, [])},
         ]
     }
     %>
@@ -69,30 +75,56 @@
 
     <div class="govuk-grid-row">
         <% if (showFilters) { %>
-            <div class="govuk-grid-column-one-quarter">
+            <div class="govuk-grid-column-one-third">
                 <form method="post">
                     <input type="hidden" name="_csrf" value="<%= csrfToken %>"/>
                     <input type="hidden" name="page" value="<%= page %>"/>
                     <input type="hidden" name="showFilters" value="true"/>
 
-                    <div class="filter-box">
-                        <div class="container-head js-container-head">
-                            <div class="govuk-heading-s govuk-!-margin-0 govuk-!-padding-1 govuk-!-padding-left-2">
+                    <div class="govuk-form-group">
+                        <fieldset class="govuk-fieldset">
+                            <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
                                 Request status
-                            </div>
-                        </div>
-                        <div role="group" aria-labelledby="option-select-title-request-status" class="options-container"
-                            id="request-status">
-                            <div class="govuk-body"">
+                            </legend>
+                            <div class="govuk-checkboxes" data-module="govuk-checkboxes">
                                 <% for (let i = 0; i < requestStatuses.length; i += 1) { %>
-                                    <label>
-                                        <input name="status" value="<%= requestStatuses[i].id %>"
-                                            type="checkbox" <%= (requestStatuses[i].isSelected ? 'checked="checked"' : '') %>>
-                                        <%= requestStatuses[i].name %>
-                                    </label>
+                                    <div class="govuk-checkboxes__item">
+                                        <input class="govuk-checkboxes__input"
+                                            id="requestStatus-<%= requestStatuses[i].id %>"
+                                            name="status"
+                                            type="checkbox"
+                                            value="<%= requestStatuses[i].id %>"
+                                            <%= (requestStatuses[i].isSelected ? 'checked' : '') %>>
+                                        <label class="govuk-label govuk-checkboxes__label" for="requestStatus-<%= requestStatuses[i].id %>">
+                                            <%= requestStatuses[i].name %>
+                                        </label>
+                                    </div>
                                 <% } %>
                             </div>
-                        </div>
+                        </fieldset>
+                    </div>
+
+                    <div class="govuk-form-group">
+                        <fieldset class="govuk-fieldset">
+                            <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+                                Type
+                            </legend>
+                            <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+                                <% for (let i = 0; i < requestTypes.length; i += 1) { %>
+                                    <div class="govuk-checkboxes__item">
+                                        <input class="govuk-checkboxes__input"
+                                            id="requestType-<%= requestTypes[i].id %>"
+                                            name="requestType"
+                                            type="checkbox"
+                                            value="<%= requestTypes[i].id %>"
+                                            <%= (requestTypes[i].isSelected ? 'checked' : '') %>>
+                                        <label class="govuk-label govuk-checkboxes__label" for="requestType-<%= requestTypes[i].id %>">
+                                            <%= requestTypes[i].name %>
+                                        </label>
+                                    </div>
+                                <% } %>
+                            </div>
+                        </fieldset>
                     </div>
 
                     <button class="govuk-button govuk-button--secondary" data-module="govuk-button">Apply filter</button>
@@ -100,7 +132,7 @@
                 </form>
             </div>
         <% } %>
-        <div class="govuk-grid-column-<%= (showFilters ? "three-quarters" : "full") %>">
+        <div class="govuk-grid-column-<%= (showFilters ? "two-thirds" : "full") %>">
             <%- include('../../sharedViews/paginationNew', paginationModel); %>
             <table class="govuk-table">
                 <thead class="govuk-table__head">
@@ -109,6 +141,7 @@
                     <th scope="col" class="govuk-table__header">Requested organisation</th>
                     <th scope="col" class="govuk-table__header">Requested by</th>
                     <th scope="col" class="govuk-table__header">Requester email</th>
+                    <th scope="col" class="govuk-table__header">Type</th>
                     <th scope="col" class="govuk-table__header">Status</th>
                     <th scope="col" class="govuk-table__header">Action</th>
                 </tr>
@@ -117,7 +150,7 @@
                 <tbody class="govuk-table__body">
                     <% if (locals.requests && locals.requests.length === 0) { %>
                         <tr class="govuk-table__row govuk-body">
-                            <td class="govuk-!-padding-top-3" colspan="6"><span class="empty-state">There are no outstanding requests.</span></td>
+                            <td class="govuk-!-padding-top-3" colspan="7"><span class="empty-state">There are no outstanding requests.</span></td>
                         </tr>
                     <% } else { %>
                     <% for (let i = 0; i < locals.requests.length; i++) { %>
@@ -126,6 +159,7 @@
                             <td class="govuk-table__cell govuk-body-s"><span class="govuk-!-text-break-word"><%= locals.requests[i].org_name %></span> </td>
                             <td class="govuk-table__cell govuk-body-s"><span class="govuk-!-text-break-word"><%= locals.requests[i].usersName %></span> </td>
                             <td class="govuk-table__cell govuk-body-s"><span class="govuk-!-text-break-word"><%= locals.requests[i].usersEmail %></span> </td>
+                            <td class="govuk-table__cell govuk-body-s"><span class="govuk-!-text-break-word"><%= locals.requests[i].request_type ? locals.requests[i].request_type.name : '' %></span> </td>
                             <td class="govuk-table__cell govuk-body-s"><span class="govuk-!-text-break-word"><%= locals.requests[i].statusText.name %></span> </td>
                             <td class="govuk-table__cell govuk-body-s"><span class="govuk-!-text-break-word"><a class="govuk-link" href="access-requests/<%= locals.requests[i].id %>/review">Review request</a></span> </td>
                         </tr>

--- a/src/app/accessRequests/views/organisationRequests.ejs
+++ b/src/app/accessRequests/views/organisationRequests.ejs
@@ -161,7 +161,10 @@
                             <td class="govuk-table__cell govuk-body-s"><span class="govuk-!-text-break-word"><%= locals.requests[i].usersEmail %></span> </td>
                             <td class="govuk-table__cell govuk-body-s"><span class="govuk-!-text-break-word"><%= locals.requests[i].request_type ? locals.requests[i].request_type.name : '' %></span> </td>
                             <td class="govuk-table__cell govuk-body-s"><span class="govuk-!-text-break-word"><%= locals.requests[i].statusText.name %></span> </td>
-                            <td class="govuk-table__cell govuk-body-s"><span class="govuk-!-text-break-word"><a class="govuk-link" href="access-requests/<%= locals.requests[i].id %>/review">Review request</a></span> </td>
+                            <% const reviewPath = locals.requests[i].request_type && locals.requests[i].request_type.id !== 'organisation'
+                                ? `access-requests/${locals.requests[i].id}/service-request/review`
+                                : `access-requests/${locals.requests[i].id}/review`; %>
+                            <td class="govuk-table__cell govuk-body-s"><span class="govuk-!-text-break-word"><a class="govuk-link" href="<%= reviewPath %>">Review request</a></span> </td>
                         </tr>
                         <% } %>
                     <% } %>

--- a/src/app/accessRequests/views/rejectServiceRequest.ejs
+++ b/src/app/accessRequests/views/rejectServiceRequest.ejs
@@ -1,0 +1,30 @@
+<div class="govuk-width-container">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-heading-xl">
+                Reason for rejection
+            </h1>
+            <form method="post" id="form-reject" class="prevent-form-double-submission">
+                <input type="hidden" name="_csrf" value="<%= csrfToken %>"/>
+                <fieldset class="govuk-fieldset">
+                    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l"><p class="govuk-body">Please give the reason why you have rejected this request. This will be recorded for audit purposes and shared with the requester.</p></legend>
+                    <div class="govuk-form-group <%= (locals.validationMessages.reason !== undefined) ? 'govuk-form-group--error' : '' %>">
+                        <label class="govuk-label" for="reason">Reason for rejection (optional)</label>
+                        <% if (locals.validationMessages.reason !== undefined) { %>
+                            <p class="govuk-error-message" id="validation-reason"><%= locals.validationMessages.reason %></p>
+                        <% } %>
+                        <textarea class="govuk-textarea" rows="6" id="reason" name="reason"
+                            <% if (locals.validationMessages.reason !== undefined) { %>
+                                aria-invalid="true" aria-describedby="validation-reason"
+                            <% } %>
+                            ><%= locals.reason %></textarea>
+                    </div>
+                </fieldset>
+                <div class="govuk-button-group">
+                    <button type="submit" class="govuk-button">Confirm</button>
+                    <a href="<%= locals.cancelLink %>" class="govuk-button govuk-button--secondary">Cancel</a>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>

--- a/src/app/accessRequests/views/reviewServiceRequest.ejs
+++ b/src/app/accessRequests/views/reviewServiceRequest.ejs
@@ -1,0 +1,71 @@
+<div class="govuk-width-container">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-half">
+            <h1 class="govuk-heading-xl">
+                Review request
+            </h1>
+            <p class="govuk-body">Review these details before actioning the <%= locals.request.request_type ? locals.request.request_type.name.toLowerCase() : 'service' %> request for <%= locals.request.usersName %>.</p>
+
+            <dl class="govuk-summary-list">
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">Name</dt>
+                    <dd class="govuk-summary-list__value"><%= locals.request.usersName %></dd>
+                </div>
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">Email address</dt>
+                    <dd class="govuk-summary-list__value"><%= locals.request.usersEmail %></dd>
+                </div>
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">Date</dt>
+                    <dd class="govuk-summary-list__value"><%= request.formattedCreatedDate %></dd>
+                </div>
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">Organisation</dt>
+                    <dd class="govuk-summary-list__value"><%= locals.request.org_name %></dd>
+                </div>
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">Service</dt>
+                    <dd class="govuk-summary-list__value"><%= locals.request.serviceName %></dd>
+                </div>
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">Request type</dt>
+                    <dd class="govuk-summary-list__value"><%= locals.request.request_type ? locals.request.request_type.name : '' %></dd>
+                </div>
+                <% if (locals.request.reason) { %>
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">Reason</dt>
+                    <dd class="govuk-summary-list__value"><%= locals.request.reason %></dd>
+                </div>
+                <% } %>
+            </dl>
+
+            <form method="post">
+                <div class="govuk-form-group <%= (locals.validationMessages.selectedResponse !== undefined) ? 'govuk-form-group--error' : '' %>">
+                    <input type="hidden" name="_csrf" value="<%= csrfToken %>"/>
+                    <fieldset class="govuk-fieldset">
+                        <% if (locals.validationMessages.selectedResponse !== undefined) { %>
+                        <p class="govuk-error-message" id="validation-selected-response"><%= locals.validationMessages.selectedResponse %></p>
+                        <% } %>
+                        <legend>
+                            <h2 class="govuk-heading-s">Your response</h2>
+                        </legend>
+                        <div class="govuk-radios" data-module="govuk-radios">
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="approve" type="radio" name="selectedResponse" value="approve" <%= (locals.selectedResponse === 'approve' ? 'checked' : '') %>>
+                                <label class="govuk-label govuk-radios__label" for="approve">Approve</label>
+                            </div>
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="reject" type="radio" name="selectedResponse" value="reject" <%= (locals.selectedResponse === 'reject' ? 'checked' : '') %>>
+                                <label class="govuk-label govuk-radios__label" for="reject">Reject</label>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+                <div class="govuk-button-group">
+                    <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+                    <a href="<%= locals.cancelLink %>" class="govuk-button govuk-button--secondary">Cancel</a>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>

--- a/src/app/sharedViews/pageForm.ejs
+++ b/src/app/sharedViews/pageForm.ejs
@@ -2,7 +2,13 @@
     <input type="hidden" name="_csrf" value="<%=csrfToken%>" />
     <input type="hidden" name="page" value="<%=page%>" />
     <% for (let i = 0; i < data.length; i++) {%>
+    <% if (Array.isArray(data[i].value)) { %>
+        <% for (let j = 0; j < data[i].value.length; j++) { %>
+        <input type="hidden" name="<%=data[i].key%>" value="<%=data[i].value[j]%>" />
+        <% } %>
+    <% } else { %>
     <input type="hidden" name="<%=data[i].key%>" value="<%=data[i].value%>" />
+    <% } %>
     <% } %>
     <button class="button-link" type="submit"><%=page%></button>
 </form>

--- a/src/app/sharedViews/paginationNew.ejs
+++ b/src/app/sharedViews/paginationNew.ejs
@@ -44,6 +44,30 @@ if (upperWindowBound < pages) {
         <% if (locals.numberOfPages >= 1) { %>
         <% if (locals.disableNextAndPrevious != true && locals.currentPage != 1) { %>
             <div class="govuk-pagination__prev">
+                <% if (locals.method === 'post') { %>
+                <form method="post">
+                    <input type="hidden" name="_csrf" value="<%=locals.csrfToken%>" />
+                    <input type="hidden" name="page" value="<%=page - 1%>" />
+                    <% for (let i = 0; i < (locals.data || []).length; i++) { %>
+                    <% const _prevItem = (locals.data || [])[i]; %>
+                    <% if (Array.isArray(_prevItem.value)) { %>
+                        <% for (let j = 0; j < _prevItem.value.length; j++) { %>
+                        <input type="hidden" name="<%=_prevItem.key%>" value="<%=_prevItem.value[j]%>" />
+                        <% } %>
+                    <% } else { %>
+                    <input type="hidden" name="<%=_prevItem.key%>" value="<%=_prevItem.value%>" />
+                    <% } %>
+                    <% } %>
+                    <button class="button-link govuk-link govuk-pagination__link" type="submit" rel="prev">
+                        <svg class="govuk-pagination__icon govuk-pagination__icon--prev" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
+                        <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
+                        </svg>
+                        <span class="govuk-pagination__link-title">
+                        Previous<span class="govuk-visually-hidden"> page</span>
+                        </span>
+                    </button>
+                </form>
+                <% } else { %>
                 <a class="govuk-link govuk-pagination__link" href="?page=<%=page - 1%>" rel="prev">
                     <svg class="govuk-pagination__icon govuk-pagination__icon--prev" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
                     <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
@@ -52,6 +76,7 @@ if (upperWindowBound < pages) {
                     Previous<span class="govuk-visually-hidden"> page</span>
                     </span>
                 </a>
+                <% } %>
             </div>
         <% } %>
         <ul class="govuk-pagination__list">
@@ -113,6 +138,30 @@ if (upperWindowBound < pages) {
         </ul>
         <% if (locals.disableNextAndPrevious != true && locals.currentPage != locals.numberOfPages) { %>
             <div class="govuk-pagination__next">
+                <% if (locals.method === 'post') { %>
+                <form method="post">
+                    <input type="hidden" name="_csrf" value="<%=locals.csrfToken%>" />
+                    <input type="hidden" name="page" value="<%=page + 1%>" />
+                    <% for (let i = 0; i < (locals.data || []).length; i++) { %>
+                    <% const _nextItem = (locals.data || [])[i]; %>
+                    <% if (Array.isArray(_nextItem.value)) { %>
+                        <% for (let j = 0; j < _nextItem.value.length; j++) { %>
+                        <input type="hidden" name="<%=_nextItem.key%>" value="<%=_nextItem.value[j]%>" />
+                        <% } %>
+                    <% } else { %>
+                    <input type="hidden" name="<%=_nextItem.key%>" value="<%=_nextItem.value%>" />
+                    <% } %>
+                    <% } %>
+                    <button class="button-link govuk-link govuk-pagination__link" type="submit" rel="next">
+                        <span class="govuk-pagination__link-title">
+                        Next<span class="govuk-visually-hidden"> page</span>
+                        </span>
+                        <svg class="govuk-pagination__icon govuk-pagination__icon--next" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
+                        <path d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
+                        </svg>
+                    </button>
+                </form>
+                <% } else { %>
                 <a class="govuk-link govuk-pagination__link" href="?page=<%=page + 1%>" rel="next">
                     <span class="govuk-pagination__link-title">
                     Next<span class="govuk-visually-hidden"> page</span>
@@ -121,6 +170,7 @@ if (upperWindowBound < pages) {
                     <path d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
                     </svg>
                 </a>
+                <% } %>
             </div>
         <% } %>
         <% } %>

--- a/test/app/accessRequests/rejectServiceRequest.get.test.js
+++ b/test/app/accessRequests/rejectServiceRequest.get.test.js
@@ -1,0 +1,48 @@
+jest.mock("./../../../src/infrastructure/config", () =>
+  require("./../../utils").configMockFactory(),
+);
+jest.mock("./../../../src/infrastructure/logger", () =>
+  require("./../../utils").loggerMockFactory(),
+);
+jest.mock("./../../../src/app/accessRequests/utils");
+
+const { getRequestMock, getResponseMock } = require("./../../utils");
+const {
+  get,
+} = require("./../../../src/app/accessRequests/rejectServiceRequest");
+
+const res = getResponseMock();
+
+describe("when rejecting a service request GET", () => {
+  let req;
+
+  beforeEach(() => {
+    req = getRequestMock({
+      params: { rid: "req-1" },
+    });
+    res.mockResetAll();
+  });
+
+  it("should render the rejectServiceRequest view", async () => {
+    await get(req, res);
+
+    expect(res.render.mock.calls).toHaveLength(1);
+    expect(res.render.mock.calls[0][0]).toBe(
+      "accessRequests/views/rejectServiceRequest",
+    );
+  });
+
+  it("should include csrf token", async () => {
+    await get(req, res);
+
+    expect(res.render.mock.calls[0][1]).toMatchObject({ csrfToken: "token" });
+  });
+
+  it("should include cancel link back to review page", async () => {
+    await get(req, res);
+
+    expect(res.render.mock.calls[0][1]).toMatchObject({
+      cancelLink: "/access-requests/req-1/service-request/review",
+    });
+  });
+});

--- a/test/app/accessRequests/reviewServiceRequest.get.test.js
+++ b/test/app/accessRequests/reviewServiceRequest.get.test.js
@@ -1,0 +1,75 @@
+jest.mock("./../../../src/infrastructure/logger", () =>
+  require("./../../utils").loggerMockFactory(),
+);
+jest.mock("./../../../src/infrastructure/config", () =>
+  require("./../../utils").configMockFactory(),
+);
+jest.mock("./../../../src/app/accessRequests/utils");
+
+const { getRequestMock, getResponseMock } = require("./../../utils");
+const accessRequestUtils = require("./../../../src/app/accessRequests/utils");
+const {
+  get,
+} = require("./../../../src/app/accessRequests/reviewServiceRequest");
+
+const res = getResponseMock();
+
+describe("when reviewing a service request GET", () => {
+  let req;
+
+  beforeEach(() => {
+    req = getRequestMock({
+      params: { rid: "req-1" },
+    });
+
+    accessRequestUtils.getAndMapServiceRequest.mockReset().mockReturnValue({
+      id: "req-1",
+      usersName: "Jane Doe",
+      usersEmail: "jane.doe@test.com",
+      serviceName: "Service A",
+      org_id: "org-1",
+      org_name: "Org One",
+      user_id: "user-1",
+      service_id: "svc-1",
+      created_date: "2024-01-01",
+      request_type: { id: "service", name: "Service access" },
+      status: { id: 0, name: "Pending" },
+    });
+
+    res.mockResetAll();
+  });
+
+  it("should render the reviewServiceRequest view", async () => {
+    await get(req, res);
+
+    expect(res.render.mock.calls).toHaveLength(1);
+    expect(res.render.mock.calls[0][0]).toBe(
+      "accessRequests/views/reviewServiceRequest",
+    );
+  });
+
+  it("should include csrf token", async () => {
+    await get(req, res);
+
+    expect(res.render.mock.calls[0][1]).toMatchObject({ csrfToken: "token" });
+  });
+
+  it("should include the mapped request", async () => {
+    await get(req, res);
+
+    expect(res.render.mock.calls[0][1].request).toMatchObject({
+      id: "req-1",
+      usersName: "Jane Doe",
+      usersEmail: "jane.doe@test.com",
+    });
+  });
+
+  it("should return 404 when request is not found", async () => {
+    accessRequestUtils.getAndMapServiceRequest.mockReturnValue(null);
+
+    await get(req, res);
+
+    expect(res.status.mock.calls[0][0]).toBe(404);
+    expect(res.render).toHaveBeenCalledWith("errors/notFound");
+  });
+});

--- a/test/app/accessRequests/reviewServiceRequest.post.test.js
+++ b/test/app/accessRequests/reviewServiceRequest.post.test.js
@@ -1,0 +1,89 @@
+jest.mock("./../../../src/infrastructure/logger", () =>
+  require("./../../utils").loggerMockFactory(),
+);
+jest.mock("./../../../src/infrastructure/config", () =>
+  require("./../../utils").configMockFactory(),
+);
+jest.mock("./../../../src/app/accessRequests/utils");
+
+const { getRequestMock, getResponseMock } = require("./../../utils");
+const accessRequestUtils = require("./../../../src/app/accessRequests/utils");
+const {
+  post,
+} = require("./../../../src/app/accessRequests/reviewServiceRequest");
+
+const res = getResponseMock();
+
+const mockRequest = {
+  id: "req-1",
+  usersName: "Jane Doe",
+  usersEmail: "jane.doe@test.com",
+  serviceName: "Service A",
+  org_id: "org-1",
+  org_name: "Org One",
+  user_id: "user-1",
+  service_id: "svc-1",
+  created_date: "2024-01-01",
+  request_type: { id: "service", name: "Service access" },
+  status: { id: 0, name: "Pending" },
+};
+
+describe("when reviewing a service request POST", () => {
+  let req;
+
+  beforeEach(() => {
+    req = getRequestMock({
+      params: { rid: "req-1" },
+      body: { selectedResponse: "approve" },
+    });
+
+    accessRequestUtils.getAndMapServiceRequest
+      .mockReset()
+      .mockReturnValue(mockRequest);
+
+    res.mockResetAll();
+  });
+
+  it("should return 404 when request is not found", async () => {
+    accessRequestUtils.getAndMapServiceRequest.mockReturnValue(null);
+
+    await post(req, res);
+
+    expect(res.status.mock.calls[0][0]).toBe(404);
+    expect(res.render).toHaveBeenCalledWith("errors/notFound");
+  });
+
+  it("should re-render with validation error when no response selected", async () => {
+    req.body.selectedResponse = null;
+
+    await post(req, res);
+
+    expect(res.render.mock.calls).toHaveLength(1);
+    expect(res.render.mock.calls[0][0]).toBe(
+      "accessRequests/views/reviewServiceRequest",
+    );
+    expect(res.render.mock.calls[0][1].validationMessages).toMatchObject({
+      selectedResponse: "Approve or Reject must be selected",
+    });
+  });
+
+  it("should redirect to absolute reject path when reject selected", async () => {
+    req.body.selectedResponse = "reject";
+
+    await post(req, res);
+
+    expect(res.redirect.mock.calls[0][0]).toBe(
+      "/access-requests/req-1/service-request/reject",
+    );
+  });
+
+  it("should redirect to absolute approve path when approve selected", async () => {
+    req.body.selectedResponse = "approve";
+
+    await post(req, res);
+
+    expect(res.redirect.mock.calls[0][0]).toBe(
+      "/access-requests/req-1/service-request/approve",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Update filter panel from old `filter-box` markup to GDS `govuk-checkboxes` / `govuk-fieldset` components
- Add new **Type** filter section with Organisation, Service, and Sub-service options
- Wire selected types through to the organisations API via `filterType`
- Add **Type** column to the results table

## Changes
- `src/app/accessRequests/utils.js` — add `requestTypeMap`, pass `filterType` to API
- `src/app/accessRequests/organisationRequests.js` — build `requestTypes` in filter model
- `src/app/accessRequests/views/organisationRequests.ejs` — GDS-style checkboxes, Type filter section, Type column in table

## Test plan
- [ ] Show filters renders two GDS-style checkbox groups: "Request status" and "Type"
- [ ] Selecting Organisation, Service, or Sub-service and applying filter narrows results correctly
- [ ] Pagination preserves selected type filters across pages
- [ ] Type column in results table shows correct label for each row
- [ ] Empty state row spans all 7 columns correctly
- [ ] Hiding and re-showing filters resets the panel without losing results

Jira: [NSA-8157](https://dfe-secureaccess.atlassian.net/browse/NSA-8157)