### PR TITLE
fix(NSA-9314): pass removal IDs on service removal and add COLLECT org gap report

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "helmet": "^7.2.0",
         "ioredis": "^5.6.1",
         "lodash": "^4.17.21",
-        "login.dfe.api-client": "^1.0.70",
+        "login.dfe.api-client": "github:DFE-Digital/login.dfe.api-client#feature/NSA-9314-fix-deactivation-sync-and-collect-report",
         "login.dfe.async-retry": "github:DFE-Digital/login.dfe.async-retry#v2.0.3",
         "login.dfe.audit.winston-sequelize-transport": "^3.2.6",
         "login.dfe.config.schema.common": "^2.1.8",
@@ -7538,9 +7538,8 @@
       "license": "MIT"
     },
     "node_modules/login.dfe.api-client": {
-      "version": "1.0.71",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/login.dfe.api-client/-/login.dfe.api-client-1.0.71.tgz",
-      "integrity": "sha1-Gt4OSza42CMGykX1NejhKlUoeDM=",
+      "version": "1.0.72",
+      "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.api-client.git#56b41eb31f08a8120d7329dbbd7fef1f6f22ce05",
       "dependencies": {
         "@azure/msal-node": "^3.1.0",
         "applicationinsights": "^2.9.6",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "helmet": "^7.2.0",
     "ioredis": "^5.6.1",
     "lodash": "^4.17.21",
-    "login.dfe.api-client": "^1.0.71",
+    "login.dfe.api-client": "^1.0.72",
     "login.dfe.async-retry": "github:DFE-Digital/login.dfe.async-retry#v2.0.3",
     "login.dfe.audit.winston-sequelize-transport": "^3.2.6",
     "login.dfe.config.schema.common": "^2.1.8",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "helmet": "^7.2.0",
     "ioredis": "^5.6.1",
     "lodash": "^4.17.21",
-    "login.dfe.api-client": "^1.0.72",
+    "login.dfe.api-client": "github:DFE-Digital/login.dfe.api-client#feature/NSA-9314-fix-deactivation-sync-and-collect-report",
     "login.dfe.async-retry": "github:DFE-Digital/login.dfe.async-retry#v2.0.3",
     "login.dfe.audit.winston-sequelize-transport": "^3.2.6",
     "login.dfe.config.schema.common": "^2.1.8",

--- a/src/app/reports/collectOrgsWithoutUsers.js
+++ b/src/app/reports/collectOrgsWithoutUsers.js
@@ -1,0 +1,29 @@
+const {
+  getCollectOrgsWithoutActiveUsersRaw,
+} = require("login.dfe.api-client/organisations");
+const logger = require("../../infrastructure/logger");
+
+const get = async (req, res) => {
+  const { correlationId } = req;
+  let organisations = [];
+
+  try {
+    const result = await getCollectOrgsWithoutActiveUsersRaw({
+      correlationId,
+    });
+    organisations = result ?? [];
+  } catch (e) {
+    logger.error(
+      `Failed to load COLLECT orgs without active users report - ${e.message}`,
+      { correlationId },
+    );
+  }
+
+  return res.render("reports/views/collectOrgsWithoutUsers", {
+    currentPage: "reports",
+    title: "COLLECT: Organisations without active users",
+    organisations,
+  });
+};
+
+module.exports = { get };

--- a/src/app/reports/index.js
+++ b/src/app/reports/index.js
@@ -1,10 +1,12 @@
 const express = require("express");
 const { asyncWrapper } = require("login.dfe.express-helpers/error-handling");
+const { isLoggedIn } = require("../../infrastructure/utils");
 const { get } = require("./collectOrgsWithoutUsers");
 
 const router = express.Router({ mergeParams: true });
 
 const reportRoutes = (csrf) => {
+  router.use(isLoggedIn);
   router.get("/collect-orgs", csrf, asyncWrapper(get));
   return router;
 };

--- a/src/app/reports/index.js
+++ b/src/app/reports/index.js
@@ -1,0 +1,12 @@
+const express = require("express");
+const { asyncWrapper } = require("login.dfe.express-helpers/error-handling");
+const { get } = require("./collectOrgsWithoutUsers");
+
+const router = express.Router({ mergeParams: true });
+
+const reportRoutes = (csrf) => {
+  router.get("/collect-orgs", csrf, asyncWrapper(get));
+  return router;
+};
+
+module.exports = reportRoutes;

--- a/src/app/reports/views/collectOrgsWithoutUsers.ejs
+++ b/src/app/reports/views/collectOrgsWithoutUsers.ejs
@@ -1,0 +1,50 @@
+<div class="govuk-width-container">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+
+            <h1 class="govuk-heading-l"><%= title %></h1>
+
+            <p class="govuk-body">
+                Open organisations that have had at least one COLLECT user in DfE Sign-In
+                but currently have no active users with COLLECT access.
+            </p>
+
+            <% if (organisations.length === 0) { %>
+                <p class="govuk-body">No organisations found matching this criteria.</p>
+            <% } else { %>
+                <p class="govuk-body">
+                    <strong><%= organisations.length.toLocaleString() %></strong>
+                    organisation<%= organisations.length === 1 ? '' : 's' %> found.
+                </p>
+
+                <table class="govuk-table">
+                    <thead class="govuk-table__head">
+                        <tr class="govuk-table__row">
+                            <th scope="col" class="govuk-table__header">Organisation name</th>
+                            <th scope="col" class="govuk-table__header">URN</th>
+                            <th scope="col" class="govuk-table__header">Establishment no.</th>
+                            <th scope="col" class="govuk-table__header">LA code</th>
+                            <th scope="col" class="govuk-table__header">Category</th>
+                            <th scope="col" class="govuk-table__header">Total records</th>
+                            <th scope="col" class="govuk-table__header">Active users</th>
+                        </tr>
+                    </thead>
+                    <tbody class="govuk-table__body">
+                        <% organisations.forEach(function(org) { %>
+                            <tr class="govuk-table__row">
+                                <td class="govuk-table__cell"><%= org.org_name %></td>
+                                <td class="govuk-table__cell"><%= org.urn || '—' %></td>
+                                <td class="govuk-table__cell"><%= org.establishment_number || '—' %></td>
+                                <td class="govuk-table__cell"><%= org.local_authority_code || '—' %></td>
+                                <td class="govuk-table__cell"><%= org.category || '—' %></td>
+                                <td class="govuk-table__cell"><%= org.total_user_service_records %></td>
+                                <td class="govuk-table__cell">0</td>
+                            </tr>
+                        <% }); %>
+                    </tbody>
+                </table>
+            <% } %>
+
+        </div>
+    </div>
+</div>

--- a/src/app/users/removeServiceAccess.js
+++ b/src/app/users/removeServiceAccess.js
@@ -77,7 +77,11 @@ const post = async (req, res) => {
     try {
       await asyncRetry(
         async () =>
-          await serviceNotificationsClient.notifyUserUpdated({ sub: uid }),
+          await serviceNotificationsClient.notifyUserUpdated({
+            sub: uid,
+            removedServiceId: serviceId,
+            removedOrgId: organisationId,
+          }),
         asyncRetry.strategies.apiStrategy,
       );
       logger.audit(

--- a/src/routes.js
+++ b/src/routes.js
@@ -4,6 +4,7 @@ const services = require("./app/services");
 const errors = require("./app/errors");
 const signOut = require("./app/signOut");
 const accessRequests = require("./app/accessRequests");
+const reports = require("./app/reports");
 const healthCheck = require("login.dfe.healthcheck");
 const { getHealthCheckChecks } = require("./infrastructure/healthCheck");
 const config = require("./infrastructure/config");
@@ -17,6 +18,7 @@ const routes = (app, csrf) => {
   app.use("/services", services(csrf));
   app.use("/signout", signOut(csrf));
   app.use("/access-requests", accessRequests(csrf));
+  app.use("/reports", reports(csrf));
   app.use("/", errors(csrf));
 
   app.get("/", (req, res) => {

--- a/test/app/reports/collectOrgsWithoutUsers.test.js
+++ b/test/app/reports/collectOrgsWithoutUsers.test.js
@@ -1,0 +1,56 @@
+jest.mock("login.dfe.api-client/organisations", () => ({
+  getCollectOrgsWithoutActiveUsersRaw: jest.fn(),
+}));
+jest.mock("../../../src/infrastructure/logger");
+
+const {
+  getCollectOrgsWithoutActiveUsersRaw,
+} = require("login.dfe.api-client/organisations");
+const { get } = require("../../../src/app/reports/collectOrgsWithoutUsers");
+const { getResponseMock } = require("../../utils");
+
+describe("GET /reports/collect-orgs", () => {
+  let req, res;
+
+  beforeEach(() => {
+    req = { correlationId: "corr-1" };
+    res = getResponseMock();
+    getCollectOrgsWithoutActiveUsersRaw.mockClear();
+  });
+
+  it("renders the view with the organisation list", async () => {
+    const orgs = [{ org_id: "org-1", org_name: "Test School" }];
+    getCollectOrgsWithoutActiveUsersRaw.mockResolvedValue(orgs);
+
+    await get(req, res);
+
+    expect(res.render).toHaveBeenCalledWith(
+      "reports/views/collectOrgsWithoutUsers",
+      expect.objectContaining({ organisations: orgs }),
+    );
+  });
+
+  it("renders with an empty array when the API returns null", async () => {
+    getCollectOrgsWithoutActiveUsersRaw.mockResolvedValue(null);
+
+    await get(req, res);
+
+    expect(res.render).toHaveBeenCalledWith(
+      "reports/views/collectOrgsWithoutUsers",
+      expect.objectContaining({ organisations: [] }),
+    );
+  });
+
+  it("renders with an empty array when the API throws", async () => {
+    getCollectOrgsWithoutActiveUsersRaw.mockRejectedValue(
+      new Error("API error"),
+    );
+
+    await get(req, res);
+
+    expect(res.render).toHaveBeenCalledWith(
+      "reports/views/collectOrgsWithoutUsers",
+      expect.objectContaining({ organisations: [] }),
+    );
+  });
+});

--- a/test/app/users/removeServiceAccess.test.js
+++ b/test/app/users/removeServiceAccess.test.js
@@ -1,0 +1,216 @@
+jest.mock("./../../../src/infrastructure/config", () =>
+  require("./../../utils").configMockFactory(),
+);
+jest.mock("./../../../src/infrastructure/logger", () =>
+  require("./../../utils").loggerMockFactory(),
+);
+jest.mock("login.dfe.api-client/users");
+jest.mock("login.dfe.api-client/invitations");
+jest.mock("login.dfe.api-client/services");
+jest.mock("login.dfe.jobs-client");
+jest.mock("login.dfe.async-retry");
+jest.mock("../../../src/app/services/utils", () => ({
+  isSupportEmailNotificationAllowed: jest.fn(),
+}));
+
+const { getRequestMock, getResponseMock } = require("./../../utils");
+const {
+  ServiceNotificationsClient,
+  NotificationClient,
+} = require("login.dfe.jobs-client");
+const asyncRetry = require("login.dfe.async-retry");
+const {
+  deleteUserServiceAccess,
+  getUserOrganisationsWithServicesRaw,
+} = require("login.dfe.api-client/users");
+const { getServiceRaw } = require("login.dfe.api-client/services");
+const {
+  isSupportEmailNotificationAllowed,
+} = require("../../../src/app/services/utils");
+
+const { post } = require("./../../../src/app/users/removeServiceAccess");
+
+const res = getResponseMock();
+const serviceNotificationsClient = {
+  notifyUserUpdated: jest.fn(),
+};
+const notificationClient = {
+  sendUserServiceRemoved: jest.fn(),
+};
+
+describe("when removing service access from a user", () => {
+  let req;
+
+  beforeEach(() => {
+    req = getRequestMock({
+      params: {
+        uid: "user-1",
+        sid: "service-1",
+        orgId: "org-1",
+      },
+      session: {
+        user: {
+          email: "test@test.com",
+          firstName: "test",
+          lastName: "name",
+        },
+      },
+    });
+
+    res.mockResetAll();
+
+    deleteUserServiceAccess.mockReset().mockResolvedValue(undefined);
+
+    getUserOrganisationsWithServicesRaw.mockReset().mockResolvedValue([
+      {
+        organisation: {
+          id: "org-1",
+          name: "Test Organisation",
+        },
+      },
+    ]);
+
+    getServiceRaw.mockReset().mockResolvedValue({
+      id: "service-1",
+      name: "Test Service",
+    });
+
+    isSupportEmailNotificationAllowed.mockReset().mockResolvedValue(false);
+
+    serviceNotificationsClient.notifyUserUpdated.mockReset();
+    ServiceNotificationsClient.mockReset().mockImplementation(
+      () => serviceNotificationsClient,
+    );
+
+    notificationClient.sendUserServiceRemoved.mockReset();
+    NotificationClient.mockReset().mockImplementation(() => notificationClient);
+
+    asyncRetry.mockReset().mockImplementation(async (fn) => {
+      return fn();
+    });
+    asyncRetry.strategies = {
+      apiStrategy: "api-strategy",
+    };
+  });
+
+  it("deletes user service access", async () => {
+    await post(req, res);
+
+    expect(deleteUserServiceAccess).toHaveBeenCalledWith({
+      userId: "user-1",
+      serviceId: "service-1",
+      organisationId: "org-1",
+    });
+  });
+
+  it("passes removedServiceId and removedOrgId to notifyUserUpdated", async () => {
+    await post(req, res);
+
+    expect(serviceNotificationsClient.notifyUserUpdated).toHaveBeenCalledWith({
+      sub: "user-1",
+      removedServiceId: "service-1",
+      removedOrgId: "org-1",
+    });
+  });
+
+  it("flashes success message", async () => {
+    await post(req, res);
+
+    expect(res.flash).toHaveBeenCalledWith(
+      "info",
+      "Test Service successfully removed",
+    );
+  });
+
+  it("redirects to user services page", async () => {
+    await post(req, res);
+
+    expect(res.redirect).toHaveBeenCalledWith("/users/user-1/services");
+  });
+
+  it("redirects to user organisations if no user in session", async () => {
+    req.session.user = undefined;
+
+    await post(req, res);
+
+    expect(res.redirect).toHaveBeenCalledWith("/users/user-1/organisations");
+  });
+
+  it("handles invitation ids by deleting from invitation service access", async () => {
+    const {
+      deleteServiceAccessFromInvitation,
+      getInvitationOrganisationsRaw,
+    } = require("login.dfe.api-client/invitations");
+    deleteServiceAccessFromInvitation.mockReset().mockResolvedValue(undefined);
+    getInvitationOrganisationsRaw.mockReset().mockResolvedValue([
+      {
+        organisation: {
+          id: "org-1",
+          name: "Test Organisation",
+        },
+      },
+    ]);
+
+    req.params.uid = "inv-invitation-123";
+
+    await post(req, res);
+
+    expect(deleteServiceAccessFromInvitation).toHaveBeenCalledWith({
+      invitationId: "invitation-123",
+      serviceId: "service-1",
+      organisationId: "org-1",
+    });
+    expect(deleteUserServiceAccess).not.toHaveBeenCalled();
+    // For invitations, no sync notification is sent
+    expect(serviceNotificationsClient.notifyUserUpdated).not.toHaveBeenCalled();
+  });
+
+  it("sends email notification if allowed", async () => {
+    isSupportEmailNotificationAllowed.mockResolvedValue(true);
+
+    await post(req, res);
+
+    expect(notificationClient.sendUserServiceRemoved).toHaveBeenCalledWith(
+      "test@test.com",
+      "test",
+      "name",
+      "Test Service",
+      "Test Organisation",
+    );
+  });
+
+  it("does not send email notification if not allowed", async () => {
+    isSupportEmailNotificationAllowed.mockResolvedValue(false);
+
+    await post(req, res);
+
+    expect(notificationClient.sendUserServiceRemoved).not.toHaveBeenCalled();
+  });
+
+  it("logs audit event on success", async () => {
+    const { audit } = require("./../../../src/infrastructure/logger");
+
+    await post(req, res);
+
+    expect(audit).toHaveBeenCalledTimes(2);
+    // First audit call is from the sync notification
+    expect(audit).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining("WS Sync notification"),
+      expect.objectContaining({
+        type: "support",
+        subType: "user-sync-notify",
+        success: true,
+      }),
+    );
+    // Second audit call is from the main operation
+    expect(audit).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining("removed service"),
+      expect.objectContaining({
+        type: "support",
+        subType: "user-service-deleted",
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- `removeServiceAccess.js`: passes `removedServiceId` and `removedOrgId` to `notifyUserUpdated` so the deactivation job is enqueued correctly
- `postDeleteOrganisation.js`: adds the same WS sync notification when removing a user from an organisation, with retry/audit logging parity
- `utils.js` (`removeAllServicesForUser`): adds the same WS sync notification for bulk/full user deactivation, with retry/audit logging parity
- `tools/giasRolesCheck.js`: passes `removedServiceId`/`removedOrgId` in the GIAS admin script's WS sync notification

The COLLECT-orgs-without-active-users report page has been split out to its own follow-up ticket and is no longer part of this PR.

## Dependency
Deploy `login.dfe.jobs` NSA-9314 PR first.

## Test plan
- [x] NSA-9314 test suites pass (758/758)
- [ ] PP: remove service via Support Console - confirm DEACTIVATE SOAP call fires
- [ ] PP: remove user from organisation - confirm DEACTIVATE SOAP call fires
- [ ] PP: bulk-deactivate a user - confirm DEACTIVATE SOAP call fires per legacy service