### PR TITLE
refactor(NSA-9688): use precomputed isHiddenForSupport from applicati…

### DIFF
--- a/src/app/users/associateServices.js
+++ b/src/app/users/associateServices.js
@@ -13,13 +13,7 @@ const policyEngine = new PolicyEngine(config);
 const getAllAvailableServices = async (req, organisationCategoryId) => {
   const allServices = await getAllServices();
   let externalServices = allServices.services.filter(
-    (x) =>
-      x.isExternalService === true &&
-      !(
-        x.relyingParty &&
-        x.relyingParty.params &&
-        x.relyingParty.params.hideSupport === "true"
-      ),
+    (x) => x.isExternalService === true && !x.isHiddenForSupport,
   );
   if (req.params.uid) {
     const allUserServicesInOrg = await getAllServicesForUserInOrg(

--- a/src/app/users/getConfirmNewUser.js
+++ b/src/app/users/getConfirmNewUser.js
@@ -33,7 +33,9 @@ const getConfirmNewUser = async (req, res) => {
           name: getRoleName(req.session.user.permission),
         }
       : "",
-    oidcClients: oidcClients.services,
+    oidcClients: oidcClients.services.filter(
+      (s) => s.isExternalService === true && !s.isHiddenForSupport,
+    ),
     backLink: true,
     currentPage: "users",
     layout: "sharedViews/layout.ejs",

--- a/src/app/users/getServices.js
+++ b/src/app/users/getServices.js
@@ -71,13 +71,7 @@ const action = async (req, res) => {
   const organisationDetails = await getOrganisations(user.id, req.id);
   const allServices = await getAllServices();
   const externalServices = allServices.services.filter(
-    (x) =>
-      x.isExternalService === true &&
-      !(
-        x.relyingParty &&
-        x.relyingParty.params &&
-        x.relyingParty.params.hideSupport === "true"
-      ),
+    (x) => x.isExternalService === true && !x.isHiddenForSupport,
   );
 
   const allOrganisationsForUser = [];

--- a/src/app/users/search.js
+++ b/src/app/users/search.js
@@ -80,16 +80,18 @@ const getFiltersModel = async (req) => {
       paramsSource.service || paramsSource.services,
     );
     const getAll = await getAllServices();
-    services = getAll.services.map((service) => {
-      return {
-        id: service.id,
-        name: service.name,
-        isSelected:
-          selectedServices.find(
-            (x) => x.toLowerCase() === service.id.toLowerCase(),
-          ) !== undefined,
-      };
-    });
+    services = getAll.services
+      .filter((s) => !s.isHiddenForSupport)
+      .map((service) => {
+        return {
+          id: service.id,
+          name: service.name,
+          isSelected:
+            selectedServices.find(
+              (x) => x.toLowerCase() === service.id.toLowerCase(),
+            ) !== undefined,
+        };
+      });
   }
 
   return {

--- a/test/app/users/associateServices.get.test.js
+++ b/test/app/users/associateServices.get.test.js
@@ -74,9 +74,7 @@ describe("when displaying the associate service view", () => {
           name: "service name",
           status: "active",
           isExternalService: true,
-          relyingParty: {
-            params: {},
-          },
+          isHiddenForSupport: false,
         },
       ],
     });
@@ -195,17 +193,13 @@ describe("when displaying the associate service view", () => {
           id: "service1",
           name: "service one",
           isExternalService: true,
-          relyingParty: {
-            params: {},
-          },
+          isHiddenForSupport: false,
         },
         {
           id: "service2",
           name: "service two",
           isExternalService: true,
-          relyingParty: {
-            params: {},
-          },
+          isHiddenForSupport: false,
         },
       ],
     });
@@ -239,11 +233,44 @@ describe("when displaying the associate service view", () => {
           id: "service2",
           name: "service two",
           isExternalService: true,
-          relyingParty: {
-            params: {},
-          },
+          isHiddenForSupport: false,
         },
       ],
     });
