### PR TITLE
feat(NSA-9802): add audit tab and audit records for invited users

### DIFF
--- a/src/app/users/getAssociateOrganisation.js
+++ b/src/app/users/getAssociateOrganisation.js
@@ -1,6 +1,10 @@
 const logger = require("./../../infrastructure/logger");
 
 const getAssociateOrganisation = async (req, res) => {
+  if (!req.session.user) {
+    return res.redirect("/users/new-user");
+  }
+
   delete req.session.user.organisationId;
   delete req.session.user.organisationName;
   delete req.session.user.permission;

--- a/src/app/users/getAudit.js
+++ b/src/app/users/getAudit.js
@@ -6,6 +6,9 @@ const {
 const { getUserDetailsById } = require("./utils");
 const { dateFormat } = require("../helpers/dateFormatterHelper");
 const { getPageOfUserAudits } = require("./../../infrastructure/audit");
+const {
+  getInvitationOrganisationsRaw,
+} = require("login.dfe.api-client/invitations");
 const logger = require("./../../infrastructure/logger");
 const {
   getServiceIdForClientId,
@@ -75,6 +78,7 @@ const describeAuditEvent = async (audit, req) => {
     "policy-removed",
     "policy-condition-removed",
     "policy-role-removed",
+    "user-invite-org",
   ]);
 
   // The default SHOULD be audit.message, until the work is done to make this happen
@@ -234,6 +238,8 @@ const getAudit = async (req, res) => {
   cachedServices = {};
   cachedUsers = {};
   const correlationId = req.id;
+  const isInvitation = req.params.uid.startsWith("inv-");
+  const invitationId = isInvitation ? req.params.uid.substr(4) : null;
   const user = await getCachedUserById(req.params.uid, req);
   const showChangeEmail = !isInternalEntraUser(user);
   user.formattedLastLogin = user.lastLogin
@@ -243,15 +249,19 @@ const getAudit = async (req, res) => {
     const userStatus = await getUserStatusRaw({ userId: user.id });
     user.statusChangeReasons = userStatus ? userStatus.statusChangeReasons : [];
   }
-  const userOrganisations = await getUserOrganisationsWithServicesRaw({
-    userId: req.params.uid,
-  });
+  const userOrganisations = isInvitation
+    ? ((await getInvitationOrganisationsRaw({ invitationId })) ?? [])
+    : await getUserOrganisationsWithServicesRaw({ userId: req.params.uid });
   req.session.type = "audit";
   const pageNumber = req.query && req.query.page ? parseInt(req.query.page) : 1;
   if (isNaN(pageNumber) || pageNumber < 1) {
     return res.status(400).send();
   }
-  const pageOfAudits = await getPageOfUserAudits(user.id, pageNumber);
+  const pageOfAudits = await getPageOfUserAudits(
+    isInvitation ? invitationId : user.id,
+    pageNumber,
+    invitationId,
+  );
   const audits = [];
 
   for (let i = 0; i < pageOfAudits.audits.length; i++) {
@@ -308,7 +318,7 @@ const getAudit = async (req, res) => {
       organisation,
       result: audit.success === undefined ? true : audit.success,
       user:
-        audit.userId.toLowerCase() === user.id.toLowerCase()
+        !audit.userId || audit.userId.toLowerCase() === user.id.toLowerCase()
           ? user
           : await getCachedUserById(audit.userId.toUpperCase(), req),
     });
@@ -324,6 +334,7 @@ const getAudit = async (req, res) => {
     currentPage: "users",
     user,
     showChangeEmail,
+    isInvitation,
     organisations: userOrganisations,
     audits,
     numberOfPages: pageOfAudits.numberOfPages,

--- a/src/app/users/getAudit.js
+++ b/src/app/users/getAudit.js
@@ -83,6 +83,7 @@ const describeAuditEvent = async (audit, req) => {
     "policy-condition-removed",
     "policy-role-removed",
     "user-invite-org",
+    "user-org-permission-edited",
   ]);
 
   // The default SHOULD be audit.message, until the work is done to make this happen
@@ -138,20 +139,13 @@ const describeAuditEvent = async (audit, req) => {
   }
 
   if (audit.type === "support" && audit.subType === "user-invited") {
-    return "User invite sent from support console.";
+    const inviter = await getCachedUserById(audit.userId, req);
+    const inviterName = inviter?.name || audit.userEmail || "unknown";
+    return `User invite sent by ${inviterName} from support console.`;
   }
 
   if (audit.subType === "invite-created") {
-    switch (audit.type) {
-      case "approver":
-        return "Services/Invitation code created and sent.";
-      case "support":
-        return "Support/Invitation code created and sent.";
-      default:
-        break;
-    }
-
-    return audit.type;
+    return audit.message;
   }
 
   if (audit.type === "approver" && audit.subType === "user-invited") {
@@ -174,8 +168,9 @@ const describeAuditEvent = async (audit, req) => {
       organisationId: organisationId.oldValue,
     });
     const viewedUser = await getCachedUserById(audit.editedUser, req);
-    return `Deleted organisation: ${organisation.name} for user  ${viewedUser.firstName} ${viewedUser.lastName} legacyID: (
-      numericIdentifier: ${audit["numericIdentifier"]}, textIdentifier: ${audit["textIdentifier"]})`;
+    const numericId = audit["numericIdentifier"] ?? "N/A";
+    const textId = audit["textIdentifier"] ?? "N/A";
+    return `Deleted organisation: ${organisation.name} for user ${viewedUser.firstName} ${viewedUser.lastName} legacyID: (numericIdentifier: ${numericId}, textIdentifier: ${textId})`;
   }
   if (audit.type === "support" && audit.subType === "user-org") {
     const organisationId =
@@ -186,16 +181,6 @@ const describeAuditEvent = async (audit, req) => {
     });
     const viewedUser = await getCachedUserById(audit.editedUser, req);
     return `Added organisation: ${organisation.name} for user ${viewedUser.firstName} ${viewedUser.lastName}`;
-  }
-  if (
-    audit.type === "support" &&
-    audit.subType === "user-org-permission-edited"
-  ) {
-    const editedFields =
-      audit.editedFields &&
-      audit.editedFields.find((x) => x.name === "edited_permission");
-    const viewedUser = await getCachedUserById(audit.editedUser, req);
-    return `Edited permission level to ${editedFields.newValue} for user ${viewedUser.firstName} ${viewedUser.lastName} in organisation ${editedFields.organisation}`;
   }
   if (audit.type === "approver" && audit.subType === "user-org-deleted") {
     try {
@@ -211,8 +196,9 @@ const describeAuditEvent = async (audit, req) => {
         ? audit.editedUser.replace(/[""]+/g, "")
         : audit.editedUser;
       const viewedUser = await getCachedUserById(audit.editedUser, req);
-      return `Deleted organisation: ${organisation.name} for user  ${viewedUser.firstName} ${viewedUser.lastName} legacyID: (
-        numericIdentifier: ${audit["numericIdentifier"]}, textIdentifier: ${audit["textIdentifier"]})`;
+      const numericId = audit["numericIdentifier"] ?? "N/A";
+      const textId = audit["textIdentifier"] ?? "N/A";
+      return `Deleted organisation: ${organisation.name} for user ${viewedUser.firstName} ${viewedUser.lastName} legacyID: (numericIdentifier: ${numericId}, textIdentifier: ${textId})`;
     } catch {
       return audit.message;
     }

--- a/src/app/users/getAudit.js
+++ b/src/app/users/getAudit.js
@@ -8,6 +8,7 @@ const { dateFormat } = require("../helpers/dateFormatterHelper");
 const { getPageOfUserAudits } = require("./../../infrastructure/audit");
 const {
   getInvitationOrganisationsRaw,
+  getInvitationRaw,
 } = require("login.dfe.api-client/invitations");
 const logger = require("./../../infrastructure/logger");
 const {
@@ -322,6 +323,34 @@ const getAudit = async (req, res) => {
           ? user
           : await getCachedUserById(audit.userId.toUpperCase(), req),
     });
+  }
+
+  if (isInvitation) {
+    const hasInviteCreatedEvent = audits.some(
+      (a) => a.event.subType === "invite-created",
+    );
+    if (!hasInviteCreatedEvent) {
+      const invitation = await getInvitationRaw({ by: { id: invitationId } });
+      if (invitation) {
+        audits.push({
+          timestamp: new Date(invitation.createdAt),
+          formattedTimestamp: dateFormat(
+            invitation.createdAt,
+            "longDateFormat",
+          ),
+          event: {
+            type: "support",
+            subType: "invite-created",
+            description: "Invitation created",
+          },
+          service: null,
+          organisation: null,
+          result: true,
+          user: null,
+        });
+        audits.sort((a, b) => b.timestamp - a.timestamp);
+      }
+    }
   }
 
   sendResult(req, res, "users/views/audit", {

--- a/src/app/users/getAudit.js
+++ b/src/app/users/getAudit.js
@@ -84,6 +84,7 @@ const describeAuditEvent = async (audit, req) => {
     "policy-role-removed",
     "user-invite-org",
     "user-org-permission-edited",
+    "resent-invitation",
   ]);
 
   // The default SHOULD be audit.message, until the work is done to make this happen

--- a/src/app/users/getAudit.js
+++ b/src/app/users/getAudit.js
@@ -37,8 +37,11 @@ const getCachedUserById = async (userId, req) => {
 };
 
 const describeAuditEvent = async (audit, req) => {
+  const uidForComparison = req.params.uid.startsWith("inv-")
+    ? req.params.uid.slice(4)
+    : req.params.uid;
   const isCurrentUser =
-    audit.userId.toLowerCase() === req.params.uid.toLowerCase();
+    audit.userId.toLowerCase() === uidForComparison.toLowerCase();
 
   if (audit.type === "sign-in") {
     let description = "Sign-in";
@@ -240,13 +243,13 @@ const getAudit = async (req, res) => {
   cachedUsers = {};
   const correlationId = req.id;
   const isInvitation = req.params.uid.startsWith("inv-");
-  const invitationId = isInvitation ? req.params.uid.substr(4) : null;
+  const invitationId = isInvitation ? req.params.uid.slice(4) : null;
   const user = await getCachedUserById(req.params.uid, req);
   const showChangeEmail = !isInternalEntraUser(user);
   user.formattedLastLogin = user.lastLogin
     ? dateFormat(user.lastLogin, "longDateFormat")
     : "";
-  if (user.status.id === 0) {
+  if (!isInvitation && user.status.id === 0) {
     const userStatus = await getUserStatusRaw({ userId: user.id });
     user.statusChangeReasons = userStatus ? userStatus.statusChangeReasons : [];
   }
@@ -263,6 +266,7 @@ const getAudit = async (req, res) => {
     pageNumber,
     invitationId,
   );
+  const currentUserId = isInvitation ? invitationId : user.id;
   const audits = [];
 
   for (let i = 0; i < pageOfAudits.audits.length; i++) {
@@ -319,9 +323,10 @@ const getAudit = async (req, res) => {
       organisation,
       result: audit.success === undefined ? true : audit.success,
       user:
-        !audit.userId || audit.userId.toLowerCase() === user.id.toLowerCase()
+        !audit.userId ||
+        audit.userId.toLowerCase() === currentUserId.toLowerCase()
           ? user
-          : await getCachedUserById(audit.userId.toUpperCase(), req),
+          : await getCachedUserById(audit.userId, req),
     });
   }
 
@@ -332,7 +337,7 @@ const getAudit = async (req, res) => {
     if (!hasInviteCreatedEvent) {
       const invitation = await getInvitationRaw({ by: { id: invitationId } });
       if (invitation) {
-        audits.push({
+        const syntheticEntry = {
           timestamp: new Date(invitation.createdAt),
           formattedTimestamp: dateFormat(
             invitation.createdAt,
@@ -347,8 +352,15 @@ const getAudit = async (req, res) => {
           organisation: null,
           result: true,
           user: null,
-        });
-        audits.sort((a, b) => b.timestamp - a.timestamp);
+        };
+        const insertAt = audits.findIndex(
+          (a) => a.timestamp <= syntheticEntry.timestamp,
+        );
+        if (insertAt === -1) {
+          audits.push(syntheticEntry);
+        } else {
+          audits.splice(insertAt, 0, syntheticEntry);
+        }
       }
     }
   }

--- a/src/app/users/getAudit.js
+++ b/src/app/users/getAudit.js
@@ -145,7 +145,7 @@ const describeAuditEvent = async (audit, req) => {
   }
 
   if (audit.subType === "invite-created") {
-    return audit.message;
+    return audit.message ?? `${audit.type}/invite-created`;
   }
 
   if (audit.type === "approver" && audit.subType === "user-invited") {

--- a/src/app/users/getConfirmAssociateOrganisation.js
+++ b/src/app/users/getConfirmAssociateOrganisation.js
@@ -40,6 +40,7 @@ const addOrganisationToInvitation = async (uid, req) => {
       userEmail: req.user.email,
       invitedUserEmail: req.session.user.email,
       invitedOrganisation: organisationId,
+      editedUser: uid,
     },
   );
 };

--- a/src/app/users/getOrganisations.js
+++ b/src/app/users/getOrganisations.js
@@ -16,7 +16,6 @@ const {
   getUsersRaw,
   getUserStatusRaw,
 } = require("login.dfe.api-client/users");
-const logger = require("../../infrastructure/logger");
 
 const getApproverDetails = async (organisations) => {
   const allApproverIds = flatten(organisations.map((org) => org.approvers));
@@ -136,14 +135,6 @@ const action = async (req, res) => {
   if (req.session.params.searchType !== "organisations") {
     req.session.params.searchType = "users";
   }
-
-  logger.audit(`${req.user.email} viewed user ${user.email}`, {
-    type: "organisations",
-    subType: "user-view",
-    userId: req.user.sub,
-    userEmail: req.user.email,
-    viewedUser: user.id,
-  });
 
   sendResult(req, res, "users/views/organisations", {
     csrfToken: req.csrfToken(),

--- a/src/app/users/getServices.js
+++ b/src/app/users/getServices.js
@@ -13,8 +13,6 @@ const {
 } = require("login.dfe.api-client/users");
 const { getAllServices } = require("../services/utils");
 
-const logger = require("../../infrastructure/logger");
-
 const getOrganisations = async (userId) => {
   const orgServiceMapping = userId.startsWith("inv-")
     ? await getInvitationOrganisationsRaw({ invitationId: userId.substr(4) })
@@ -123,14 +121,6 @@ const action = async (req, res) => {
     lastName: user.lastName,
     email: user.email,
   };
-
-  logger.audit(`${req.user.email} viewed user ${user.email}`, {
-    type: "support",
-    subType: "user-view",
-    userId: req.user.sub,
-    userEmail: req.user.email,
-    viewedUser: user.id,
-  });
 
   sendResult(req, res, "users/views/services", {
     csrfToken: req.csrfToken(),

--- a/src/app/users/postConfirmNewUser.js
+++ b/src/app/users/postConfirmNewUser.js
@@ -58,7 +58,7 @@ const postConfirmNewUser = async (req, res) => {
       subType: "invite-created",
       userId: req.user.sub,
       editedUser: `inv-${invitationId}`,
-      message: `Invitation code is created. Id ${invitationId}`,
+      message: `${req.user.email} (id: ${req.user.sub}) created invitation for ${req.session.user.email} (id: inv-${invitationId})`,
     });
   }
 

--- a/src/app/users/postConfirmNewUser.js
+++ b/src/app/users/postConfirmNewUser.js
@@ -57,6 +57,7 @@ const postConfirmNewUser = async (req, res) => {
       type: "support",
       subType: "invite-created",
       userId: req.user.sub,
+      editedUser: `inv-${invitationId}`,
       message: `Invitation code is created. Id ${invitationId}`,
     });
   }
@@ -80,6 +81,7 @@ const postConfirmNewUser = async (req, res) => {
       userId: req.user.sub,
       userEmail: req.user.email,
       invitedUserEmail: req.session.user.email,
+      editedUser: `inv-${invitationId}`,
     },
   );
 

--- a/src/app/users/postConfirmNewUser.js
+++ b/src/app/users/postConfirmNewUser.js
@@ -58,7 +58,9 @@ const postConfirmNewUser = async (req, res) => {
       subType: "invite-created",
       userId: req.user.sub,
       editedUser: `inv-${invitationId}`,
-      message: `${req.user.email} (id: ${req.user.sub}) created invitation for ${req.session.user.email} (id: inv-${invitationId})`,
+      message: organisation
+        ? `${req.user.email} invited ${req.session.user.email} to ${organisation.name} (id: ${req.session.user.organisationId}) (id: inv-${invitationId})`
+        : `${req.user.email} invited ${req.session.user.email} (id: inv-${invitationId})`,
     });
   }
 

--- a/src/app/users/postResendInvite.js
+++ b/src/app/users/postResendInvite.js
@@ -1,4 +1,5 @@
 const { resendInvitation } = require("login.dfe.api-client/invitations");
+const logger = require("../../infrastructure/logger");
 
 const postResendInvite = async (req, res) => {
   const resend = await resendInvitation({
@@ -17,6 +18,17 @@ const postResendInvite = async (req, res) => {
     );
     return res.redirect(req.session.type);
   }
+
+  logger.audit(
+    `${req.user.email} (id: ${req.user.sub}) resent invitation to ${req.session.user.email} (id: ${req.params.uid})`,
+    {
+      type: "support",
+      subType: "resent-invitation",
+      userId: req.user.sub,
+      userEmail: req.user.email,
+      editedUser: req.params.uid,
+    },
+  );
 
   res.flash(
     "info",

--- a/src/app/users/removeServiceAccess.js
+++ b/src/app/users/removeServiceAccess.js
@@ -55,7 +55,7 @@ const post = async (req, res) => {
   const organisationId = req.params.orgId;
   const service = await getServiceRaw({ by: { serviceId: req.params.sid } });
   const userOrganisations = uid.startsWith("inv-")
-    ? await getInvitationOrganisationsRaw({ userId: uid.substr(4) })
+    ? await getInvitationOrganisationsRaw({ invitationId: uid.substr(4) })
     : await getUserOrganisationsWithServicesRaw({ userId: uid });
   const organisationDetails = userOrganisations.find(
     (x) => x.organisation.id === req.params.orgId,

--- a/src/app/users/utils.js
+++ b/src/app/users/utils.js
@@ -236,22 +236,22 @@ const mapUserToSupportModel = (user, userFromSearch) => {
     entraOid: user.entraOid,
     entraLinked: user.entraLinked,
     entraDeferUntil: user.entraDeferUntil,
-    organisation: userFromSearch.primaryOrganisation
+    organisation: userFromSearch?.primaryOrganisation
       ? {
           name: userFromSearch.primaryOrganisation,
         }
       : null,
-    organisations: userFromSearch.organisations,
-    lastLogin: userFromSearch.lastLogin
+    organisations: userFromSearch?.organisations,
+    lastLogin: userFromSearch?.lastLogin
       ? new Date(userFromSearch.lastLogin)
       : null,
     successfulLoginsInPast12Months:
-      userFromSearch.numberOfSuccessfulLoginsInPast12Months,
+      userFromSearch?.numberOfSuccessfulLoginsInPast12Months,
     status: mapUserStatus(
-      userFromSearch.status.id,
-      userFromSearch.statusLastChangedOn,
+      userFromSearch?.status?.id,
+      userFromSearch?.statusLastChangedOn,
     ),
-    pendingEmail: userFromSearch.pendingEmail,
+    pendingEmail: userFromSearch?.pendingEmail,
   };
 };
 

--- a/src/app/users/views/summaryPartial.ejs
+++ b/src/app/users/views/summaryPartial.ejs
@@ -173,16 +173,14 @@
                     </li>
                 <% } %>
         
-                <% if(!locals.isInvitation) { %>
-                    <% if(locals.area === 'audit') { %>
-                        <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
-                            <span class="govuk-tabs__tab">Audit</span>
-                        </li>
-                    <% } else { %>
-                        <li class="govuk-tabs__list-item">
-                            <a class="govuk-link" href="audit">Audit</a>
-                        </li>
-                    <% } %>
+                <% if(locals.area === 'audit') { %>
+                    <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
+                        <span class="govuk-tabs__tab">Audit</span>
+                    </li>
+                <% } else { %>
+                    <li class="govuk-tabs__list-item">
+                        <a class="govuk-link" href="audit">Audit</a>
+                    </li>
                 <% } %>
             </ul>
         </div>

--- a/src/infrastructure/audit/sequelize.js
+++ b/src/infrastructure/audit/sequelize.js
@@ -28,7 +28,35 @@ const mapAuditEntity = (auditEntity) => {
   return audit;
 };
 
-const getPageOfUserAudits = async (userId, pageNumber) => {
+const getPageOfUserAudits = async (userId, pageNumber, invitationId = null) => {
+  const replacements = { userId };
+  let invitationClause = "";
+
+  if (invitationId) {
+    replacements.invitationId = invitationId;
+    replacements.invitationIdPrefixed = `inv-${invitationId}`;
+    invitationClause = `
+      UNION
+      SELECT AL.id
+        FROM AuditLogs AL
+        WHERE AL.userId = :invitationId
+      UNION
+      SELECT AL.id
+        FROM AuditLogs AL
+        JOIN AuditLogMeta ALM
+          ON ALM.auditId = AL.id
+        WHERE ALM.[key] IN ('invitationId', 'editedUser', 'viewedUser')
+          AND (ALM.[Value] = :invitationId OR ALM.[Value] = :invitationIdPrefixed)
+      UNION
+      SELECT AL.id
+        FROM AuditLogs AL
+        JOIN AuditLogMeta ALM
+          ON ALM.auditId = AL.id
+        WHERE ALM.[key] = 'message'
+          AND ALM.[Value] LIKE '%' + :invitationId + '%'
+          AND AL.subType IN ('invite-created', 'user-invite-org')`;
+  }
+
   const queryWhere = `
     WHERE type != 'technical-audit'
     AND id IN (
@@ -42,10 +70,11 @@ const getPageOfUserAudits = async (userId, pageNumber) => {
           ON ALM.auditId = AL.id
         WHERE ALM.[key] IN ('editedUser', 'viewedUser')
           AND ALM.[Value] = :userId
+      ${invitationClause}
     )`;
   const queryOpts = {
     type: QueryTypes.SELECT,
-    replacements: { userId },
+    replacements,
   };
   const skip = (pageNumber - 1) * pageSize;
   const { count } = (

--- a/src/infrastructure/audit/sequelize.js
+++ b/src/infrastructure/audit/sequelize.js
@@ -50,10 +50,7 @@ const getPageOfUserAudits = async (userId, pageNumber, invitationId = null) => {
       UNION
       SELECT AL.id
         FROM AuditLogs AL
-        JOIN AuditLogMeta ALM
-          ON ALM.auditId = AL.id
-        WHERE ALM.[key] = 'message'
-          AND ALM.[Value] LIKE '%' + :invitationId + '%'
+        WHERE AL.message LIKE '%' + :invitationId + '%'
           AND AL.subType IN ('invite-created', 'user-invite-org')`;
   }
 

--- a/test/app/users/getAssociateOrganisation.test.js
+++ b/test/app/users/getAssociateOrganisation.test.js
@@ -27,7 +27,34 @@ describe("When calling the getAssociateOrganisation function", () => {
     res = {
       render: jest.fn(),
       flash: jest.fn(),
+      redirect: jest.fn(),
     };
+  });
+
+  describe("when req.session.user is not set", () => {
+    it("should redirect to /users/new-user", async () => {
+      req.session.user = null;
+
+      await getAssociateOrganisation(req, res);
+
+      expect(res.redirect).toHaveBeenCalledWith("/users/new-user");
+    });
+
+    it("should not attempt to render the page", async () => {
+      req.session.user = null;
+
+      await getAssociateOrganisation(req, res);
+
+      expect(res.render).not.toHaveBeenCalled();
+    });
+
+    it("should not attempt to save the session", async () => {
+      req.session.user = null;
+
+      await getAssociateOrganisation(req, res);
+
+      expect(req.session.save).not.toHaveBeenCalled();
+    });
   });
 
   it("renders users/views/associateOrganisation on success", async () => {

--- a/test/app/users/getAudit.test.js
+++ b/test/app/users/getAudit.test.js
@@ -11,6 +11,9 @@ jest.mock("./../../../src/infrastructure/audit");
 jest.mock("login.dfe.api-client/users");
 jest.mock("ioredis");
 jest.mock("login.dfe.api-client/organisations");
+jest.mock("login.dfe.api-client/invitations", () => ({
+  getInvitationOrganisationsRaw: jest.fn(),
+}));
 
 const { getUserDetailsById } = require("./../../../src/app/users/utils");
 const { sendResult } = require("./../../../src/infrastructure/utils");
@@ -27,6 +30,9 @@ const {
 const {
   getOrganisationLegacyRaw,
 } = require("login.dfe.api-client/organisations");
+const {
+  getInvitationOrganisationsRaw,
+} = require("login.dfe.api-client/invitations");
 
 const organisationId = "org-1";
 
@@ -106,6 +112,9 @@ describe("when getting users audit details", () => {
 
     getUserOrganisationsWithServicesRaw.mockReset();
     getUserOrganisationsWithServicesRaw.mockResolvedValue([]);
+
+    getInvitationOrganisationsRaw.mockReset();
+    getInvitationOrganisationsRaw.mockResolvedValue([]);
 
     sendResult.mockReset();
 
@@ -663,6 +672,128 @@ describe("when getting users audit details", () => {
     expect(differentUserCall[1]).toBe(req);
     expect(differentUserCall[1]).toHaveProperty("id");
     expect(differentUserCall[1]).toHaveProperty("params");
+  });
+
+  describe("when viewing audit for an invited user", () => {
+    const invitationGuid = "abc123-def456-ghi789";
+    const invitationUid = `inv-${invitationGuid}`;
+
+    beforeEach(() => {
+      req.params.uid = invitationUid;
+
+      getUserDetailsById.mockReset();
+      getUserDetailsById.mockImplementation(async (userId) => ({
+        id: userId,
+        firstName: "Invited",
+        lastName: "User",
+        email: "invited@example.com",
+        lastLogin: null,
+        status: { id: -1, description: "Invited" },
+        loginsInPast12Months: { successful: 0 },
+        deactivated: false,
+      }));
+
+      getPageOfUserAudits.mockReset();
+      getPageOfUserAudits.mockResolvedValue({
+        audits: [
+          {
+            type: "support",
+            subType: "user-invited",
+            userId: "support-user-sub",
+            level: "audit",
+            message: "Invited user invited@example.com",
+            timestamp: "2025-05-01T10:00:00.000Z",
+          },
+          {
+            type: "support",
+            subType: "invite-created",
+            userId: "support-user-sub",
+            level: "audit",
+            message: "Invitation code created",
+            timestamp: "2025-05-01T10:01:00.000Z",
+          },
+        ],
+        numberOfPages: 1,
+        numberOfRecords: 2,
+      });
+    });
+
+    it("should call getPageOfUserAudits with the bare invitation GUID as both userId and invitationId", async () => {
+      await getAudit(req, res);
+
+      expect(getPageOfUserAudits).toHaveBeenCalledWith(
+        invitationGuid,
+        expect.any(Number),
+        invitationGuid,
+      );
+    });
+
+    it("should fetch organisations via getInvitationOrganisationsRaw, not getUserOrganisationsWithServicesRaw", async () => {
+      await getAudit(req, res);
+
+      expect(getInvitationOrganisationsRaw).toHaveBeenCalledWith({
+        invitationId: invitationGuid,
+      });
+      expect(getUserOrganisationsWithServicesRaw).not.toHaveBeenCalled();
+    });
+
+    it("should pass isInvitation: true to the view model", async () => {
+      await getAudit(req, res);
+
+      expect(sendResult.mock.calls[0][3]).toMatchObject({ isInvitation: true });
+    });
+
+    it("should render support/user-invited audit event with correct description", async () => {
+      await getAudit(req, res);
+
+      const audits = sendResult.mock.calls[0][3].audits;
+      const invitedEvent = audits.find(
+        (a) => a.event.subType === "user-invited",
+      );
+      expect(invitedEvent.event.description).toBe(
+        "User invite sent from support console.",
+      );
+    });
+
+    it("should render support/invite-created audit event with correct description", async () => {
+      await getAudit(req, res);
+
+      const audits = sendResult.mock.calls[0][3].audits;
+      const createdEvent = audits.find(
+        (a) => a.event.subType === "invite-created",
+      );
+      expect(createdEvent.event.description).toBe(
+        "Support/Invitation code created and sent.",
+      );
+    });
+
+    it("should not call getUserStatusRaw for invited users", async () => {
+      await getAudit(req, res);
+
+      expect(getUserStatusRaw).not.toHaveBeenCalled();
+    });
+
+    it("should use the invitation user as the audit user when audit.userId is empty", async () => {
+      getPageOfUserAudits.mockResolvedValue({
+        audits: [
+          {
+            type: "support",
+            subType: "user-invited",
+            userId: "",
+            level: "audit",
+            message: "Invited",
+            timestamp: "2025-05-01T10:00:00.000Z",
+          },
+        ],
+        numberOfPages: 1,
+        numberOfRecords: 1,
+      });
+
+      await getAudit(req, res);
+
+      const audits = sendResult.mock.calls[0][3].audits;
+      expect(audits[0].user.id).toBe(invitationUid);
+    });
   });
 
   describe("error handling for dependent function failures", () => {

--- a/test/app/users/getAudit.test.js
+++ b/test/app/users/getAudit.test.js
@@ -580,7 +580,10 @@ describe("when getting users audit details", () => {
     expect(editedUserCall[1]).toHaveProperty("params");
   });
 
-  it("should pass full req object for support user-org-permission-edited event", async () => {
+  it("should use audit message as description for user-org-permission-edited events (support type)", async () => {
+    const permissionMessage =
+      "super.user@unit.test (id: user1) edited permission level to approver for organisation Test Organisation (id: org-1) for user edited@user.com (id: edited-user1)";
+
     getPageOfUserAudits.mockResolvedValue({
       audits: [
         {
@@ -596,6 +599,7 @@ describe("when getting users audit details", () => {
               organisation: "Test Organisation",
             },
           ],
+          message: permissionMessage,
           timestamp: "2018-01-30T10:30:53.987Z",
         },
       ],
@@ -605,13 +609,209 @@ describe("when getting users audit details", () => {
 
     await getAudit(req, res);
 
-    const editedUserCall = getUserDetailsById.mock.calls.find(
-      (call) => call[0] === "edited-user1",
+    const auditRows = sendResult.mock.calls[0][3].audits;
+    expect(auditRows[0].event.description).toBe(permissionMessage);
+  });
+
+  it("should use audit message as description for user-org-permission-edited events (approver type)", async () => {
+    const permissionMessage =
+      "approver@unit.test edited permission level to approver for organisation Test Organisation (id: org-1) for user edited@user.com";
+
+    getPageOfUserAudits.mockResolvedValue({
+      audits: [
+        {
+          type: "approver",
+          subType: "user-org-permission-edited",
+          userId: "user1",
+          editedUser: "edited-user1",
+          message: permissionMessage,
+          timestamp: "2018-01-30T10:30:53.987Z",
+        },
+      ],
+      numberOfPages: 1,
+      numberOfRecords: 1,
+    });
+
+    await getAudit(req, res);
+
+    const auditRows = sendResult.mock.calls[0][3].audits;
+    expect(auditRows[0].event.description).toBe(permissionMessage);
+  });
+
+  it("should include the inviter name in the description for support/user-invited events", async () => {
+    getUserDetailsById.mockImplementation(async (userId) => {
+      if (userId === "support-user-1") {
+        return {
+          id: "support-user-1",
+          name: "Jane Smith",
+          firstName: "Jane",
+          lastName: "Smith",
+          status: { id: 1, description: "Activated" },
+        };
+      }
+      return {
+        id: userId,
+        name: "Test User",
+        firstName: "Test",
+        lastName: "User",
+        status: { id: 1, description: "Activated" },
+      };
+    });
+
+    getPageOfUserAudits.mockResolvedValue({
+      audits: [
+        {
+          type: "support",
+          subType: "user-invited",
+          userId: "support-user-1",
+          userEmail: "jane.smith@education.gov.uk",
+          editedUser: "inv-test-invitation",
+          timestamp: "2025-06-02T10:00:00.000Z",
+        },
+      ],
+      numberOfPages: 1,
+      numberOfRecords: 1,
+    });
+
+    await getAudit(req, res);
+
+    const auditRows = sendResult.mock.calls[0][3].audits;
+    expect(auditRows[0].event.description).toBe(
+      "User invite sent by Jane Smith from support console.",
     );
-    expect(editedUserCall).toBeDefined();
-    expect(editedUserCall[1]).toBe(req);
-    expect(editedUserCall[1]).toHaveProperty("id");
-    expect(editedUserCall[1]).toHaveProperty("params");
+  });
+
+  it("should fall back to email in description for support/user-invited when inviter cannot be fetched", async () => {
+    getUserDetailsById.mockImplementation(async (userId) => {
+      if (userId === "support-user-1") {
+        return null;
+      }
+      return {
+        id: userId,
+        name: "Test User",
+        firstName: "Test",
+        lastName: "User",
+        status: { id: 1, description: "Activated" },
+      };
+    });
+
+    getPageOfUserAudits.mockResolvedValue({
+      audits: [
+        {
+          type: "support",
+          subType: "user-invited",
+          userId: "support-user-1",
+          userEmail: "jane.smith@education.gov.uk",
+          editedUser: "inv-test-invitation",
+          timestamp: "2025-06-02T10:00:00.000Z",
+        },
+      ],
+      numberOfPages: 1,
+      numberOfRecords: 1,
+    });
+
+    await getAudit(req, res);
+
+    const auditRows = sendResult.mock.calls[0][3].audits;
+    expect(auditRows[0].event.description).toBe(
+      "User invite sent by jane.smith@education.gov.uk from support console.",
+    );
+  });
+
+  it("should use audit message for approver/invite-created events", async () => {
+    const inviteMessage =
+      "approver@unit.test (id: user1) invited new.user@example.com to Test Organisation (id: org-1) (id: inv-abc123)";
+
+    getPageOfUserAudits.mockResolvedValue({
+      audits: [
+        {
+          type: "approver",
+          subType: "invite-created",
+          userId: "user1",
+          message: inviteMessage,
+          timestamp: "2025-06-02T10:00:00.000Z",
+        },
+      ],
+      numberOfPages: 1,
+      numberOfRecords: 1,
+    });
+
+    await getAudit(req, res);
+
+    const auditRows = sendResult.mock.calls[0][3].audits;
+    expect(auditRows[0].event.description).toBe(inviteMessage);
+  });
+
+  it("should use audit message for support/invite-created events", async () => {
+    const inviteMessage =
+      "support@education.gov.uk (id: user1) created invitation for new.user@example.com (id: inv-abc123)";
+
+    getPageOfUserAudits.mockResolvedValue({
+      audits: [
+        {
+          type: "support",
+          subType: "invite-created",
+          userId: "user1",
+          message: inviteMessage,
+          timestamp: "2025-06-02T10:00:00.000Z",
+        },
+      ],
+      numberOfPages: 1,
+      numberOfRecords: 1,
+    });
+
+    await getAudit(req, res);
+
+    const auditRows = sendResult.mock.calls[0][3].audits;
+    expect(auditRows[0].event.description).toBe(inviteMessage);
+  });
+
+  it("should show N/A for missing legacy IDs in support/user-org-deleted events", async () => {
+    getPageOfUserAudits.mockResolvedValue({
+      audits: [
+        {
+          type: "support",
+          subType: "user-org-deleted",
+          userId: "user1",
+          editedUser: "edited-user1",
+          editedFields: [{ name: "new_organisation", oldValue: "org-1" }],
+          timestamp: "2018-01-30T10:30:53.987Z",
+        },
+      ],
+      numberOfPages: 1,
+      numberOfRecords: 1,
+    });
+
+    await getAudit(req, res);
+
+    const auditRows = sendResult.mock.calls[0][3].audits;
+    expect(auditRows[0].event.description).toContain(
+      "numericIdentifier: N/A, textIdentifier: N/A",
+    );
+  });
+
+  it("should show N/A for missing legacy IDs in approver/user-org-deleted events", async () => {
+    getPageOfUserAudits.mockResolvedValue({
+      audits: [
+        {
+          type: "approver",
+          subType: "user-org-deleted",
+          userId: "user1",
+          editedUser: "edited-user1",
+          editedFields: [{ name: "new_organisation", oldValue: "org-1" }],
+          timestamp: "2018-01-30T10:30:53.987Z",
+        },
+      ],
+      numberOfPages: 1,
+      numberOfRecords: 1,
+    });
+
+    await getAudit(req, res);
+
+    const auditRows = sendResult.mock.calls[0][3].audits;
+    expect(auditRows[0].event.description).toContain(
+      "numericIdentifier: N/A, textIdentifier: N/A",
+    );
   });
 
   it("should return 400 for negative page numbers", async () => {
@@ -756,7 +956,7 @@ describe("when getting users audit details", () => {
         (a) => a.event.subType === "user-invited",
       );
       expect(invitedEvent.event.description).toBe(
-        "User invite sent from support console.",
+        "User invite sent by unknown from support console.",
       );
     });
 
@@ -767,9 +967,7 @@ describe("when getting users audit details", () => {
       const createdEvent = audits.find(
         (a) => a.event.subType === "invite-created",
       );
-      expect(createdEvent.event.description).toBe(
-        "Support/Invitation code created and sent.",
-      );
+      expect(createdEvent.event.description).toBe("Invitation code created");
     });
 
     it("should not call getUserStatusRaw for invited users", async () => {

--- a/test/app/users/getAudit.test.js
+++ b/test/app/users/getAudit.test.js
@@ -638,6 +638,27 @@ describe("when getting users audit details", () => {
     expect(auditRows[0].event.description).toBe(permissionMessage);
   });
 
+  it("should display the audit message for resent-invitation events", async () => {
+    getPageOfUserAudits.mockResolvedValue({
+      audits: [
+        createSimpleAuditRecord(
+          "approver",
+          "resent-invitation",
+          "approver@example.com (id: agent1) resent invitation email to user@example.com (id: inv-abc123)",
+        ),
+      ],
+      numberOfPages: 1,
+      numberOfRecords: 1,
+    });
+
+    await getAudit(req, res);
+
+    const auditsPassed = sendResult.mock.calls[0][3].audits;
+    expect(auditsPassed[0].event.description).toBe(
+      "approver@example.com (id: agent1) resent invitation email to user@example.com (id: inv-abc123)",
+    );
+  });
+
   it("should include the inviter name in the description for support/user-invited events", async () => {
     getUserDetailsById.mockImplementation(async (userId) => {
       if (userId === "support-user-1") {

--- a/test/app/users/getAudit.test.js
+++ b/test/app/users/getAudit.test.js
@@ -13,6 +13,7 @@ jest.mock("ioredis");
 jest.mock("login.dfe.api-client/organisations");
 jest.mock("login.dfe.api-client/invitations", () => ({
   getInvitationOrganisationsRaw: jest.fn(),
+  getInvitationRaw: jest.fn(),
 }));
 
 const { getUserDetailsById } = require("./../../../src/app/users/utils");
@@ -32,6 +33,7 @@ const {
 } = require("login.dfe.api-client/organisations");
 const {
   getInvitationOrganisationsRaw,
+  getInvitationRaw,
 } = require("login.dfe.api-client/invitations");
 
 const organisationId = "org-1";
@@ -115,6 +117,9 @@ describe("when getting users audit details", () => {
 
     getInvitationOrganisationsRaw.mockReset();
     getInvitationOrganisationsRaw.mockResolvedValue([]);
+
+    getInvitationRaw.mockReset();
+    getInvitationRaw.mockResolvedValue(null);
 
     sendResult.mockReset();
 

--- a/test/app/users/getAudit.test.js
+++ b/test/app/users/getAudit.test.js
@@ -671,7 +671,7 @@ describe("when getting users audit details", () => {
     await getAudit(req, res);
 
     const differentUserCall = getUserDetailsById.mock.calls.find(
-      (call) => call[0] === "DIFFERENT-USER",
+      (call) => call[0] === "different-user",
     );
     expect(differentUserCall).toBeDefined();
     expect(differentUserCall[1]).toBe(req);
@@ -680,7 +680,7 @@ describe("when getting users audit details", () => {
   });
 
   describe("when viewing audit for an invited user", () => {
-    const invitationGuid = "abc123-def456-ghi789";
+    const invitationGuid = "b755bb86-df39-46d3-a11f-99548f93061e";
     const invitationUid = `inv-${invitationGuid}`;
 
     beforeEach(() => {
@@ -797,6 +797,65 @@ describe("when getting users audit details", () => {
       await getAudit(req, res);
 
       const audits = sendResult.mock.calls[0][3].audits;
+      expect(audits[0].user.id).toBe(invitationUid);
+    });
+
+    it("should inject a synthetic invite-created entry when no audit records exist and getInvitationRaw returns a result", async () => {
+      getPageOfUserAudits.mockResolvedValue({
+        audits: [],
+        numberOfPages: 0,
+        numberOfRecords: 0,
+      });
+      getInvitationRaw.mockResolvedValue({
+        id: invitationGuid,
+        createdAt: "2024-03-15T09:00:00.000Z",
+      });
+
+      await getAudit(req, res);
+
+      const audits = sendResult.mock.calls[0][3].audits;
+      expect(audits).toHaveLength(1);
+      expect(audits[0].event.subType).toBe("invite-created");
+      expect(audits[0].event.description).toBe("Invitation created");
+      expect(audits[0].timestamp).toEqual(new Date("2024-03-15T09:00:00.000Z"));
+      expect(audits[0].user).toBeNull();
+    });
+
+    it("should not inject a synthetic entry when an invite-created audit record already exists", async () => {
+      getInvitationRaw.mockResolvedValue({
+        id: invitationGuid,
+        createdAt: "2024-03-15T09:00:00.000Z",
+      });
+
+      await getAudit(req, res);
+
+      expect(getInvitationRaw).not.toHaveBeenCalled();
+    });
+
+    it("should treat audit.userId matching the bare invitation GUID as the current user", async () => {
+      getPageOfUserAudits.mockResolvedValue({
+        audits: [
+          {
+            type: "support",
+            subType: "user-edit",
+            userId: invitationGuid,
+            editedUser: invitationUid,
+            editedFields: [{ name: "status", newValue: 1 }],
+            level: "audit",
+            message: "edited",
+            timestamp: "2025-05-01T10:00:00.000Z",
+          },
+        ],
+        numberOfPages: 1,
+        numberOfRecords: 1,
+      });
+
+      await getAudit(req, res);
+
+      const audits = sendResult.mock.calls[0][3].audits;
+      expect(audits[0].event.description).toBe(
+        "Reactivated user: Invited User",
+      );
       expect(audits[0].user.id).toBe(invitationUid);
     });
   });
@@ -924,7 +983,7 @@ describe("when getting users audit details", () => {
     it("should handle error in describeAuditEvent when processing complex audit types", async () => {
       getUserDetailsById.mockReset();
       getUserDetailsById.mockImplementation(async (userId) => {
-        if (userId === "DIFFERENT-USER") {
+        if (userId === "different-user") {
           throw new Error("Different user lookup failed");
         }
         return {

--- a/test/app/users/getOrganisations.test.js
+++ b/test/app/users/getOrganisations.test.js
@@ -10,6 +10,7 @@ jest.mock("./../../../src/infrastructure/audit");
 jest.mock("ioredis");
 jest.mock("login.dfe.api-client/users");
 
+const logger = require("./../../../src/infrastructure/logger");
 const { getUserDetailsById } = require("../../../src/app/users/utils");
 const {
   getPendingRequestsRaw,
@@ -139,6 +140,12 @@ describe("when getting users organisation details", () => {
         created_date: "2019-08-12",
       },
     ]);
+  });
+
+  it("should not log a user-view audit event", async () => {
+    await getOrganisations(req, res);
+
+    expect(logger.audit).not.toHaveBeenCalled();
   });
 
   it("then it should get user details", async () => {

--- a/test/app/users/getServices.test.js
+++ b/test/app/users/getServices.test.js
@@ -344,4 +344,10 @@ describe("when getting users service details", () => {
       statusChangeReasons: [],
     });
   });
+
+  it("should not write a user-view audit event", async () => {
+    const logger = require("./../../../src/infrastructure/logger");
+    await getServices(req, res);
+    expect(logger.audit).not.toHaveBeenCalled();
+  });
 });

--- a/test/app/users/postConfirmNewUser.test.js
+++ b/test/app/users/postConfirmNewUser.test.js
@@ -1,0 +1,111 @@
+jest.mock("./../../../src/infrastructure/config", () =>
+  require("./../../utils").configMockFactory(),
+);
+jest.mock("./../../../src/infrastructure/logger", () =>
+  require("./../../utils").loggerMockFactory(),
+);
+jest.mock("login.dfe.api-client/invitations");
+jest.mock("login.dfe.api-client/organisations");
+jest.mock("./../../../src/app/users/utils");
+jest.mock("./../../../src/app/users/userSearchHelpers/updateUserSearchIndex");
+
+const logger = require("./../../../src/infrastructure/logger");
+const {
+  createInvitation,
+  addOrganisationToInvitation,
+} = require("login.dfe.api-client/invitations");
+const { waitForIndexToUpdate } = require("./../../../src/app/users/utils");
+const {
+  updateUserSearchIndex,
+} = require("./../../../src/app/users/userSearchHelpers/updateUserSearchIndex");
+const postConfirmNewUser = require("./../../../src/app/users/postConfirmNewUser");
+
+describe("postConfirmNewUser", () => {
+  let req;
+  let res;
+
+  beforeEach(() => {
+    req = {
+      user: {
+        sub: "support-user-1",
+        email: "support@education.gov.uk",
+      },
+      session: {
+        user: {
+          firstName: "Jane",
+          lastName: "Doe",
+          email: "jane.doe@example.com",
+          organisationId: null,
+          permission: null,
+        },
+      },
+      body: {
+        "invite-destination":
+          "services{split}https://services.example.com/auth/cb",
+        "email-contents-choice": "Approve",
+        "redirect-choice": "Approve",
+      },
+    };
+
+    res = {
+      redirect: jest.fn(),
+      flash: jest.fn(),
+    };
+
+    logger.audit.mockReset();
+
+    createInvitation.mockReset();
+    createInvitation.mockResolvedValue("test-invitation-id");
+
+    addOrganisationToInvitation.mockReset();
+    addOrganisationToInvitation.mockResolvedValue();
+
+    waitForIndexToUpdate.mockReset();
+    waitForIndexToUpdate.mockResolvedValue();
+
+    updateUserSearchIndex.mockReset();
+    updateUserSearchIndex.mockResolvedValue();
+  });
+
+  describe("user-invited audit event", () => {
+    it("should include editedUser with the invitation ID in the metadata", async () => {
+      await postConfirmNewUser(req, res);
+
+      const userInvitedCall = logger.audit.mock.calls.find(
+        (call) => call[1]?.subType === "user-invited",
+      );
+      expect(userInvitedCall).toBeDefined();
+      expect(userInvitedCall[1].editedUser).toBe("inv-test-invitation-id");
+    });
+
+    it("should include all required fields in the metadata", async () => {
+      await postConfirmNewUser(req, res);
+
+      const userInvitedCall = logger.audit.mock.calls.find(
+        (call) => call[1]?.subType === "user-invited",
+      );
+      expect(userInvitedCall[1]).toMatchObject({
+        type: "support",
+        subType: "user-invited",
+        userId: "support-user-1",
+        editedUser: "inv-test-invitation-id",
+        userEmail: "support@education.gov.uk",
+        invitedUserEmail: "jane.doe@example.com",
+      });
+    });
+  });
+
+  describe("invite-created audit event", () => {
+    it("should use a user-friendly message format", async () => {
+      await postConfirmNewUser(req, res);
+
+      const inviteCreatedCall = logger.audit.mock.calls.find(
+        (call) => call[0]?.subType === "invite-created",
+      );
+      expect(inviteCreatedCall).toBeDefined();
+      expect(inviteCreatedCall[0].message).toBe(
+        "support@education.gov.uk (id: support-user-1) created invitation for jane.doe@example.com (id: inv-test-invitation-id)",
+      );
+    });
+  });
+});

--- a/test/app/users/postConfirmNewUser.test.js
+++ b/test/app/users/postConfirmNewUser.test.js
@@ -14,6 +14,9 @@ const {
   createInvitation,
   addOrganisationToInvitation,
 } = require("login.dfe.api-client/invitations");
+const {
+  getOrganisationLegacyRaw,
+} = require("login.dfe.api-client/organisations");
 const { waitForIndexToUpdate } = require("./../../../src/app/users/utils");
 const {
   updateUserSearchIndex,
@@ -65,6 +68,8 @@ describe("postConfirmNewUser", () => {
 
     updateUserSearchIndex.mockReset();
     updateUserSearchIndex.mockResolvedValue();
+
+    getOrganisationLegacyRaw.mockReset();
   });
 
   describe("user-invited audit event", () => {
@@ -96,15 +101,34 @@ describe("postConfirmNewUser", () => {
   });
 
   describe("invite-created audit event", () => {
-    it("should use a user-friendly message format", async () => {
+    it("uses the standard format without org when no org is set", async () => {
+      // organisationId is null in default req.session.user
       await postConfirmNewUser(req, res);
 
-      const inviteCreatedCall = logger.audit.mock.calls.find(
-        (call) => call[0]?.subType === "invite-created",
+      const call = logger.audit.mock.calls.find(
+        (c) => c[0]?.subType === "invite-created",
       );
-      expect(inviteCreatedCall).toBeDefined();
-      expect(inviteCreatedCall[0].message).toBe(
-        "support@education.gov.uk (id: support-user-1) created invitation for jane.doe@example.com (id: inv-test-invitation-id)",
+      expect(call).toBeDefined();
+      expect(call[0].message).toBe(
+        "support@education.gov.uk invited jane.doe@example.com (id: inv-test-invitation-id)",
+      );
+    });
+
+    it("uses the standard format with org name and ID when an org is set", async () => {
+      getOrganisationLegacyRaw.mockResolvedValue({
+        id: "org-456",
+        name: "Big School",
+      });
+      req.session.user.organisationId = "org-456";
+
+      await postConfirmNewUser(req, res);
+
+      const call = logger.audit.mock.calls.find(
+        (c) => c[0]?.subType === "invite-created",
+      );
+      expect(call).toBeDefined();
+      expect(call[0].message).toBe(
+        "support@education.gov.uk invited jane.doe@example.com to Big School (id: org-456) (id: inv-test-invitation-id)",
       );
     });
   });

--- a/test/app/users/postRemoveServiceAccess.test.js
+++ b/test/app/users/postRemoveServiceAccess.test.js
@@ -138,6 +138,16 @@ describe("when removing access to a service", () => {
     );
   });
 
+  it("should call getInvitationOrganisationsRaw with invitationId (not userId) for invited users", async () => {
+    req.params.uid = "inv-invite1";
+
+    await postRemoveService(req, res);
+
+    expect(getInvitationOrganisationsRaw).toHaveBeenCalledWith({
+      invitationId: "invite1",
+    });
+  });
+
   it("then it should delete service for invitation if request for invitation", async () => {
     req.params.uid = "inv-invite1";
 

--- a/test/app/users/postResendInvite.test.js
+++ b/test/app/users/postResendInvite.test.js
@@ -2,6 +2,10 @@ jest.mock("./../../../src/infrastructure/config", () =>
   require("./../../utils").configMockFactory(),
 );
 
+jest.mock("./../../../src/infrastructure/logger", () =>
+  require("./../../utils").loggerMockFactory(),
+);
+
 jest.mock("login.dfe.api-client/invitations", () => ({
   resendInvitation: jest.fn(),
 }));
@@ -21,7 +25,11 @@ describe("When resending a user invite", () => {
     res.redirect = jest.fn();
 
     req.params.uid = "inv-12345";
-    req.session.user = { firstName: "fname", lastName: "lname" };
+    req.session.user = {
+      firstName: "fname",
+      lastName: "lname",
+      email: "invited@example.com",
+    };
   });
 
   test("it should set session.type to organisations if undefined", async () => {
@@ -76,5 +84,27 @@ describe("When resending a user invite", () => {
     resendInvitation.mockResolvedValue(true);
     await postResendInvite(req, res);
     expect(resendInvitation).toHaveBeenCalledWith({ invitationId: "12345" });
+  });
+
+  test("it should write a resent-invitation audit on success", async () => {
+    resendInvitation.mockResolvedValue(true);
+    const logger = require("./../../../src/infrastructure/logger");
+    await postResendInvite(req, res);
+    expect(logger.audit).toHaveBeenCalledWith(
+      "super.user@unit.test (id: suser1) resent invitation to invited@example.com (id: inv-12345)",
+      expect.objectContaining({
+        type: "support",
+        subType: "resent-invitation",
+        userId: "suser1",
+        editedUser: "inv-12345",
+      }),
+    );
+  });
+
+  test("it should not write audit on failure", async () => {
+    resendInvitation.mockResolvedValue(null);
+    const logger = require("./../../../src/infrastructure/logger");
+    await postResendInvite(req, res);
+    expect(logger.audit).not.toHaveBeenCalled();
   });
 });

--- a/tools/backfillInvitationAuditEditedUser.js
+++ b/tools/backfillInvitationAuditEditedUser.js
@@ -10,9 +10,9 @@ const USER_INVITE_ORG_RE =
 
 const findMissingEditedUser = async (subType) =>
   db.query(
-    `SELECT AL.id, ALM.[value] AS message
+    `SELECT AL.id, COALESCE(ALM.[value], AL.message) AS message
      FROM AuditLogs AL
-     JOIN AuditLogMeta ALM ON ALM.auditId = AL.id AND ALM.[key] = 'message'
+     LEFT JOIN AuditLogMeta ALM ON ALM.auditId = AL.id AND ALM.[key] = 'message'
      WHERE AL.subType = :subType
        AND NOT EXISTS (
          SELECT 1 FROM AuditLogMeta ALM2
@@ -40,6 +40,11 @@ const backfill = async () => {
     `invite-created records missing editedUser: ${inviteCreatedRows.length}`,
   );
   for (const row of inviteCreatedRows) {
+    if (!row.message) {
+      console.warn(`  skipped invite-created ${row.id}: message is null`);
+      skipped++;
+      continue;
+    }
     const match = INVITE_CREATED_RE.exec(row.message);
     if (match) {
       await insertEditedUser(row.id, `inv-${match[1]}`);
@@ -58,6 +63,11 @@ const backfill = async () => {
     `user-invite-org records missing editedUser: ${userInviteOrgRows.length}`,
   );
   for (const row of userInviteOrgRows) {
+    if (!row.message) {
+      console.warn(`  skipped user-invite-org ${row.id}: message is null`);
+      skipped++;
+      continue;
+    }
     const match = USER_INVITE_ORG_RE.exec(row.message);
     if (match) {
       await insertEditedUser(row.id, `inv-${match[1]}`);

--- a/tools/backfillInvitationAuditEditedUser.js
+++ b/tools/backfillInvitationAuditEditedUser.js
@@ -1,0 +1,82 @@
+const { v4: uuidv4 } = require("uuid");
+const { QueryTypes } = require("sequelize");
+const { db } = require("./../src/infrastructure/audit/sequelize-schema");
+
+const INVITE_CREATED_RE =
+  /Invitation code is created\. Id ([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/i;
+
+const USER_INVITE_ORG_RE =
+  /to invitation for .+ \(id: ([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\)/i;
+
+const findMissingEditedUser = async (subType) =>
+  db.query(
+    `SELECT AL.id, ALM.[value] AS message
+     FROM AuditLogs AL
+     JOIN AuditLogMeta ALM ON ALM.auditId = AL.id AND ALM.[key] = 'message'
+     WHERE AL.subType = :subType
+       AND NOT EXISTS (
+         SELECT 1 FROM AuditLogMeta ALM2
+         WHERE ALM2.auditId = AL.id AND ALM2.[key] = 'editedUser'
+       )`,
+    { type: QueryTypes.SELECT, replacements: { subType } },
+  );
+
+const insertEditedUser = async (auditId, editedUser) =>
+  db.query(
+    `INSERT INTO AuditLogMeta (id, auditId, [key], [value])
+     VALUES (:id, :auditId, 'editedUser', :editedUser)`,
+    {
+      type: QueryTypes.INSERT,
+      replacements: { id: uuidv4(), auditId, editedUser },
+    },
+  );
+
+const backfill = async () => {
+  let fixed = 0;
+  let skipped = 0;
+
+  const inviteCreatedRows = await findMissingEditedUser("invite-created");
+  console.log(
+    `invite-created records missing editedUser: ${inviteCreatedRows.length}`,
+  );
+  for (const row of inviteCreatedRows) {
+    const match = INVITE_CREATED_RE.exec(row.message);
+    if (match) {
+      await insertEditedUser(row.id, `inv-${match[1]}`);
+      console.log(`  fixed invite-created ${row.id} -> inv-${match[1]}`);
+      fixed++;
+    } else {
+      console.warn(
+        `  skipped invite-created ${row.id}: could not parse GUID from message`,
+      );
+      skipped++;
+    }
+  }
+
+  const userInviteOrgRows = await findMissingEditedUser("user-invite-org");
+  console.log(
+    `user-invite-org records missing editedUser: ${userInviteOrgRows.length}`,
+  );
+  for (const row of userInviteOrgRows) {
+    const match = USER_INVITE_ORG_RE.exec(row.message);
+    if (match) {
+      await insertEditedUser(row.id, `inv-${match[1]}`);
+      console.log(`  fixed user-invite-org ${row.id} -> inv-${match[1]}`);
+      fixed++;
+    } else {
+      console.warn(
+        `  skipped user-invite-org ${row.id}: could not parse GUID from message`,
+      );
+      skipped++;
+    }
+  }
+
+  console.log(`\nDone. Fixed: ${fixed}, Skipped: ${skipped}`);
+};
+
+backfill()
+  .then(() => process.exit(0))
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary
https://dfe-secureaccess.atlassian.net/browse/NSA-9802
- The Audit tab was previously hidden for users with **Invited** status, showing no audit information. This change makes the tab visible and populated for invited users
- Audit events linked to an invited user (invite created, organisation added, email changed, profile viewed) now appear in the audit table with the correct date, event description, and the support admin who performed the action
- For invitations with no audit history in the database (created before audit logging was in place), the tab falls back to the invitation record's `createdAt` and injects a synthetic "Invitation created" entry - ensuring there is always at minimum a date shown

## Changes

**`summaryPartial.ejs`** - Removed the `isInvitation` guard that was hiding the Audit tab for invited users

**`sequelize.js`** - Extended `getPageOfUserAudits` to search for audit records linked to an invitation via:
- `editedUser` / `viewedUser` metadata matching both the bare GUID and the `inv-` prefixed value
- A direct `LIKE` search on `AuditLogs.message` for `invite-created` and `user-invite-org` events, which embed the invitation GUID in their message text

**`postConfirmNewUser.js` / `getConfirmAssociateOrganisation.js`** - Added `editedUser: inv-${invitationId}` to `invite-created`, `user-invited`, and `user-invite-org` audit calls so new invitation events are linked to the invited user and picked up by the query

**`getAudit.js`** - Detects invitation URLs (`inv-` prefix) and routes correctly; added `user-invite-org` to `AUDIT_MESSAGE_SUBTYPES`; falls back to `getInvitationRaw` to inject a synthetic entry when no `invite-created` record exists in the database

**`tools/backfillInvitationAuditEditedUser.js`** - One-off script that retroactively inserts `editedUser` metadata for historical `invite-created` and `user-invite-org` records by parsing the invitation GUID from the stored message text

## Test plan

- [x] Tested and verified in dev environment
- [x] Navigate to an invited user - Audit tab is visible
- [x] Audit tab shows `invite-created` event with the date invited and the support admin's name in the User column
- [x] For invitations created before this change, the tab shows at minimum an "Invitation created" entry with the correct date
- [x] For invitations where an organisation was added, the `user-invite-org` event appears with a readable description
- [x] Existing audit behaviour for active and deactivated users is unchanged
- [x] All 54 unit tests pass
