### PR TITLE
NSA-8951: Remove status from addOrganisationToUser calls in support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "helmet": "^7.2.0",
         "ioredis": "^5.6.1",
         "lodash": "^4.17.21",
-        "login.dfe.api-client": "^1.0.67",
+        "login.dfe.api-client": "^1.0.70",
         "login.dfe.async-retry": "github:DFE-Digital/login.dfe.async-retry#v2.0.3",
         "login.dfe.audit.winston-sequelize-transport": "^3.2.6",
         "login.dfe.config.schema.common": "^2.1.8",
@@ -7538,9 +7538,9 @@
       "license": "MIT"
     },
     "node_modules/login.dfe.api-client": {
-      "version": "1.0.69",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/login.dfe.api-client/-/login.dfe.api-client-1.0.69.tgz",
-      "integrity": "sha1-AHNFlmxl5DgYgGFnNm4zVHdbItA=",
+      "version": "1.0.70",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/login.dfe.api-client/-/login.dfe.api-client-1.0.70.tgz",
+      "integrity": "sha1-/4LQX9y9CSX6Zv1lgFNrD+cRang=",
       "dependencies": {
         "@azure/msal-node": "^3.1.0",
         "applicationinsights": "^2.9.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "login.dfe.async-retry": "github:DFE-Digital/login.dfe.async-retry#v2.0.3",
         "login.dfe.audit.winston-sequelize-transport": "^3.2.6",
         "login.dfe.config.schema.common": "^2.1.8",
-        "login.dfe.dao": "^5.0.6",
+        "login.dfe.dao": "^5.0.7",
         "login.dfe.entra-auth-extensions": "^1.0.24",
         "login.dfe.express-flash-2": "github:DFE-Digital/login.dfe.express-flash-2#v2.0.2",
         "login.dfe.express-helpers": "^2.0.0",
@@ -7593,9 +7593,9 @@
       }
     },
     "node_modules/login.dfe.dao": {
-      "version": "5.0.6",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/login.dfe.dao/-/login.dfe.dao-5.0.6.tgz",
-      "integrity": "sha1-bwk7ASTuXw1/Rb8QmiSLQgQ7FIk=",
+      "version": "5.0.7",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/login.dfe.dao/-/login.dfe.dao-5.0.7.tgz",
+      "integrity": "sha1-2d28ey6pNzJiqHiXfmwancZouRA=",
       "license": "ISC",
       "dependencies": {
         "express": "^4.17.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7538,9 +7538,9 @@
       "license": "MIT"
     },
     "node_modules/login.dfe.api-client": {
-      "version": "1.0.67",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/login.dfe.api-client/-/login.dfe.api-client-1.0.67.tgz",
-      "integrity": "sha1-R5gSTIGwwzHL3jgAxCXCjmxJUpA=",
+      "version": "1.0.69",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/login.dfe.api-client/-/login.dfe.api-client-1.0.69.tgz",
+      "integrity": "sha1-AHNFlmxl5DgYgGFnNm4zVHdbItA=",
       "dependencies": {
         "@azure/msal-node": "^3.1.0",
         "applicationinsights": "^2.9.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7538,9 +7538,9 @@
       "license": "MIT"
     },
     "node_modules/login.dfe.api-client": {
-      "version": "1.0.70",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/login.dfe.api-client/-/login.dfe.api-client-1.0.70.tgz",
-      "integrity": "sha1-/4LQX9y9CSX6Zv1lgFNrD+cRang=",
+      "version": "1.0.71",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/login.dfe.api-client/-/login.dfe.api-client-1.0.71.tgz",
+      "integrity": "sha1-Gt4OSza42CMGykX1NejhKlUoeDM=",
       "dependencies": {
         "@azure/msal-node": "^3.1.0",
         "applicationinsights": "^2.9.6",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "helmet": "^7.2.0",
     "ioredis": "^5.6.1",
     "lodash": "^4.17.21",
-    "login.dfe.api-client": "^1.0.69",
+    "login.dfe.api-client": "^1.0.70",
     "login.dfe.async-retry": "github:DFE-Digital/login.dfe.async-retry#v2.0.3",
     "login.dfe.audit.winston-sequelize-transport": "^3.2.6",
     "login.dfe.config.schema.common": "^2.1.8",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "helmet": "^7.2.0",
     "ioredis": "^5.6.1",
     "lodash": "^4.17.21",
-    "login.dfe.api-client": "^1.0.70",
+    "login.dfe.api-client": "^1.0.71",
     "login.dfe.async-retry": "github:DFE-Digital/login.dfe.async-retry#v2.0.3",
     "login.dfe.audit.winston-sequelize-transport": "^3.2.6",
     "login.dfe.config.schema.common": "^2.1.8",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "login.dfe.async-retry": "github:DFE-Digital/login.dfe.async-retry#v2.0.3",
     "login.dfe.audit.winston-sequelize-transport": "^3.2.6",
     "login.dfe.config.schema.common": "^2.1.8",
-    "login.dfe.dao": "^5.0.6",
+    "login.dfe.dao": "^5.0.7",
     "login.dfe.entra-auth-extensions": "^1.0.24",
     "login.dfe.express-flash-2": "github:DFE-Digital/login.dfe.express-flash-2#v2.0.2",
     "login.dfe.express-helpers": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "helmet": "^7.2.0",
     "ioredis": "^5.6.1",
     "lodash": "^4.17.21",
-    "login.dfe.api-client": "^1.0.67",
+    "login.dfe.api-client": "^1.0.69",
     "login.dfe.async-retry": "github:DFE-Digital/login.dfe.async-retry#v2.0.3",
     "login.dfe.audit.winston-sequelize-transport": "^3.2.6",
     "login.dfe.config.schema.common": "^2.1.8",

--- a/src/app/accessRequests/selectPermissionLevel.js
+++ b/src/app/accessRequests/selectPermissionLevel.js
@@ -126,7 +126,6 @@ const post = async (req, res) => {
     await addOrganisationToUser({
       organisationId: model.request.org_id,
       userId: model.request.user_id,
-      status: 1,
       roleId: model.selectedLevel,
     });
     await updateRequestForOrganisationRaw({

--- a/src/app/accessRequests/utils.js
+++ b/src/app/accessRequests/utils.js
@@ -64,11 +64,11 @@ const putUserInOrganisation = async (req) => {
 
   const userId = req.body.user_id;
   const orgId = req.body.org_id;
-  const status = req.body.approve_reject.toLowerCase() === "approve" ? 1 : -1;
+  const approved = req.body.approve_reject.toLowerCase() === "approve";
   let role = 0;
   let reason = req.body.message;
 
-  if (status === 1) {
+  if (approved) {
     reason = "";
     role = req.body.role.toLowerCase() === "approver" ? 10000 : 1;
   }
@@ -77,7 +77,6 @@ const putUserInOrganisation = async (req) => {
     userId,
     organisationId: orgId,
     roleId: role,
-    status,
     reason,
   });
 
@@ -86,7 +85,7 @@ const putUserInOrganisation = async (req) => {
       req.body.email,
       req.body.name,
       req.body.org_name,
-      status === 1,
+      approved,
       reason,
     );
   }

--- a/test/app/accessRequests/selectPermissionLevel.post.test.js
+++ b/test/app/accessRequests/selectPermissionLevel.post.test.js
@@ -260,7 +260,6 @@ describe("when selecting a permission level", () => {
     expect(addOrganisationToUser).toHaveBeenCalledWith({
       organisationId: "org1",
       roleId: 0,
-      status: 1,
       userId: "userId",
     });
   });

--- a/test/app/accessRequests/utils.putUserInOrganisation.test.js
+++ b/test/app/accessRequests/utils.putUserInOrganisation.test.js
@@ -67,7 +67,6 @@ describe("When putting a user in an organisation", () => {
       organisationId: "org1",
       reason: "",
       roleId: 1,
-      status: 1,
       userId: "user1",
     });
   });
@@ -82,7 +81,6 @@ describe("When putting a user in an organisation", () => {
       organisationId: "org1",
       reason: "",
       roleId: 10000,
-      status: 1,
       userId: "user1",
     });
   });
@@ -97,7 +95,6 @@ describe("When putting a user in an organisation", () => {
       organisationId: "org1",
       reason: "test message",
       roleId: 0,
-      status: -1,
       userId: "user1",
     });
   });


### PR DESCRIPTION
## Summary

- Removes `status` from `addOrganisationToUser` call in `utils.js` — refactored `status` variable to `approved` boolean for clarity
- Removes `status: 1` from `addOrganisationToUser` call in `selectPermissionLevel.js`
- Updates tests to remove `status` from expected call assertions

## Context

Support wrote `status: 1` (approve) or `status: -1` (reject) into a column that was never read. Part of NSA-8951.

## Test plan

- [ ] AC2, AC3 from NSA-8951 Jira ticket
- [ ] Approve access request via Support console — user added with correct role, approval email sent
- [ ] Reject access request via Support console — user NOT added, rejection email sent
- [ ] All 640 unit tests passing (2 pre-existing failures in `postConfirmNewUser.test.js` are unrelated to this change)