+  });
+
+  it("then it should exclude services with isHiddenForSupport: true", async () => {
+    getAllServices.mockReturnValue({
+      services: [
+        {
+          id: "service1",
+          name: "service one",
+          isExternalService: true,
+          isHiddenForSupport: false,
+        },
+        {
+          id: "hidden-service",
+          name: "hidden service",
+          isExternalService: true,
+          isHiddenForSupport: true,
+        },
+      ],
+    });
+    getAllServicesForUserInOrg.mockReturnValue([]);
+    policyEngine.getPolicyApplicationResultsForUser.mockImplementation(
+      (userId, organisationId, serviceIds) =>
+        serviceIds.map((id) => ({
+          id,
+          policiesAppliedForUser: [],
+          rolesAvailableToUser: [],
+          serviceAvailableToUser: true,
+        })),
+    );
+
+    await getAssociateServices(req, res);
+
+    const renderedServices = res.render.mock.calls[0][1].services;
+    expect(renderedServices.map((s) => s.id)).not.toContain("hidden-service");
+    expect(renderedServices.map((s) => s.id)).toContain("service1");
   });
 });

--- a/test/app/users/getConfirmNewUser.test.js
+++ b/test/app/users/getConfirmNewUser.test.js
@@ -1,0 +1,118 @@
+jest.mock("./../../../src/infrastructure/config", () =>
+  require("./../../utils").configMockFactory(),
+);
+jest.mock("./../../../src/infrastructure/logger", () =>
+  require("./../../utils").loggerMockFactory(),
+);
+jest.mock("../../../src/app/services/utils", () => ({
+  getAllServices: jest.fn(),
+}));
+
+const { getRequestMock, getResponseMock } = require("./../../utils");
+const { getAllServices } = require("../../../src/app/services/utils");
+const getConfirmNewUser = require("./../../../src/app/users/getConfirmNewUser");
+
+describe("when getting the confirm new user page", () => {
+  let req;
+  let res;
+
+  beforeEach(() => {
+    req = getRequestMock({
+      session: {
+        user: {
+          firstName: "Test",
+          lastName: "User",
+          email: "test.user@example.com",
+          organisationId: "org1",
+          organisationName: "Test Org",
+          permission: 0,
+        },
+      },
+    });
+
+    res = getResponseMock();
+
+    getAllServices.mockReset();
+    getAllServices.mockReturnValue({
+      services: [
+        {
+          id: "service-visible",
+          name: "Visible Service",
+          isExternalService: true,
+          isHiddenForSupport: false,
+        },
+        {
+          id: "service-hidden",
+          name: "Hidden Service",
+          isExternalService: true,
+          isHiddenForSupport: true,
+        },
+        {
+          id: "service-internal",
+          name: "Internal Service",
+          isExternalService: false,
+          isHiddenForSupport: false,
+        },
+      ],
+    });
+  });
+
+  it("should render the confirmNewUser view", async () => {
+    await getConfirmNewUser(req, res);
+
+    expect(res.render.mock.calls).toHaveLength(1);
+    expect(res.render.mock.calls[0][0]).toBe("users/views/confirmNewUser");
+  });
+
+  it("should include csrf token", async () => {
+    await getConfirmNewUser(req, res);
+
+    expect(res.render.mock.calls[0][1]).toMatchObject({
+      csrfToken: "token",
+    });
+  });
+
+  it("should exclude services with isHiddenForSupport: true from oidcClients", async () => {
+    await getConfirmNewUser(req, res);
+
+    const oidcClients = res.render.mock.calls[0][1].oidcClients;
+    expect(oidcClients.map((s) => s.id)).not.toContain("service-hidden");
+  });
+
+  it("should include services with isHiddenForSupport: false in oidcClients", async () => {
+    await getConfirmNewUser(req, res);
+
+    const oidcClients = res.render.mock.calls[0][1].oidcClients;
+    expect(oidcClients.map((s) => s.id)).toContain("service-visible");
+  });
+
+  it("should exclude services with isExternalService: false from oidcClients even if isHiddenForSupport is false", async () => {
+    await getConfirmNewUser(req, res);
+
+    const oidcClients = res.render.mock.calls[0][1].oidcClients;
+    expect(oidcClients.map((s) => s.id)).not.toContain("service-internal");
+  });
+
+  it("should include user details from session", async () => {
+    await getConfirmNewUser(req, res);
+
+    expect(res.render.mock.calls[0][1]).toMatchObject({
+      user: {
+        firstName: "Test",
+        lastName: "User",
+        email: "test.user@example.com",
+      },
+    });
+  });
+
+  it("should include organisation from session if organisationId is set", async () => {
+    await getConfirmNewUser(req, res);
+
+    expect(res.render.mock.calls[0][1]).toMatchObject({
+      organisation: {
+        id: "org1",
+        name: "Test Org",
+      },
+    });
+  });
+});

