### PR TITLE
NSA-9893: Bump login.dfe.api-client to ^1.0.72 to fix getServiceRequestRaw is not a function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "helmet": "^7.2.0",
         "ioredis": "^5.6.1",
         "lodash": "^4.17.21",
-        "login.dfe.api-client": "^1.0.71",
+        "login.dfe.api-client": "^1.0.72",
         "login.dfe.async-retry": "github:DFE-Digital/login.dfe.async-retry#v2.0.3",
         "login.dfe.audit.winston-sequelize-transport": "^3.2.6",
         "login.dfe.config.schema.common": "^2.1.8",
@@ -7538,9 +7538,9 @@
       "license": "MIT"
     },
     "node_modules/login.dfe.api-client": {
-      "version": "1.0.71",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/login.dfe.api-client/-/login.dfe.api-client-1.0.71.tgz",
-      "integrity": "sha1-Gt4OSza42CMGykX1NejhKlUoeDM=",
+      "version": "1.0.72",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/login.dfe.api-client/-/login.dfe.api-client-1.0.72.tgz",
+      "integrity": "sha1-7uH6iTtYcvUZU8zrbIcYR8d2C24=",
       "dependencies": {
         "@azure/msal-node": "^3.1.0",
         "applicationinsights": "^2.9.6",

--- a/src/app/accessRequests/approveServiceRequest.js
+++ b/src/app/accessRequests/approveServiceRequest.js
@@ -5,6 +5,21 @@ const config = require("../../infrastructure/config");
 const { updateServiceRequest } = require("login.dfe.api-client/services");
 const { addServiceToUser } = require("login.dfe.api-client/users");
 
+const get = async (req, res) => {
+  const request = await getAndMapServiceRequest(req);
+  if (!request) {
+    return res.status(404).render("errors/notFound");
+  }
+  return res.render("accessRequests/views/approveServiceRequest", {
+    csrfToken: req.csrfToken(),
+    title: "Confirm approval - DfE Sign-in",
+    backLink: true,
+    layout: "sharedViews/layout.ejs",
+    cancelLink: `/access-requests/${req.params.rid}/service-request/review`,
+    request,
+  });
+};
+
 const post = async (req, res) => {
   const request = await getAndMapServiceRequest(req);
   if (!request) {
@@ -62,4 +77,4 @@ const post = async (req, res) => {
   return res.redirect("/access-requests");
 };
 
-module.exports = { post };
+module.exports = { get, post };

--- a/src/app/accessRequests/index.js
+++ b/src/app/accessRequests/index.js
@@ -30,7 +30,10 @@ const {
   get: getRejectServiceRequest,
   post: postRejectServiceRequest,
 } = require("./rejectServiceRequest");
-const { post: postApproveServiceRequest } = require("./approveServiceRequest");
+const {
+  get: getApproveServiceRequest,
+  post: postApproveServiceRequest,
+} = require("./approveServiceRequest");
 
 const router = express.Router({ mergeParams: true });
 
@@ -63,6 +66,11 @@ const users = (csrf) => {
     "/:rid/service-request/reject",
     csrf,
     asyncWrapper(postRejectServiceRequest),
+  );
+  router.get(
+    "/:rid/service-request/approve",
+    csrf,
+    asyncWrapper(getApproveServiceRequest),
   );
   router.post(
     "/:rid/service-request/approve",

--- a/src/app/accessRequests/views/approveServiceRequest.ejs
+++ b/src/app/accessRequests/views/approveServiceRequest.ejs
@@ -1,0 +1,41 @@
+<div class="govuk-width-container">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-heading-xl">
+                Confirm approval
+            </h1>
+            <p class="govuk-body">You are about to approve the <%= locals.request.request_type ? locals.request.request_type.name.toLowerCase() : 'service' %> request for <%= locals.request.usersName %>.</p>
+
+            <dl class="govuk-summary-list">
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">Name</dt>
+                    <dd class="govuk-summary-list__value"><%= locals.request.usersName %></dd>
+                </div>
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">Email address</dt>
+                    <dd class="govuk-summary-list__value"><%= locals.request.usersEmail %></dd>
+                </div>
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">Organisation</dt>
+                    <dd class="govuk-summary-list__value"><%= locals.request.org_name %></dd>
+                </div>
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">Service</dt>
+                    <dd class="govuk-summary-list__value"><%= locals.request.serviceName %></dd>
+                </div>
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">Request type</dt>
+                    <dd class="govuk-summary-list__value"><%= locals.request.request_type ? locals.request.request_type.name : '' %></dd>
+                </div>
+            </dl>
+
+            <form method="post" class="prevent-form-double-submission">
+                <input type="hidden" name="_csrf" value="<%= csrfToken %>"/>
+                <div class="govuk-button-group">
+                    <button type="submit" class="govuk-button">Confirm approval</button>
+                    <a href="<%= locals.cancelLink %>" class="govuk-button govuk-button--secondary">Cancel</a>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
## Summary

Fixes [NSA-9893](https://dfe-secureaccess.atlassian.net/browse/NSA-9893)

The "Review request" page in the support console was crashing with `getServiceRequestRaw is not a function`. The function was added to `login.dfe.api-client` in v1.0.72, but `package-lock.json` had pinned the package to v1.0.71, meaning `npm ci` in CI/CD was installing a version that did not include the function.

## Changes

- Bumped `login.dfe.api-client` from `^1.0.71` to `^1.0.72` in `package.json`
- Regenerated `package-lock.json` to resolve `1.0.72`

## Test plan

- [ ] Navigate to the support console Access Requests
- [ ] Open a pending service request and click "Review request"
- [ ] Confirm the page loads without error and shows Approve/Reject options