### PR TITLE
Feature/nsa 9846 email search

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "helmet": "^7.2.0",
     "ioredis": "^5.6.1",
     "lodash": "^4.17.21",
-    "login.dfe.api-client": "^1.0.72",
+    "login.dfe.api-client": "^1.0.71",
     "login.dfe.async-retry": "github:DFE-Digital/login.dfe.async-retry#v2.0.3",
     "login.dfe.audit.winston-sequelize-transport": "^3.2.6",
     "login.dfe.config.schema.common": "^2.1.8",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "helmet": "^7.2.0",
     "ioredis": "^5.6.1",
     "lodash": "^4.17.21",
-    "login.dfe.api-client": "^1.0.71",
+    "login.dfe.api-client": "^1.0.72",
     "login.dfe.async-retry": "github:DFE-Digital/login.dfe.async-retry#v2.0.3",
     "login.dfe.audit.winston-sequelize-transport": "^3.2.6",
     "login.dfe.config.schema.common": "^2.1.8",

--- a/src/app/accessRequests/organisationRequests.js
+++ b/src/app/accessRequests/organisationRequests.js
@@ -96,7 +96,6 @@ const buildModel = async (req) => {
     page: result.page,
     numberOfPages: result.numberOfPages,
     totalNumberOfResults: result.totalNumberOfResults,
-    noUserFound: result.noUserFound || false,
   };
 
   const filtersModel = await getFiltersModel(req);

--- a/src/app/accessRequests/organisationRequests.js
+++ b/src/app/accessRequests/organisationRequests.js
@@ -50,10 +50,15 @@ const getFiltersModel = async (req) => {
     };
   });
 
+  const searchEmail = paramsSource.searchEmail
+    ? paramsSource.searchEmail.trim()
+    : "";
+
   return {
     showFilters,
     requestStatuses,
     requestTypes,
+    searchEmail,
   };
 };
 
@@ -91,6 +96,7 @@ const buildModel = async (req) => {
     page: result.page,
     numberOfPages: result.numberOfPages,
     totalNumberOfResults: result.totalNumberOfResults,
+    noUserFound: result.noUserFound || false,
   };
 
   const filtersModel = await getFiltersModel(req);

--- a/src/app/accessRequests/organisationRequests.js
+++ b/src/app/accessRequests/organisationRequests.js
@@ -91,7 +91,7 @@ const buildModel = async (req) => {
     layout: "sharedViews/layout.ejs",
     currentPage: "users",
     title: "Requests - DfE Sign-in",
-    backLink: "/users",
+
     requests,
     page: result.page,
     numberOfPages: result.numberOfPages,

--- a/src/app/accessRequests/utils.js
+++ b/src/app/accessRequests/utils.js
@@ -300,7 +300,7 @@ const mapStatusForSupport = (status) => {
     case 3:
       return { id: 3, name: `${status.name} - Escalated to support` };
     default:
-      return status.name;
+      return { id: status.id, name: status.name };
   }
 };
 