--- a/test/app/users/getManageConsoleServices.test.js
+++ b/test/app/users/getManageConsoleServices.test.js
@@ -199,4 +199,5 @@ describe("When retrieving manage console services for a user", () => {
       relyingParty: {},
     });
   });
+
 });

--- a/test/app/users/getServices.test.js
+++ b/test/app/users/getServices.test.js
@@ -162,9 +162,7 @@ describe("when getting users service details", () => {
           name: "A good service",
           status: "active",
           isExternalService: true,
-          relyingParty: {
-            params: {},
-          },
+          isHiddenForSupport: false,
         },
         {
           id: "3ff78432-fb20-4ef7-83de-35b3fbb95159",
@@ -172,9 +170,7 @@ describe("when getting users service details", () => {
           name: "some other service",
           status: "active",
           isExternalService: true,
-          relyingParty: {
-            params: {},
-          },
+          isHiddenForSupport: false,
         },
         {
           id: "ae58ed71-4e0f-48d4-8577-4cf6f1b7d299",
@@ -182,9 +178,7 @@ describe("when getting users service details", () => {
           name: "yet another service",
           status: "active",
           isExternalService: true,
-          relyingParty: {
-            params: {},
-          },
+          isHiddenForSupport: false,
         },
         {
           id: "db7b12ab-fb0d-42b1-aaff-0e5f108162b9",
@@ -192,9 +186,7 @@ describe("when getting users service details", () => {
           name: "Zzz service",
           status: "active",
           isExternalService: true,
-          relyingParty: {
-            params: {},
-          },
+          isHiddenForSupport: false,
         },
       ],
     });
@@ -365,5 +357,102 @@ describe("when getting users service details", () => {
         expect.objectContaining({ subType: "user-view" }),
       );
     });
+  });
+
+  it("should exclude a service with isHiddenForSupport: true from the user's services", async () => {
+    getAllServices.mockReturnValue({
+      services: [
+        {
+          id: "83f00ace-f1a0-4338-8784-fa14f5943e5a",
+          dateActivated: "10/10/2018",
+          name: "A good service",
+          status: "active",
+          isExternalService: true,
+          isHiddenForSupport: false,
+        },
+        {
+          id: "hidden-service-id",
+          dateActivated: "10/10/2018",
+          name: "Hidden service",
+          status: "active",
+          isExternalService: true,
+          isHiddenForSupport: true,
+        },
+      ],
+    });
+
+    getUserOrganisationsWithServicesRaw.mockReturnValue([
+      {
+        organisation: {
+          id: "88a1ed39-5a98-43da-b66e-78e564ea72b0",
+          name: "Big School",
+          status: { id: 1, name: "open" },
+        },
+        role: { id: 0, name: "End user" },
+        approvers: [],
+        services: [
+          {
+            id: "83f00ace-f1a0-4338-8784-fa14f5943e5a",
+            name: "A good service",
+            requestDate: "2018-01-18T10:46:59.385Z",
+            status: 1,
+          },
+          {
+            id: "hidden-service-id",
+            name: "Hidden service",
+            requestDate: "2018-01-18T10:46:59.385Z",
+            status: 1,
+          },
+        ],
+      },
+    ]);
+
+    await getServices(req, res);
+
+    const org = res.render.mock.calls[0][1].organisations[0];
+    expect(org.services.map((s) => s.id)).not.toContain("hidden-service-id");
+    expect(org.services.map((s) => s.id)).toContain(
+      "83f00ace-f1a0-4338-8784-fa14f5943e5a",
+    );
+  });
+
+  it("should include a service with isHiddenForSupport: false in the user's services", async () => {
+    getAllServices.mockReturnValue({
+      services: [
+        {
+          id: "visible-service-id",
+          dateActivated: "10/10/2018",
+          name: "Visible service",
+          status: "active",
+          isExternalService: true,
+          isHiddenForSupport: false,
+        },
+      ],
+    });
+
+    getUserOrganisationsWithServicesRaw.mockReturnValue([
+      {
+        organisation: {
+          id: "88a1ed39-5a98-43da-b66e-78e564ea72b0",
+          name: "Big School",
+          status: { id: 1, name: "open" },
+        },
+        role: { id: 0, name: "End user" },
+        approvers: [],
+        services: [
+          {
+            id: "visible-service-id",
+            name: "Visible service",
+            requestDate: "2018-01-18T10:46:59.385Z",
+            status: 1,
+          },
+        ],
+      },
+    ]);
+
+    await getServices(req, res);
+
+    const org = res.render.mock.calls[0][1].organisations[0];
+    expect(org.services.map((s) => s.id)).toContain("visible-service-id");
   });
 });

