### PR TITLE
NSA-9834: Filter approvers to display only active ones in information…

### DIFF
--- a/src/app/users/getOrganisations.js
+++ b/src/app/users/getOrganisations.js
@@ -38,7 +38,7 @@ const getOrganisations = async (userId) => {
   const allApprovers = await getApproverDetails(orgMapping);
   // Filter out all deactivated accounts
   const activeAccountApprovers = allApprovers.filter(
-    (approver) => approver.status !== 0,
+    (approver) => approver.status === 1,
   );
 
   const organisations = await Promise.all(


### PR DESCRIPTION
Changed filtering for approvers in 'information and approvers dropdown' in support/ user/ orgs . We will now only display 'active approvers' which means anyone who was deactivated or invited deactivated won't show within a list.