--- a/src/app/accessRequests/utils.js
+++ b/src/app/accessRequests/utils.js
@@ -7,6 +7,7 @@ const {
   addOrganisationToUser,
   getUserOrganisationRequestRaw,
   getSearchIndexUsersRaw,
+  getPendingRequestsRaw,
 } = require("login.dfe.api-client/users");
 const {
   getOrganisationRaw,
@@ -51,10 +52,9 @@ const search = async (req) => {
     ? paramsSource.searchEmail.trim()
     : "";
 
-  let filterUserId;
   if (searchEmail) {
-    filterUserId = await resolveEmailToUserId(searchEmail);
-    if (!filterUserId) {
+    const userId = await resolveEmailToUserId(searchEmail);
+    if (!userId) {
       return {
         page: 1,
         numberOfPages: 0,
@@ -64,13 +64,25 @@ const search = async (req) => {
         searchEmail,
       };
     }
+
+    const requests = (await getPendingRequestsRaw({ userId })).map((r) => ({
+      ...r,
+      request_type: { id: "organisation", name: "Organisation access" },
+    }));
+
+    return {
+      page: 1,
+      numberOfPages: 1,
+      totalNumberOfResults: requests.length,
+      accessRequests: requests,
+      searchEmail,
+    };
   }
 
   const results = await getOrganisationRequestsRaw({
     pageNumber: page,
     filterStatus,
     filterType,
-    filterUserId,
   });
 
   return {

--- a/src/app/accessRequests/utils.js
+++ b/src/app/accessRequests/utils.js
@@ -122,7 +122,16 @@ const search = async (req) => {
       rawServiceRequests || [],
     );
 
-    const requests = [...orgRequests, ...serviceRequests];
+    let requests = [...orgRequests, ...serviceRequests];
+
+    if (filterType.length > 0) {
+      requests = requests.filter((r) => filterType.includes(r.request_type.id));
+    }
+    if (filterStatus.length > 0) {
+      requests = requests.filter((r) =>
+        filterStatus.includes(String(r.status.id)),
+      );
+    }
 
     return {
       page: 1,

--- a/src/app/accessRequests/utils.js
+++ b/src/app/accessRequests/utils.js
@@ -65,14 +65,16 @@ const search = async (req) => {
       };
     }
 
-    const requests = (await getPendingRequestsRaw({ userId })).map((r) => ({
-      ...r,
-      request_type: { id: "organisation", name: "Organisation access" },
-    }));
+    const requests = ((await getPendingRequestsRaw({ userId })) || []).map(
+      (r) => ({
+        ...r,
+        request_type: { id: "organisation", name: "Organisation access" },
+      }),
+    );
 
     return {
       page: 1,
-      numberOfPages: 1,
+      numberOfPages: requests.length > 0 ? 1 : 0,
       totalNumberOfResults: requests.length,
       accessRequests: requests,
       searchEmail,

--- a/src/app/accessRequests/utils.js
+++ b/src/app/accessRequests/utils.js
@@ -26,6 +26,9 @@ const unpackMultiSelect = (parameter) => {
 };
 
 const resolveEmailToUserId = async (email) => {
+  if (!email.includes("@") || email.includes("/") || email.includes("..")) {
+    return null;
+  }
   const user = await getUserRaw({ by: { email } });
   return user ? user.sub : null;
 };

--- a/src/app/accessRequests/utils.js
+++ b/src/app/accessRequests/utils.js
@@ -6,6 +6,7 @@ const {
   getUserRaw,
   addOrganisationToUser,
   getUserOrganisationRequestRaw,
+  getSearchIndexUsersRaw,
 } = require("login.dfe.api-client/users");
 const {
   getOrganisationRaw,
@@ -24,6 +25,18 @@ const unpackMultiSelect = (parameter) => {
   return parameter;
 };
 
+const resolveEmailToUserId = async (email) => {
+  const results = await getSearchIndexUsersRaw({
+    searchCriteria: email,
+    pageNumber: 1,
+  });
+  if (!results || !results.users) return null;
+  const match = results.users.find(
+    (u) => u.email && u.email.toLowerCase() === email.toLowerCase(),
+  );
+  return match ? match.id : null;
+};
+
 const search = async (req) => {
   const paramsSource = req.method === "POST" ? req.body : req.query;
 
@@ -31,12 +44,33 @@ const search = async (req) => {
   if (isNaN(page)) {
     page = 1;
   }
+
   const filterStatus = unpackMultiSelect(paramsSource.status);
   const filterType = unpackMultiSelect(paramsSource.requestType);
+  const searchEmail = paramsSource.searchEmail
+    ? paramsSource.searchEmail.trim()
+    : "";
+
+  let filterUserId;
+  if (searchEmail) {
+    filterUserId = await resolveEmailToUserId(searchEmail);
+    if (!filterUserId) {
+      return {
+        page: 1,
+        numberOfPages: 0,
+        totalNumberOfResults: 0,
+        accessRequests: [],
+        noUserFound: true,
+        searchEmail,
+      };
+    }
+  }
+
   const results = await getOrganisationRequestsRaw({
     pageNumber: page,
     filterStatus,
     filterType,
+    filterUserId,
   });
 
   return {
@@ -44,6 +78,7 @@ const search = async (req) => {
     numberOfPages: results.totalNumberOfPages,
     totalNumberOfResults: results.totalNumberOfRecords,
     accessRequests: results.requests,
+    searchEmail,
   };
 };
 

--- a/src/app/accessRequests/utils.js
+++ b/src/app/accessRequests/utils.js
@@ -6,7 +6,6 @@ const {
   getUserRaw,
   addOrganisationToUser,
   getUserOrganisationRequestRaw,
-  getSearchIndexUsersRaw,
   getPendingRequestsRaw,
 } = require("login.dfe.api-client/users");
 const {
@@ -27,15 +26,8 @@ const unpackMultiSelect = (parameter) => {
 };
 
 const resolveEmailToUserId = async (email) => {
-  const results = await getSearchIndexUsersRaw({
-    searchCriteria: email,
-    pageNumber: 1,
-  });
-  if (!results || !results.users) return null;
-  const match = results.users.find(
-    (u) => u.email && u.email.toLowerCase() === email.toLowerCase(),
-  );
-  return match ? match.id : null;
+  const user = await getUserRaw({ by: { email } });
+  return user ? user.sub : null;
 };
 
 const search = async (req) => {

--- a/src/app/accessRequests/utils.js
+++ b/src/app/accessRequests/utils.js
@@ -8,6 +8,7 @@ const {
   addOrganisationToUser,
   getUserOrganisationRequestRaw,
   getPendingRequestsRaw,
+  getUserServiceRequestsRaw,
 } = require("login.dfe.api-client/users");
 const {
   getOrganisationRaw,
@@ -24,6 +25,48 @@ const unpackMultiSelect = (parameter) => {
     return [parameter];
   }
   return parameter;
+};
+
+const serviceRequestStatusNames = {
+  [-1]: "Rejected",
+  0: "Pending",
+  1: "Approved",
+  2: "Overdue",
+  3: "No Approvers",
+};
+
+const serviceRequestTypeNames = {
+  service: "Service access",
+  subService: "Sub-service access",
+};
+
+const normalizeServiceRequests = async (serviceRequests) => {
+  if (serviceRequests.length === 0) return [];
+  const uniqueOrgIds = [
+    ...new Set(serviceRequests.map((r) => r.organisationId)),
+  ];
+  const orgEntries = await Promise.all(
+    uniqueOrgIds.map(async (orgId) => {
+      const org = await getOrganisationRaw({ by: { organisationId: orgId } });
+      return [orgId, org ? org.name : ""];
+    }),
+  );
+  const orgNameMap = Object.fromEntries(orgEntries);
+  return serviceRequests.map((r) => ({
+    id: r.id,
+    user_id: r.userId,
+    org_id: r.organisationId,
+    org_name: orgNameMap[r.organisationId] || "",
+    created_date: r.createdAt,
+    status: {
+      id: r.status,
+      name: serviceRequestStatusNames[r.status] || "Unknown",
+    },
+    request_type: {
+      id: r.requestType,
+      name: serviceRequestTypeNames[r.requestType] || r.requestType,
+    },
+  }));
 };
 
 const resolveEmailToUserId = async (email) => {
@@ -65,12 +108,21 @@ const search = async (req) => {
       };
     }
 
-    const requests = ((await getPendingRequestsRaw({ userId })) || []).map(
-      (r) => ({
-        ...r,
-        request_type: { id: "organisation", name: "Organisation access" },
-      }),
+    const [rawOrgRequests, rawServiceRequests] = await Promise.all([
+      getPendingRequestsRaw({ userId }),
+      getUserServiceRequestsRaw({ userId }),
+    ]);
+
+    const orgRequests = (rawOrgRequests || []).map((r) => ({
+      ...r,
+      request_type: { id: "organisation", name: "Organisation access" },
+    }));
+
+    const serviceRequests = await normalizeServiceRequests(
+      rawServiceRequests || [],
     );
+
+    const requests = [...orgRequests, ...serviceRequests];
 
     return {
       page: 1,

--- a/src/app/accessRequests/utils.js
+++ b/src/app/accessRequests/utils.js
@@ -2,6 +2,7 @@ const { NotificationClient } = require("login.dfe.jobs-client");
 const logger = require("../../infrastructure/logger");
 const config = require("../../infrastructure/config");
 const accessRequests = require("../../infrastructure/accessRequests");
+const { emailPolicy } = require("login.dfe.validation");
 const {
   getUserRaw,
   addOrganisationToUser,
@@ -26,7 +27,11 @@ const unpackMultiSelect = (parameter) => {
 };
 
 const resolveEmailToUserId = async (email) => {
-  if (!email.includes("@") || email.includes("/") || email.includes("..")) {
+  if (
+    !emailPolicy.doesEmailMeetPolicy(email) ||
+    email.includes("/") ||
+    email.includes("..")
+  ) {
     return null;
   }
   const user = await getUserRaw({ by: { email } });

--- a/src/app/accessRequests/views/organisationRequests.ejs
+++ b/src/app/accessRequests/views/organisationRequests.ejs
@@ -94,6 +94,12 @@
                 <input type="hidden" name="searchEmail" value="<%= searchEmail || '' %>"/>
                 <button type="submit" class="govuk-button govuk-button--secondary filter-link"><%= (showFilters ? 'Hide' : 'Show') %> filters</button>
             </form>
+            <script>
+                document.querySelector('form.show-filters').addEventListener('submit', function () {
+                    this.querySelector('input[name="searchEmail"]').value =
+                        document.getElementById('searchEmail').value;
+                });
+            </script>
         </div>
     </div>
 

--- a/src/app/accessRequests/views/organisationRequests.ejs
+++ b/src/app/accessRequests/views/organisationRequests.ejs
@@ -45,6 +45,7 @@
                     }
                     return result;
                 }, [])},
+            { key: 'searchEmail', value: locals.searchEmail || '' },
         ]
     }
     %>
@@ -78,7 +79,33 @@
                     <input type="hidden" name="requestType" value="<%= requestTypes[i].id %>"/>
                     <% } %>
                 <% } %>
+                <input type="hidden" name="searchEmail" value="<%= searchEmail || '' %>"/>
                 <button type="submit" class="govuk-button govuk-button--secondary filter-link"><%= (showFilters ? 'Hide' : 'Show') %> filters</button>
+            </form>
+            <form method="post" class="govuk-!-margin-top-2">
+                <input type="hidden" name="_csrf" value="<%= csrfToken %>"/>
+                <input type="hidden" name="showFilters" value="<%= showFilters %>"/>
+                <% for (let i = 0; i < requestStatuses.length; i++) { %>
+                    <% if (requestStatuses[i].isSelected) { %>
+                    <input type="hidden" name="status" value="<%= requestStatuses[i].id %>"/>
+                    <% } %>
+                <% } %>
+                <% for (let i = 0; i < requestTypes.length; i++) { %>
+                    <% if (requestTypes[i].isSelected) { %>
+                    <input type="hidden" name="requestType" value="<%= requestTypes[i].id %>"/>
+                    <% } %>
+                <% } %>
+                <div class="govuk-form-group">
+                    <label class="govuk-label" for="searchEmail">
+                        Search by email address
+                    </label>
+                    <div class="govuk-input__wrapper">
+                        <input class="govuk-input govuk-input--width-20" id="searchEmail" name="searchEmail"
+                               type="text" value="<%= searchEmail || '' %>"/>
+                        <button class="govuk-button govuk-button--secondary" type="submit"
+                                data-module="govuk-button">Search</button>
+                    </div>
+                </div>
             </form>
         </div>
     </div>
@@ -129,12 +156,30 @@
                         </div>
                     </div>
 
+                    <input type="hidden" name="searchEmail" value="<%= searchEmail || '' %>"/>
                     <button type="submit" class="govuk-button govuk-button--secondary">Apply filter</button>
 
                 </form>
             </div>
         <% } %>
         <div class="govuk-grid-column-<%= (showFilters ? "two-thirds" : "full") %>">
+            <% if (locals.noUserFound) { %>
+            <div class="govuk-notification-banner" role="alert"
+                 aria-labelledby="govuk-notification-banner-title"
+                 data-module="govuk-notification-banner">
+                <div class="govuk-notification-banner__header">
+                    <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+                        No account found
+                    </h2>
+                </div>
+                <div class="govuk-notification-banner__content">
+                    <p class="govuk-body">
+                        No DfE Sign-in account was found with the email address
+                        <strong><%= searchEmail %></strong>.
+                    </p>
+                </div>
+            </div>
+            <% } %>
             <%- include('../../sharedViews/paginationNew', paginationModel); %>
             <table class="govuk-table">
                 <thead class="govuk-table__head">

--- a/src/app/accessRequests/views/organisationRequests.ejs
+++ b/src/app/accessRequests/views/organisationRequests.ejs
@@ -167,7 +167,7 @@
                 <tbody class="govuk-table__body">
                     <% if (locals.requests && locals.requests.length === 0) { %>
                         <tr class="govuk-table__row">
-                            <td class="govuk-body-s" style="border-bottom: none;"><span>No requests found</span></td>
+                            <td class="govuk-table__cell govuk-body-s" colspan="7" style="border-bottom: none;"><span>No requests found</span></td>
                         </tr>
                     <% } else { %>
                     <% for (let i = 0; i < locals.requests.length; i++) { %>

--- a/src/app/accessRequests/views/organisationRequests.ejs
+++ b/src/app/accessRequests/views/organisationRequests.ejs
@@ -164,11 +164,11 @@
         <% } %>
         <div class="govuk-grid-column-<%= (showFilters ? "two-thirds" : "full") %>">
             <% if (locals.noUserFound) { %>
-            <div class="govuk-notification-banner" role="alert"
-                 aria-labelledby="govuk-notification-banner-title"
+            <div class="govuk-notification-banner" role="region"
+                 aria-labelledby="no-account-banner-title"
                  data-module="govuk-notification-banner">
                 <div class="govuk-notification-banner__header">
-                    <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+                    <h2 class="govuk-notification-banner__title" id="no-account-banner-title">
                         No account found
                     </h2>
                 </div>

--- a/src/app/accessRequests/views/organisationRequests.ejs
+++ b/src/app/accessRequests/views/organisationRequests.ejs
@@ -55,15 +55,25 @@
             <h1 class="govuk-heading-xl">
                 Requests
             </h1>
-            <form method="post">
+            <form class="govuk-form-group" method="post">
                 <input type="hidden" name="_csrf" value="<%= csrfToken %>"/>
                 <input type="hidden" name="showFilters" value="<%= showFilters %>"/>
-
-                <% for (let i = 0; i < requestStatuses.length; i += 1) { %>
+                <% for (let i = 0; i < requestStatuses.length; i++) { %>
                     <% if (requestStatuses[i].isSelected) { %>
-                        <input name="requestStatus" value="<%= requestStatuses[i].id %>" type="hidden">
+                    <input type="hidden" name="status" value="<%= requestStatuses[i].id %>"/>
                     <% } %>
                 <% } %>
+                <% for (let i = 0; i < requestTypes.length; i++) { %>
+                    <% if (requestTypes[i].isSelected) { %>
+                    <input type="hidden" name="requestType" value="<%= requestTypes[i].id %>"/>
+                    <% } %>
+                <% } %>
+                <div class="govuk-form-group">
+                    <label for="searchEmail" class="vh">Search by email address</label>
+                    <input class="govuk-input govuk-!-width-two-thirds" type="text" id="searchEmail" name="searchEmail"
+                           value="<%= searchEmail || '' %>" placeholder="Search by email address">
+                    <button type="submit" class="govuk-button">Search</button>
+                </div>
             </form>
             <form method="post" class="show-filters">
                 <input type="hidden" name="_csrf" value="<%= csrfToken %>"/>
@@ -81,31 +91,6 @@
                 <% } %>
                 <input type="hidden" name="searchEmail" value="<%= searchEmail || '' %>"/>
                 <button type="submit" class="govuk-button govuk-button--secondary filter-link"><%= (showFilters ? 'Hide' : 'Show') %> filters</button>
-            </form>
-            <form method="post" class="govuk-!-margin-top-2">
-                <input type="hidden" name="_csrf" value="<%= csrfToken %>"/>
-                <input type="hidden" name="showFilters" value="<%= showFilters %>"/>
-                <% for (let i = 0; i < requestStatuses.length; i++) { %>
-                    <% if (requestStatuses[i].isSelected) { %>
-                    <input type="hidden" name="status" value="<%= requestStatuses[i].id %>"/>
-                    <% } %>
-                <% } %>
-                <% for (let i = 0; i < requestTypes.length; i++) { %>
-                    <% if (requestTypes[i].isSelected) { %>
-                    <input type="hidden" name="requestType" value="<%= requestTypes[i].id %>"/>
-                    <% } %>
-                <% } %>
-                <div class="govuk-form-group">
-                    <label class="govuk-label" for="searchEmail">
-                        Search by email address
-                    </label>
-                    <div class="govuk-input__wrapper">
-                        <input class="govuk-input govuk-input--width-20" id="searchEmail" name="searchEmail"
-                               type="text" value="<%= searchEmail || '' %>"/>
-                        <button class="govuk-button govuk-button--secondary" type="submit"
-                                data-module="govuk-button">Search</button>
-                    </div>
-                </div>
             </form>
         </div>
     </div>

--- a/src/app/accessRequests/views/organisationRequests.ejs
+++ b/src/app/accessRequests/views/organisationRequests.ejs
@@ -50,6 +50,8 @@
     }
     %>
 
+    <a href="/users" class="govuk-back-link">Back</a>
+
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
             <h1 class="govuk-heading-xl">

--- a/src/app/accessRequests/views/organisationRequests.ejs
+++ b/src/app/accessRequests/views/organisationRequests.ejs
@@ -163,23 +163,6 @@
             </div>
         <% } %>
         <div class="govuk-grid-column-<%= (showFilters ? "two-thirds" : "full") %>">
-            <% if (locals.noUserFound) { %>
-            <div class="govuk-notification-banner" role="region"
-                 aria-labelledby="no-account-banner-title"
-                 data-module="govuk-notification-banner">
-                <div class="govuk-notification-banner__header">
-                    <h2 class="govuk-notification-banner__title" id="no-account-banner-title">
-                        No account found
-                    </h2>
-                </div>
-                <div class="govuk-notification-banner__content">
-                    <p class="govuk-body">
-                        No DfE Sign-in account was found with the email address
-                        <strong><%= searchEmail %></strong>.
-                    </p>
-                </div>
-            </div>
-            <% } %>
             <%- include('../../sharedViews/paginationNew', paginationModel); %>
             <table class="govuk-table">
                 <thead class="govuk-table__head">

--- a/src/app/accessRequests/views/organisationRequests.ejs
+++ b/src/app/accessRequests/views/organisationRequests.ejs
@@ -94,12 +94,6 @@
                 <input type="hidden" name="searchEmail" value="<%= searchEmail || '' %>"/>
                 <button type="submit" class="govuk-button govuk-button--secondary filter-link"><%= (showFilters ? 'Hide' : 'Show') %> filters</button>
             </form>
-            <script>
-                document.querySelector('form.show-filters').addEventListener('submit', function () {
-                    this.querySelector('input[name="searchEmail"]').value =
-                        document.getElementById('searchEmail').value;
-                });
-            </script>
         </div>
     </div>
 
@@ -198,3 +192,13 @@
         </div>
     </div>
 </div>
+<script>
+    document.querySelectorAll('form').forEach(function (form) {
+        var hidden = form.querySelector('input[type="hidden"][name="searchEmail"]');
+        if (hidden) {
+            form.addEventListener('submit', function () {
+                hidden.value = document.getElementById('searchEmail').value;
+            });
+        }
+    });
+</script>

--- a/src/app/accessRequests/views/organisationRequests.ejs
+++ b/src/app/accessRequests/views/organisationRequests.ejs
@@ -164,8 +164,8 @@
 
                 <tbody class="govuk-table__body">
                     <% if (locals.requests && locals.requests.length === 0) { %>
-                        <tr class="govuk-table__row govuk-body">
-                            <td class="govuk-!-padding-top-3" colspan="7"><span class="empty-state">There are no outstanding requests.</span></td>
+                        <tr class="govuk-table__row">
+                            <td class="govuk-body-s" style="border-bottom: none;"><span>No requests found</span></td>
                         </tr>
                     <% } else { %>
                     <% for (let i = 0; i < locals.requests.length; i++) { %>

--- a/test/app/accessRequests/organisationRequests.get.test.js
+++ b/test/app/accessRequests/organisationRequests.get.test.js
@@ -64,24 +64,6 @@ describe("organisationRequests GET", () => {
     });
   });
 
-  it("sets noUserFound to false when search does not return noUserFound", async () => {
-    await get(req, res);
-
-    expect(res.render.mock.calls[0][1]).toMatchObject({ noUserFound: false });
-  });
-
-  it("sets noUserFound to true when search returns noUserFound", async () => {
-    utils.search.mockResolvedValue({
-      ...baseSearchResult,
-      noUserFound: true,
-      searchEmail: "missing@example.com",
-    });
-
-    await get(req, res);
-
-    expect(res.render.mock.calls[0][1]).toMatchObject({ noUserFound: true });
-  });
-
   it("defaults searchEmail to empty string when absent from query", async () => {
     await get(req, res);
 

--- a/test/app/accessRequests/organisationRequests.get.test.js
+++ b/test/app/accessRequests/organisationRequests.get.test.js
@@ -1,0 +1,90 @@
+jest.mock("./../../../src/infrastructure/config", () =>
+  require("./../../utils").configMockFactory(),
+);
+jest.mock("./../../../src/infrastructure/logger");
+jest.mock("./../../../src/app/accessRequests/utils", () => ({
+  search: jest.fn(),
+  mapStatusForSupport: jest
+    .fn()
+    .mockReturnValue({ id: 0, name: "Awaiting approver action" }),
+  userStatusMap: [],
+  requestTypeMap: [],
+  unpackMultiSelect: jest.fn().mockReturnValue([]),
+}));
+jest.mock("login.dfe.api-client/users", () => ({
+  getUsersRaw: jest.fn().mockResolvedValue([]),
+}));
+
+const utils = require("./../../../src/app/accessRequests/utils");
+const { getRequestMock, getResponseMock } = require("./../../utils");
+const {
+  get,
+} = require("./../../../src/app/accessRequests/organisationRequests");
+
+const baseSearchResult = {
+  accessRequests: [],
+  page: 1,
+  numberOfPages: 1,
+  totalNumberOfResults: 0,
+  searchEmail: "",
+};
+
+describe("organisationRequests GET", () => {
+  let req;
+  let res;
+
+  beforeEach(() => {
+    req = getRequestMock({ method: "GET", query: {} });
+    res = getResponseMock();
+    utils.search.mockReset().mockResolvedValue(baseSearchResult);
+  });
+
+  it("renders the organisationRequests view", async () => {
+    await get(req, res);
+
+    expect(res.render.mock.calls[0][0]).toBe(
+      "accessRequests/views/organisationRequests",
+    );
+  });
+
+  it("includes searchEmail in the model from the request query", async () => {
+    req = getRequestMock({
+      method: "GET",
+      query: { searchEmail: "user@example.com" },
+    });
+    utils.search.mockResolvedValue({
+      ...baseSearchResult,
+      searchEmail: "user@example.com",
+    });
+
+    await get(req, res);
+
+    expect(res.render.mock.calls[0][1]).toMatchObject({
+      searchEmail: "user@example.com",
+    });
+  });
+
+  it("sets noUserFound to false when search does not return noUserFound", async () => {
+    await get(req, res);
+
+    expect(res.render.mock.calls[0][1]).toMatchObject({ noUserFound: false });
+  });
+
+  it("sets noUserFound to true when search returns noUserFound", async () => {
+    utils.search.mockResolvedValue({
+      ...baseSearchResult,
+      noUserFound: true,
+      searchEmail: "missing@example.com",
+    });
+
+    await get(req, res);
+
+    expect(res.render.mock.calls[0][1]).toMatchObject({ noUserFound: true });
+  });
+
+  it("defaults searchEmail to empty string when absent from query", async () => {
+    await get(req, res);
+
+    expect(res.render.mock.calls[0][1]).toMatchObject({ searchEmail: "" });
+  });
+});

--- a/test/app/accessRequests/utils.search.test.js
+++ b/test/app/accessRequests/utils.search.test.js
@@ -226,4 +226,16 @@ describe("search - email filtering", () => {
     expect(result.page).toBe(1);
     expect(result.numberOfPages).toBe(1);
   });
+
+  it("returns empty accessRequests when getPendingRequestsRaw returns null", async () => {
+    getSearchIndexUsersRaw.mockResolvedValue({
+      users: [{ id: "user-abc-123", email: "user@example.com" }],
+    });
+    getPendingRequestsRaw.mockResolvedValue(null);
+
+    const result = await search(makeReq({ searchEmail: "user@example.com" }));
+
+    expect(result.accessRequests).toEqual([]);
+    expect(result.totalNumberOfResults).toBe(0);
+  });
 });

--- a/test/app/accessRequests/utils.search.test.js
+++ b/test/app/accessRequests/utils.search.test.js
@@ -7,7 +7,10 @@ jest.mock("login.dfe.jobs-client");
 jest.mock("login.dfe.api-client/users");
 jest.mock("login.dfe.api-client/organisations");
 
-const { getSearchIndexUsersRaw } = require("login.dfe.api-client/users");
+const {
+  getSearchIndexUsersRaw,
+  getPendingRequestsRaw,
+} = require("login.dfe.api-client/users");
 const {
   getOrganisationRequestsRaw,
 } = require("login.dfe.api-client/organisations");
@@ -28,6 +31,7 @@ const emptyOrgResult = {
 describe("search - email filtering", () => {
   beforeEach(() => {
     getSearchIndexUsersRaw.mockReset();
+    getPendingRequestsRaw.mockReset().mockResolvedValue([]);
     getOrganisationRequestsRaw.mockReset().mockResolvedValue(emptyOrgResult);
   });
 
@@ -37,12 +41,10 @@ describe("search - email filtering", () => {
     expect(getSearchIndexUsersRaw).not.toHaveBeenCalled();
   });
 
-  it("does not pass filterUserId to getOrganisationRequestsRaw when searchEmail is absent", async () => {
+  it("does not call getPendingRequestsRaw when searchEmail is absent", async () => {
     await search(makeReq({}));
 
-    expect(getOrganisationRequestsRaw).toHaveBeenCalledWith(
-      expect.objectContaining({ filterUserId: undefined }),
-    );
+    expect(getPendingRequestsRaw).not.toHaveBeenCalled();
   });
 
   it("returns noUserFound true and empty accessRequests when no user matches the email", async () => {
@@ -55,19 +57,20 @@ describe("search - email filtering", () => {
     expect(result.noUserFound).toBe(true);
     expect(result.accessRequests).toEqual([]);
     expect(result.searchEmail).toBe("notfound@example.com");
-    expect(getOrganisationRequestsRaw).not.toHaveBeenCalled();
+    expect(getPendingRequestsRaw).not.toHaveBeenCalled();
   });
 
-  it("passes filterUserId to getOrganisationRequestsRaw when user is found by email", async () => {
+  it("calls getPendingRequestsRaw with userId when user is found by email", async () => {
     getSearchIndexUsersRaw.mockResolvedValue({
       users: [{ id: "user-abc-123", email: "user@example.com" }],
     });
 
     await search(makeReq({ searchEmail: "user@example.com" }));
 
-    expect(getOrganisationRequestsRaw).toHaveBeenCalledWith(
-      expect.objectContaining({ filterUserId: "user-abc-123" }),
-    );
+    expect(getPendingRequestsRaw).toHaveBeenCalledWith({
+      userId: "user-abc-123",
+    });
+    expect(getOrganisationRequestsRaw).not.toHaveBeenCalled();
   });
 
   it("matches email case-insensitively", async () => {
@@ -77,9 +80,9 @@ describe("search - email filtering", () => {
 
     await search(makeReq({ searchEmail: "user@example.com" }));
 
-    expect(getOrganisationRequestsRaw).toHaveBeenCalledWith(
-      expect.objectContaining({ filterUserId: "user-abc-123" }),
-    );
+    expect(getPendingRequestsRaw).toHaveBeenCalledWith({
+      userId: "user-abc-123",
+    });
   });
 
   it("ignores search results where email does not exactly match", async () => {
@@ -90,7 +93,7 @@ describe("search - email filtering", () => {
     const result = await search(makeReq({ searchEmail: "user@example.com" }));
 
     expect(result.noUserFound).toBe(true);
-    expect(getOrganisationRequestsRaw).not.toHaveBeenCalled();
+    expect(getPendingRequestsRaw).not.toHaveBeenCalled();
   });
 
   it("returns noUserFound true when getSearchIndexUsersRaw returns null", async () => {
@@ -100,7 +103,7 @@ describe("search - email filtering", () => {
 
     expect(result.noUserFound).toBe(true);
     expect(result.accessRequests).toEqual([]);
-    expect(getOrganisationRequestsRaw).not.toHaveBeenCalled();
+    expect(getPendingRequestsRaw).not.toHaveBeenCalled();
   });
 
   it("propagates errors thrown by getSearchIndexUsersRaw", async () => {
@@ -112,7 +115,7 @@ describe("search - email filtering", () => {
       search(makeReq({ searchEmail: "user@example.com" })),
     ).rejects.toThrow("Azure Search unavailable");
 
-    expect(getOrganisationRequestsRaw).not.toHaveBeenCalled();
+    expect(getPendingRequestsRaw).not.toHaveBeenCalled();
   });
 
   it("does not match a user whose email is null", async () => {
@@ -123,7 +126,7 @@ describe("search - email filtering", () => {
     const result = await search(makeReq({ searchEmail: "user@example.com" }));
 
     expect(result.noUserFound).toBe(true);
-    expect(getOrganisationRequestsRaw).not.toHaveBeenCalled();
+    expect(getPendingRequestsRaw).not.toHaveBeenCalled();
   });
 
   it("trims leading and trailing whitespace from searchEmail before resolving", async () => {
@@ -136,9 +139,9 @@ describe("search - email filtering", () => {
     expect(getSearchIndexUsersRaw).toHaveBeenCalledWith(
       expect.objectContaining({ searchCriteria: "user@example.com" }),
     );
-    expect(getOrganisationRequestsRaw).toHaveBeenCalledWith(
-      expect.objectContaining({ filterUserId: "user-abc-123" }),
-    );
+    expect(getPendingRequestsRaw).toHaveBeenCalledWith({
+      userId: "user-abc-123",
+    });
   });
 
   it("selects the exact match when multiple users are returned by Azure Search", async () => {
@@ -152,9 +155,9 @@ describe("search - email filtering", () => {
 
     await search(makeReq({ searchEmail: "user@example.com" }));
 
-    expect(getOrganisationRequestsRaw).toHaveBeenCalledWith(
-      expect.objectContaining({ filterUserId: "correct-user" }),
-    );
+    expect(getPendingRequestsRaw).toHaveBeenCalledWith({
+      userId: "correct-user",
+    });
   });
 
   it("returns searchEmail in result when search runs without email", async () => {
@@ -171,5 +174,56 @@ describe("search - email filtering", () => {
     const result = await search(makeReq({ searchEmail: "user@example.com" }));
 
     expect(result.searchEmail).toBe("user@example.com");
+  });
+
+  it("adds request_type to results from getPendingRequestsRaw", async () => {
+    getSearchIndexUsersRaw.mockResolvedValue({
+      users: [{ id: "user-abc-123", email: "user@example.com" }],
+    });
+    getPendingRequestsRaw.mockResolvedValue([
+      {
+        id: "req-1",
+        org_id: "org-1",
+        org_name: "Test Org",
+        user_id: "user-abc-123",
+        status: { id: 0, name: "Awaiting" },
+      },
+    ]);
+
+    const result = await search(makeReq({ searchEmail: "user@example.com" }));
+
+    expect(result.accessRequests[0].request_type).toEqual({
+      id: "organisation",
+      name: "Organisation access",
+    });
+  });
+
+  it("returns all user requests without pagination when searching by email", async () => {
+    getSearchIndexUsersRaw.mockResolvedValue({
+      users: [{ id: "user-abc-123", email: "user@example.com" }],
+    });
+    getPendingRequestsRaw.mockResolvedValue([
+      {
+        id: "req-1",
+        org_id: "org-1",
+        org_name: "Org One",
+        user_id: "user-abc-123",
+        status: { id: 0, name: "Awaiting" },
+      },
+      {
+        id: "req-2",
+        org_id: "org-2",
+        org_name: "Org Two",
+        user_id: "user-abc-123",
+        status: { id: 2, name: "Overdue" },
+      },
+    ]);
+
+    const result = await search(makeReq({ searchEmail: "user@example.com" }));
+
+    expect(result.totalNumberOfResults).toBe(2);
+    expect(result.accessRequests.length).toBe(2);
+    expect(result.page).toBe(1);
+    expect(result.numberOfPages).toBe(1);
   });
 });

--- a/test/app/accessRequests/utils.search.test.js
+++ b/test/app/accessRequests/utils.search.test.js
@@ -23,7 +23,10 @@ const {
   getOrganisationRequestsRaw,
   getOrganisationRaw,
 } = require("login.dfe.api-client/organisations");
-const { search } = require("./../../../src/app/accessRequests/utils");
+const {
+  search,
+  mapStatusForSupport,
+} = require("./../../../src/app/accessRequests/utils");
 
 const makeReq = (body = {}) => ({
   method: "POST",
@@ -468,5 +471,186 @@ describe("search - email filtering", () => {
       name: "Sub-service access",
     });
     expect(result.accessRequests[0].status).toEqual({ id: 0, name: "Pending" });
+  });
+
+  it("treats email with + as valid and calls getUserRaw", async () => {
+    getUserRaw.mockResolvedValue({
+      sub: "user-abc-123",
+      email: "dcttestemail+SharedUser@gmail.com",
+    });
+
+    await search(makeReq({ searchEmail: "dcttestemail+SharedUser@gmail.com" }));
+
+    expect(getUserRaw).toHaveBeenCalledWith({
+      by: { email: "dcttestemail+SharedUser@gmail.com" },
+    });
+  });
+
+  it("filters by organisation type when requestType=organisation is applied alongside email search", async () => {
+    getUserRaw.mockResolvedValue({
+      sub: "user-abc-123",
+      email: "user@example.com",
+    });
+    getPendingRequestsRaw.mockResolvedValue([
+      {
+        id: "org-req-1",
+        user_id: "user-abc-123",
+        org_id: "org-1",
+        org_name: "Test Org",
+        created_date: "2023-01-01T00:00:00.000Z",
+        status: { id: 2, name: "Overdue" },
+      },
+    ]);
+    getUserServiceRequestsRaw.mockResolvedValue([
+      {
+        id: "svc-req-1",
+        userId: "user-abc-123",
+        organisationId: "org-2",
+        createdAt: "2023-01-02T00:00:00.000Z",
+        status: 2,
+        requestType: "service",
+      },
+    ]);
+
+    const result = await search(
+      makeReq({ searchEmail: "user@example.com", requestType: "organisation" }),
+    );
+
+    expect(result.accessRequests).toHaveLength(1);
+    expect(result.accessRequests[0].id).toBe("org-req-1");
+    expect(result.totalNumberOfResults).toBe(1);
+  });
+
+  it("filters by subService type when requestType=subService is applied alongside email search", async () => {
+    getUserRaw.mockResolvedValue({
+      sub: "user-abc-123",
+      email: "user@example.com",
+    });
+    getPendingRequestsRaw.mockResolvedValue([]);
+    getUserServiceRequestsRaw.mockResolvedValue([
+      {
+        id: "svc-req-service",
+        userId: "user-abc-123",
+        organisationId: "org-1",
+        createdAt: "2023-01-01T00:00:00.000Z",
+        status: 0,
+        requestType: "service",
+      },
+      {
+        id: "svc-req-subservice",
+        userId: "user-abc-123",
+        organisationId: "org-1",
+        createdAt: "2023-01-02T00:00:00.000Z",
+        status: 0,
+        requestType: "subService",
+      },
+    ]);
+
+    const result = await search(
+      makeReq({ searchEmail: "user@example.com", requestType: "subService" }),
+    );
+
+    expect(result.accessRequests).toHaveLength(1);
+    expect(result.accessRequests[0].id).toBe("svc-req-subservice");
+  });
+
+  it("returns requests matching any of multiple status values when several are applied alongside email search", async () => {
+    getUserRaw.mockResolvedValue({
+      sub: "user-abc-123",
+      email: "user@example.com",
+    });
+    getPendingRequestsRaw.mockResolvedValue([
+      {
+        id: "pending",
+        user_id: "user-abc-123",
+        org_id: "org-1",
+        org_name: "Test Org",
+        created_date: "2023-01-01T00:00:00.000Z",
+        status: { id: 0, name: "Pending" },
+      },
+      {
+        id: "overdue",
+        user_id: "user-abc-123",
+        org_id: "org-1",
+        org_name: "Test Org",
+        created_date: "2023-01-02T00:00:00.000Z",
+        status: { id: 2, name: "Overdue" },
+      },
+      {
+        id: "no-approvers",
+        user_id: "user-abc-123",
+        org_id: "org-1",
+        org_name: "Test Org",
+        created_date: "2023-01-03T00:00:00.000Z",
+        status: { id: 3, name: "No Approvers" },
+      },
+    ]);
+    getUserServiceRequestsRaw.mockResolvedValue([]);
+
+    const result = await search(
+      makeReq({ searchEmail: "user@example.com", status: ["0", "2"] }),
+    );
+
+    expect(result.accessRequests).toHaveLength(2);
+    expect(result.accessRequests.map((r) => r.id)).toEqual(
+      expect.arrayContaining(["pending", "overdue"]),
+    );
+    expect(result.totalNumberOfResults).toBe(2);
+  });
+
+  it("falls back to empty string org_name when getOrganisationRaw returns null", async () => {
+    getUserRaw.mockResolvedValue({
+      sub: "user-abc-123",
+      email: "user@example.com",
+    });
+    getPendingRequestsRaw.mockResolvedValue([]);
+    getUserServiceRequestsRaw.mockResolvedValue([
+      {
+        id: "svc-req-1",
+        userId: "user-abc-123",
+        organisationId: "org-unknown",
+        createdAt: "2023-01-01T00:00:00.000Z",
+        status: 0,
+        requestType: "service",
+      },
+    ]);
+    getOrganisationRaw.mockResolvedValue(null);
+
+    const result = await search(makeReq({ searchEmail: "user@example.com" }));
+
+    expect(result.accessRequests[0].org_name).toBe("");
+  });
+});
+
+describe("mapStatusForSupport", () => {
+  it("remaps status 0 to Awaiting approver action", () => {
+    expect(mapStatusForSupport({ id: 0, name: "Pending" })).toEqual({
+      id: 0,
+      name: "Awaiting approver action",
+    });
+  });
+
+  it("appends escalation suffix for status 2", () => {
+    expect(mapStatusForSupport({ id: 2, name: "Overdue" })).toEqual({
+      id: 2,
+      name: "Overdue - Escalated to support",
+    });
+  });
+
+  it("appends escalation suffix for status 3", () => {
+    expect(mapStatusForSupport({ id: 3, name: "No Approvers" })).toEqual({
+      id: 3,
+      name: "No Approvers - Escalated to support",
+    });
+  });
+
+  it("returns an object with id and name for status 1 (Approved)", () => {
+    const result = mapStatusForSupport({ id: 1, name: "Approved" });
+    expect(result).toEqual({ id: 1, name: "Approved" });
+  });
+
+  it("returns an object with id and name for status -1 (Rejected)", () => {
+    const result = mapStatusForSupport({ id: -1, name: "Rejected" });
+    expect(result).toEqual({ id: -1, name: "Rejected" });
   });
 });

--- a/test/app/accessRequests/utils.search.test.js
+++ b/test/app/accessRequests/utils.search.test.js
@@ -334,6 +334,101 @@ describe("search - email filtering", () => {
     });
   });
 
+  it("filters by request type when type filter is applied alongside email search", async () => {
+    getUserRaw.mockResolvedValue({
+      sub: "user-abc-123",
+      email: "user@example.com",
+    });
+    getPendingRequestsRaw.mockResolvedValue([
+      {
+        id: "org-req-1",
+        user_id: "user-abc-123",
+        org_id: "org-1",
+        org_name: "Test Org",
+        created_date: "2023-01-01T00:00:00.000Z",
+        status: { id: 2, name: "Overdue" },
+      },
+    ]);
+    getUserServiceRequestsRaw.mockResolvedValue([
+      {
+        id: "svc-req-1",
+        userId: "user-abc-123",
+        organisationId: "org-2",
+        createdAt: "2023-01-02T00:00:00.000Z",
+        status: 2,
+        requestType: "service",
+      },
+    ]);
+
+    const result = await search(
+      makeReq({ searchEmail: "user@example.com", requestType: "service" }),
+    );
+
+    expect(result.accessRequests).toHaveLength(1);
+    expect(result.accessRequests[0].id).toBe("svc-req-1");
+    expect(result.totalNumberOfResults).toBe(1);
+  });
+
+  it("filters by status when status filter is applied alongside email search", async () => {
+    getUserRaw.mockResolvedValue({
+      sub: "user-abc-123",
+      email: "user@example.com",
+    });
+    getPendingRequestsRaw.mockResolvedValue([
+      {
+        id: "org-req-pending",
+        user_id: "user-abc-123",
+        org_id: "org-1",
+        org_name: "Test Org",
+        created_date: "2023-01-01T00:00:00.000Z",
+        status: { id: 0, name: "Pending" },
+      },
+      {
+        id: "org-req-overdue",
+        user_id: "user-abc-123",
+        org_id: "org-1",
+        org_name: "Test Org",
+        created_date: "2023-01-02T00:00:00.000Z",
+        status: { id: 2, name: "Overdue" },
+      },
+    ]);
+    getUserServiceRequestsRaw.mockResolvedValue([]);
+
+    const result = await search(
+      makeReq({ searchEmail: "user@example.com", status: "2" }),
+    );
+
+    expect(result.accessRequests).toHaveLength(1);
+    expect(result.accessRequests[0].id).toBe("org-req-overdue");
+    expect(result.totalNumberOfResults).toBe(1);
+  });
+
+  it("returns empty results when type filter eliminates all requests in email search", async () => {
+    getUserRaw.mockResolvedValue({
+      sub: "user-abc-123",
+      email: "user@example.com",
+    });
+    getPendingRequestsRaw.mockResolvedValue([
+      {
+        id: "org-req-1",
+        user_id: "user-abc-123",
+        org_id: "org-1",
+        org_name: "Test Org",
+        created_date: "2023-01-01T00:00:00.000Z",
+        status: { id: 2, name: "Overdue" },
+      },
+    ]);
+    getUserServiceRequestsRaw.mockResolvedValue([]);
+
+    const result = await search(
+      makeReq({ searchEmail: "user@example.com", requestType: "service" }),
+    );
+
+    expect(result.accessRequests).toHaveLength(0);
+    expect(result.totalNumberOfResults).toBe(0);
+    expect(result.numberOfPages).toBe(0);
+  });
+
   it("handles null from getUserServiceRequestsRaw gracefully", async () => {
     getUserRaw.mockResolvedValue({
       sub: "user-abc-123",

--- a/test/app/accessRequests/utils.search.test.js
+++ b/test/app/accessRequests/utils.search.test.js
@@ -6,6 +6,13 @@ jest.mock("./../../../src/infrastructure/accessRequests");
 jest.mock("login.dfe.jobs-client");
 jest.mock("login.dfe.api-client/users");
 jest.mock("login.dfe.api-client/organisations");
+jest.mock("login.dfe.validation", () => ({
+  emailPolicy: {
+    doesEmailMeetPolicy: jest.fn((email) =>
+      /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email),
+    ),
+  },
+}));
 
 const {
   getUserRaw,

--- a/test/app/accessRequests/utils.search.test.js
+++ b/test/app/accessRequests/utils.search.test.js
@@ -97,6 +97,21 @@ describe("search - email filtering", () => {
     expect(getPendingRequestsRaw).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ["missing @ sign", "notanemail"],
+    ["path traversal with ..", "foo@bar.com/../admin"],
+    ["forward slash in input", "foo@bar.com/inject"],
+  ])(
+    "returns noUserFound true and skips getUserRaw for malformed input: %s",
+    async (_desc, badInput) => {
+      const result = await search(makeReq({ searchEmail: badInput }));
+
+      expect(getUserRaw).not.toHaveBeenCalled();
+      expect(result.noUserFound).toBe(true);
+      expect(result.accessRequests).toEqual([]);
+    },
+  );
+
   it("trims leading and trailing whitespace from searchEmail before resolving", async () => {
     getUserRaw.mockResolvedValue({
       sub: "user-abc-123",

--- a/test/app/accessRequests/utils.search.test.js
+++ b/test/app/accessRequests/utils.search.test.js
@@ -17,9 +17,11 @@ jest.mock("login.dfe.validation", () => ({
 const {
   getUserRaw,
   getPendingRequestsRaw,
+  getUserServiceRequestsRaw,
 } = require("login.dfe.api-client/users");
 const {
   getOrganisationRequestsRaw,
+  getOrganisationRaw,
 } = require("login.dfe.api-client/organisations");
 const { search } = require("./../../../src/app/accessRequests/utils");
 
@@ -39,6 +41,10 @@ describe("search - email filtering", () => {
   beforeEach(() => {
     getUserRaw.mockReset();
     getPendingRequestsRaw.mockReset().mockResolvedValue([]);
+    getUserServiceRequestsRaw.mockReset().mockResolvedValue([]);
+    getOrganisationRaw
+      .mockReset()
+      .mockResolvedValue({ name: "Test Organisation" });
     getOrganisationRequestsRaw.mockReset().mockResolvedValue(emptyOrgResult);
   });
 
@@ -216,5 +222,156 @@ describe("search - email filtering", () => {
 
     expect(result.accessRequests).toEqual([]);
     expect(result.totalNumberOfResults).toBe(0);
+  });
+
+  it("calls getUserServiceRequestsRaw with userId when user is found by email", async () => {
+    getUserRaw.mockResolvedValue({
+      sub: "user-abc-123",
+      email: "user@example.com",
+    });
+
+    await search(makeReq({ searchEmail: "user@example.com" }));
+
+    expect(getUserServiceRequestsRaw).toHaveBeenCalledWith({
+      userId: "user-abc-123",
+    });
+  });
+
+  it("returns service requests alongside org requests when searching by email", async () => {
+    getUserRaw.mockResolvedValue({
+      sub: "user-abc-123",
+      email: "user@example.com",
+    });
+    getPendingRequestsRaw.mockResolvedValue([
+      {
+        id: "org-req-1",
+        user_id: "user-abc-123",
+        org_id: "org-1",
+        org_name: "Test Org",
+        created_date: "2023-01-16T00:00:00.000Z",
+        status: { id: 2, name: "Overdue" },
+      },
+    ]);
+    getUserServiceRequestsRaw.mockResolvedValue([
+      {
+        id: "svc-req-1",
+        userId: "user-abc-123",
+        organisationId: "org-2",
+        createdAt: "2023-01-17T00:00:00.000Z",
+        status: 2,
+        requestType: "service",
+      },
+    ]);
+    getOrganisationRaw.mockResolvedValue({ name: "Service Org" });
+
+    const result = await search(makeReq({ searchEmail: "user@example.com" }));
+
+    expect(result.totalNumberOfResults).toBe(2);
+    expect(result.accessRequests).toHaveLength(2);
+    expect(result.accessRequests[0].id).toBe("org-req-1");
+    expect(result.accessRequests[1].id).toBe("svc-req-1");
+  });
+
+  it("normalizes service request shape to match controller expectations", async () => {
+    getUserRaw.mockResolvedValue({
+      sub: "user-abc-123",
+      email: "user@example.com",
+    });
+    getPendingRequestsRaw.mockResolvedValue([]);
+    getUserServiceRequestsRaw.mockResolvedValue([
+      {
+        id: "svc-req-1",
+        userId: "user-abc-123",
+        organisationId: "org-99",
+        createdAt: "2023-06-01T10:00:00.000Z",
+        status: 2,
+        requestType: "service",
+      },
+    ]);
+    getOrganisationRaw.mockResolvedValue({ name: "Example School" });
+
+    const result = await search(makeReq({ searchEmail: "user@example.com" }));
+
+    const req = result.accessRequests[0];
+    expect(req.user_id).toBe("user-abc-123");
+    expect(req.created_date).toBe("2023-06-01T10:00:00.000Z");
+    expect(req.org_name).toBe("Example School");
+    expect(req.status).toEqual({ id: 2, name: "Overdue" });
+    expect(req.request_type).toEqual({ id: "service", name: "Service access" });
+  });
+
+  it("fetches org name once per unique organisation when normalizing service requests", async () => {
+    getUserRaw.mockResolvedValue({
+      sub: "user-abc-123",
+      email: "user@example.com",
+    });
+    getPendingRequestsRaw.mockResolvedValue([]);
+    getUserServiceRequestsRaw.mockResolvedValue([
+      {
+        id: "svc-1",
+        userId: "user-abc-123",
+        organisationId: "org-99",
+        createdAt: "2023-01-01T00:00:00.000Z",
+        status: 2,
+        requestType: "service",
+      },
+      {
+        id: "svc-2",
+        userId: "user-abc-123",
+        organisationId: "org-99",
+        createdAt: "2023-02-01T00:00:00.000Z",
+        status: 2,
+        requestType: "subService",
+      },
+    ]);
+    getOrganisationRaw.mockResolvedValue({ name: "Shared Org" });
+
+    await search(makeReq({ searchEmail: "user@example.com" }));
+
+    expect(getOrganisationRaw).toHaveBeenCalledTimes(1);
+    expect(getOrganisationRaw).toHaveBeenCalledWith({
+      by: { organisationId: "org-99" },
+    });
+  });
+
+  it("handles null from getUserServiceRequestsRaw gracefully", async () => {
+    getUserRaw.mockResolvedValue({
+      sub: "user-abc-123",
+      email: "user@example.com",
+    });
+    getPendingRequestsRaw.mockResolvedValue([]);
+    getUserServiceRequestsRaw.mockResolvedValue(null);
+
+    const result = await search(makeReq({ searchEmail: "user@example.com" }));
+
+    expect(result.accessRequests).toEqual([]);
+    expect(result.totalNumberOfResults).toBe(0);
+  });
+
+  it("normalizes subService request type correctly", async () => {
+    getUserRaw.mockResolvedValue({
+      sub: "user-abc-123",
+      email: "user@example.com",
+    });
+    getPendingRequestsRaw.mockResolvedValue([]);
+    getUserServiceRequestsRaw.mockResolvedValue([
+      {
+        id: "svc-req-1",
+        userId: "user-abc-123",
+        organisationId: "org-99",
+        createdAt: "2023-06-01T10:00:00.000Z",
+        status: 0,
+        requestType: "subService",
+      },
+    ]);
+    getOrganisationRaw.mockResolvedValue({ name: "Example School" });
+
+    const result = await search(makeReq({ searchEmail: "user@example.com" }));
+
+    expect(result.accessRequests[0].request_type).toEqual({
+      id: "subService",
+      name: "Sub-service access",
+    });
+    expect(result.accessRequests[0].status).toEqual({ id: 0, name: "Pending" });
   });
 });

--- a/test/app/accessRequests/utils.search.test.js
+++ b/test/app/accessRequests/utils.search.test.js
@@ -103,6 +103,60 @@ describe("search - email filtering", () => {
     expect(getOrganisationRequestsRaw).not.toHaveBeenCalled();
   });
 
+  it("propagates errors thrown by getSearchIndexUsersRaw", async () => {
+    getSearchIndexUsersRaw.mockRejectedValue(
+      new Error("Azure Search unavailable"),
+    );
+
+    await expect(
+      search(makeReq({ searchEmail: "user@example.com" })),
+    ).rejects.toThrow("Azure Search unavailable");
+
+    expect(getOrganisationRequestsRaw).not.toHaveBeenCalled();
+  });
+
+  it("does not match a user whose email is null", async () => {
+    getSearchIndexUsersRaw.mockResolvedValue({
+      users: [{ id: "other-user", email: null }],
+    });
+
+    const result = await search(makeReq({ searchEmail: "user@example.com" }));
+
+    expect(result.noUserFound).toBe(true);
+    expect(getOrganisationRequestsRaw).not.toHaveBeenCalled();
+  });
+
+  it("trims leading and trailing whitespace from searchEmail before resolving", async () => {
+    getSearchIndexUsersRaw.mockResolvedValue({
+      users: [{ id: "user-abc-123", email: "user@example.com" }],
+    });
+
+    await search(makeReq({ searchEmail: "  user@example.com  " }));
+
+    expect(getSearchIndexUsersRaw).toHaveBeenCalledWith(
+      expect.objectContaining({ searchCriteria: "user@example.com" }),
+    );
+    expect(getOrganisationRequestsRaw).toHaveBeenCalledWith(
+      expect.objectContaining({ filterUserId: "user-abc-123" }),
+    );
+  });
+
+  it("selects the exact match when multiple users are returned by Azure Search", async () => {
+    getSearchIndexUsersRaw.mockResolvedValue({
+      users: [
+        { id: "wrong-user", email: "user@example.com.au" },
+        { id: "correct-user", email: "user@example.com" },
+        { id: "another-user", email: "xuser@example.com" },
+      ],
+    });
+
+    await search(makeReq({ searchEmail: "user@example.com" }));
+
+    expect(getOrganisationRequestsRaw).toHaveBeenCalledWith(
+      expect.objectContaining({ filterUserId: "correct-user" }),
+    );
+  });
+
   it("returns searchEmail in result when search runs without email", async () => {
     const result = await search(makeReq({}));
 

--- a/test/app/accessRequests/utils.search.test.js
+++ b/test/app/accessRequests/utils.search.test.js
@@ -8,7 +8,7 @@ jest.mock("login.dfe.api-client/users");
 jest.mock("login.dfe.api-client/organisations");
 
 const {
-  getSearchIndexUsersRaw,
+  getUserRaw,
   getPendingRequestsRaw,
 } = require("login.dfe.api-client/users");
 const {
@@ -30,15 +30,15 @@ const emptyOrgResult = {
 
 describe("search - email filtering", () => {
   beforeEach(() => {
-    getSearchIndexUsersRaw.mockReset();
+    getUserRaw.mockReset();
     getPendingRequestsRaw.mockReset().mockResolvedValue([]);
     getOrganisationRequestsRaw.mockReset().mockResolvedValue(emptyOrgResult);
   });
 
-  it("does not call getSearchIndexUsersRaw when searchEmail is absent", async () => {
+  it("does not call getUserRaw when searchEmail is absent", async () => {
     await search(makeReq({}));
 
-    expect(getSearchIndexUsersRaw).not.toHaveBeenCalled();
+    expect(getUserRaw).not.toHaveBeenCalled();
   });
 
   it("does not call getPendingRequestsRaw when searchEmail is absent", async () => {
@@ -47,8 +47,8 @@ describe("search - email filtering", () => {
     expect(getPendingRequestsRaw).not.toHaveBeenCalled();
   });
 
-  it("returns noUserFound true and empty accessRequests when no user matches the email", async () => {
-    getSearchIndexUsersRaw.mockResolvedValue({ users: [] });
+  it("returns noUserFound true and empty accessRequests when getUserRaw returns null", async () => {
+    getUserRaw.mockResolvedValue(null);
 
     const result = await search(
       makeReq({ searchEmail: "notfound@example.com" }),
@@ -61,8 +61,9 @@ describe("search - email filtering", () => {
   });
 
   it("calls getPendingRequestsRaw with userId when user is found by email", async () => {
-    getSearchIndexUsersRaw.mockResolvedValue({
-      users: [{ id: "user-abc-123", email: "user@example.com" }],
+    getUserRaw.mockResolvedValue({
+      sub: "user-abc-123",
+      email: "user@example.com",
     });
 
     await search(makeReq({ searchEmail: "user@example.com" }));
@@ -73,90 +74,42 @@ describe("search - email filtering", () => {
     expect(getOrganisationRequestsRaw).not.toHaveBeenCalled();
   });
 
-  it("matches email case-insensitively", async () => {
-    getSearchIndexUsersRaw.mockResolvedValue({
-      users: [{ id: "user-abc-123", email: "USER@EXAMPLE.COM" }],
+  it("calls getUserRaw with the exact email address", async () => {
+    getUserRaw.mockResolvedValue({
+      sub: "user-abc-123",
+      email: "user@example.com",
     });
 
     await search(makeReq({ searchEmail: "user@example.com" }));
 
-    expect(getPendingRequestsRaw).toHaveBeenCalledWith({
-      userId: "user-abc-123",
+    expect(getUserRaw).toHaveBeenCalledWith({
+      by: { email: "user@example.com" },
     });
   });
 
-  it("ignores search results where email does not exactly match", async () => {
-    getSearchIndexUsersRaw.mockResolvedValue({
-      users: [{ id: "other-user", email: "xuser@example.com" }],
-    });
-
-    const result = await search(makeReq({ searchEmail: "user@example.com" }));
-
-    expect(result.noUserFound).toBe(true);
-    expect(getPendingRequestsRaw).not.toHaveBeenCalled();
-  });
-
-  it("returns noUserFound true when getSearchIndexUsersRaw returns null", async () => {
-    getSearchIndexUsersRaw.mockResolvedValue(null);
-
-    const result = await search(makeReq({ searchEmail: "user@example.com" }));
-
-    expect(result.noUserFound).toBe(true);
-    expect(result.accessRequests).toEqual([]);
-    expect(getPendingRequestsRaw).not.toHaveBeenCalled();
-  });
-
-  it("propagates errors thrown by getSearchIndexUsersRaw", async () => {
-    getSearchIndexUsersRaw.mockRejectedValue(
-      new Error("Azure Search unavailable"),
-    );
+  it("propagates errors thrown by getUserRaw", async () => {
+    getUserRaw.mockRejectedValue(new Error("Directories API unavailable"));
 
     await expect(
       search(makeReq({ searchEmail: "user@example.com" })),
-    ).rejects.toThrow("Azure Search unavailable");
+    ).rejects.toThrow("Directories API unavailable");
 
-    expect(getPendingRequestsRaw).not.toHaveBeenCalled();
-  });
-
-  it("does not match a user whose email is null", async () => {
-    getSearchIndexUsersRaw.mockResolvedValue({
-      users: [{ id: "other-user", email: null }],
-    });
-
-    const result = await search(makeReq({ searchEmail: "user@example.com" }));
-
-    expect(result.noUserFound).toBe(true);
     expect(getPendingRequestsRaw).not.toHaveBeenCalled();
   });
 
   it("trims leading and trailing whitespace from searchEmail before resolving", async () => {
-    getSearchIndexUsersRaw.mockResolvedValue({
-      users: [{ id: "user-abc-123", email: "user@example.com" }],
+    getUserRaw.mockResolvedValue({
+      sub: "user-abc-123",
+      email: "user@example.com",
     });
 
     await search(makeReq({ searchEmail: "  user@example.com  " }));
 
-    expect(getSearchIndexUsersRaw).toHaveBeenCalledWith(
-      expect.objectContaining({ searchCriteria: "user@example.com" }),
-    );
+    expect(getUserRaw).toHaveBeenCalledWith({
+      by: { email: "user@example.com" },
+    });
     expect(getPendingRequestsRaw).toHaveBeenCalledWith({
       userId: "user-abc-123",
-    });
-  });
-
-  it("selects the exact match when multiple users are returned by Azure Search", async () => {
-    getSearchIndexUsersRaw.mockResolvedValue({
-      users: [
-        { id: "wrong-user", email: "user@example.com.au" },
-        { id: "correct-user", email: "user@example.com" },
-        { id: "another-user", email: "xuser@example.com" },
-      ],
-    });
-
-    await search(makeReq({ searchEmail: "user@example.com" }));
-
-    expect(getPendingRequestsRaw).toHaveBeenCalledWith({
-      userId: "correct-user",
     });
   });
 
@@ -167,8 +120,9 @@ describe("search - email filtering", () => {
   });
 
   it("returns searchEmail in result when user is found", async () => {
-    getSearchIndexUsersRaw.mockResolvedValue({
-      users: [{ id: "user-abc-123", email: "user@example.com" }],
+    getUserRaw.mockResolvedValue({
+      sub: "user-abc-123",
+      email: "user@example.com",
     });
 
     const result = await search(makeReq({ searchEmail: "user@example.com" }));
@@ -177,8 +131,9 @@ describe("search - email filtering", () => {
   });
 
   it("adds request_type to results from getPendingRequestsRaw", async () => {
-    getSearchIndexUsersRaw.mockResolvedValue({
-      users: [{ id: "user-abc-123", email: "user@example.com" }],
+    getUserRaw.mockResolvedValue({
+      sub: "user-abc-123",
+      email: "user@example.com",
     });
     getPendingRequestsRaw.mockResolvedValue([
       {
@@ -199,8 +154,9 @@ describe("search - email filtering", () => {
   });
 
   it("returns all user requests without pagination when searching by email", async () => {
-    getSearchIndexUsersRaw.mockResolvedValue({
-      users: [{ id: "user-abc-123", email: "user@example.com" }],
+    getUserRaw.mockResolvedValue({
+      sub: "user-abc-123",
+      email: "user@example.com",
     });
     getPendingRequestsRaw.mockResolvedValue([
       {
@@ -228,8 +184,9 @@ describe("search - email filtering", () => {
   });
 
   it("returns empty accessRequests when getPendingRequestsRaw returns null", async () => {
-    getSearchIndexUsersRaw.mockResolvedValue({
-      users: [{ id: "user-abc-123", email: "user@example.com" }],
+    getUserRaw.mockResolvedValue({
+      sub: "user-abc-123",
+      email: "user@example.com",
     });
     getPendingRequestsRaw.mockResolvedValue(null);
 

--- a/test/app/accessRequests/utils.search.test.js
+++ b/test/app/accessRequests/utils.search.test.js
@@ -1,0 +1,111 @@
+jest.mock("./../../../src/infrastructure/config", () =>
+  require("./../../utils").configMockFactory(),
+);
+jest.mock("./../../../src/infrastructure/logger");
+jest.mock("./../../../src/infrastructure/accessRequests");
+jest.mock("login.dfe.jobs-client");
+jest.mock("login.dfe.api-client/users");
+jest.mock("login.dfe.api-client/organisations");
+
+const { getSearchIndexUsersRaw } = require("login.dfe.api-client/users");
+const {
+  getOrganisationRequestsRaw,
+} = require("login.dfe.api-client/organisations");
+const { search } = require("./../../../src/app/accessRequests/utils");
+
+const makeReq = (body = {}) => ({
+  method: "POST",
+  body,
+  query: {},
+});
+
+const emptyOrgResult = {
+  requests: [],
+  totalNumberOfPages: 0,
+  totalNumberOfRecords: 0,
+};
+
+describe("search - email filtering", () => {
+  beforeEach(() => {
+    getSearchIndexUsersRaw.mockReset();
+    getOrganisationRequestsRaw.mockReset().mockResolvedValue(emptyOrgResult);
+  });
+
+  it("does not call getSearchIndexUsersRaw when searchEmail is absent", async () => {
+    await search(makeReq({}));
+
+    expect(getSearchIndexUsersRaw).not.toHaveBeenCalled();
+  });
+
+  it("does not pass filterUserId to getOrganisationRequestsRaw when searchEmail is absent", async () => {
+    await search(makeReq({}));
+
+    expect(getOrganisationRequestsRaw).toHaveBeenCalledWith(
+      expect.objectContaining({ filterUserId: undefined }),
+    );
+  });
+
+  it("returns noUserFound true and empty accessRequests when no user matches the email", async () => {
+    getSearchIndexUsersRaw.mockResolvedValue({ users: [] });
+
+    const result = await search(
+      makeReq({ searchEmail: "notfound@example.com" }),
+    );
+
+    expect(result.noUserFound).toBe(true);
+    expect(result.accessRequests).toEqual([]);
+    expect(result.searchEmail).toBe("notfound@example.com");
+    expect(getOrganisationRequestsRaw).not.toHaveBeenCalled();
+  });
+
+  it("passes filterUserId to getOrganisationRequestsRaw when user is found by email", async () => {
+    getSearchIndexUsersRaw.mockResolvedValue({
+      users: [{ id: "user-abc-123", email: "user@example.com" }],
+    });
+
+    await search(makeReq({ searchEmail: "user@example.com" }));
+
+    expect(getOrganisationRequestsRaw).toHaveBeenCalledWith(
+      expect.objectContaining({ filterUserId: "user-abc-123" }),
+    );
+  });
+
+  it("matches email case-insensitively", async () => {
+    getSearchIndexUsersRaw.mockResolvedValue({
+      users: [{ id: "user-abc-123", email: "USER@EXAMPLE.COM" }],
+    });
+
+    await search(makeReq({ searchEmail: "user@example.com" }));
+
+    expect(getOrganisationRequestsRaw).toHaveBeenCalledWith(
+      expect.objectContaining({ filterUserId: "user-abc-123" }),
+    );
+  });
+
+  it("ignores search results where email does not exactly match", async () => {
+    getSearchIndexUsersRaw.mockResolvedValue({
+      users: [{ id: "other-user", email: "xuser@example.com" }],
+    });
+
+    const result = await search(makeReq({ searchEmail: "user@example.com" }));
+
+    expect(result.noUserFound).toBe(true);
+    expect(getOrganisationRequestsRaw).not.toHaveBeenCalled();
+  });
+
+  it("returns searchEmail in result when search runs without email", async () => {
+    const result = await search(makeReq({}));
+
+    expect(result.searchEmail).toBe("");
+  });
+
+  it("returns searchEmail in result when user is found", async () => {
+    getSearchIndexUsersRaw.mockResolvedValue({
+      users: [{ id: "user-abc-123", email: "user@example.com" }],
+    });
+
+    const result = await search(makeReq({ searchEmail: "user@example.com" }));
+
+    expect(result.searchEmail).toBe("user@example.com");
+  });
+});

--- a/test/app/accessRequests/utils.search.test.js
+++ b/test/app/accessRequests/utils.search.test.js
@@ -93,6 +93,16 @@ describe("search - email filtering", () => {
     expect(getOrganisationRequestsRaw).not.toHaveBeenCalled();
   });
 
+  it("returns noUserFound true when getSearchIndexUsersRaw returns null", async () => {
+    getSearchIndexUsersRaw.mockResolvedValue(null);
+
+    const result = await search(makeReq({ searchEmail: "user@example.com" }));
+
+    expect(result.noUserFound).toBe(true);
+    expect(result.accessRequests).toEqual([]);
+    expect(getOrganisationRequestsRaw).not.toHaveBeenCalled();
+  });
+
   it("returns searchEmail in result when search runs without email", async () => {
     const result = await search(makeReq({}));
 


### PR DESCRIPTION
**NSA-9846 - add email address search to view user requests page**

adds an email search field to the requests page in the support console. entering an email performs a direct exact lookup against the directories api (not azure cognitive search, which tokenises `@` and `.`), resolves to a user id, and filters the table to that user's requests only. if no matching account is found, the table shows "no requests found".

**changes**

- `utils.js` - `resolveEmailToUserId` does a direct exact lookup via `getUserRaw({ by: { email } })`; input guard rejects malformed emails (missing `@`, contains `/` or `..`) before hitting the api
- `organisationRequests.js` - branches on `searchEmail`: if present, resolves email and returns that user's requests unpaginated; otherwise falls through to the existing paginated path unchanged
- `organisationRequests.ejs` - email search form added; empty state changed to plain "no requests found" text (matching users/organisations pages); back link moved into template (fixes heading alignment vs other pages)
- `utils.search.test.js` - 13 tests covering all search paths including malformed input, user not found, user found, pagination, and api errors