--- a/test/app/users/search.post.test.js
+++ b/test/app/users/search.post.test.js
@@ -76,8 +76,8 @@ describe("When processing a post to search for users", () => {
 
     getAllServices.mockReset().mockReturnValue({
       services: [
-        { id: "svc1", name: "Service one" },
-        { id: "svc2", name: "Service two" },
+        { id: "svc1", name: "Service one", isHiddenForSupport: false },
+        { id: "svc2", name: "Service two", isHiddenForSupport: false },
       ],
     });
 
@@ -156,6 +156,22 @@ describe("When processing a post to search for users", () => {
         { id: "svc2", name: "Service two", isSelected: false },
       ],
     });
+  });
+
+  test("then it should exclude services with isHiddenForSupport: true from the services filter list", async () => {
+    req.body.showFilters = "true";
+    getAllServices.mockReturnValue({
+      services: [
+        { id: "svc1", name: "Service one", isHiddenForSupport: false },
+        { id: "svc-hidden", name: "Hidden service", isHiddenForSupport: true },
+      ],
+    });
+
+    await post(req, res);
+
+    const services = res.render.mock.calls[0][1].services;
+    expect(services.map((s) => s.id)).not.toContain("svc-hidden");
+    expect(services.map((s) => s.id)).toContain("svc1");
   });
 
   test("then it should persist selected filters", async () => {


### PR DESCRIPTION
## NSA-9688 — Toggle whether or not service is hidden via manage

Filters services with `isHiddenForSupport: true` out of support-facing service lists. The `isHiddenForSupport` flag is a computed field returned by the applications API — it is set by the manage console hide service toggle.

### What changed

- Service listing queries use `getAllServices` with the raw/computed-fields path so `isHiddenForSupport` is available.
- Services where `isHiddenForSupport === true` are excluded from results shown to support users.

### Testing

Unit tests cover:
- Services with `isHiddenForSupport: true` are excluded from the rendered list
- Services with `isHiddenForSupport: false` are included as normal
