### PR TITLE
NSA-9922: Fix ghost search field on Users and Organisations filter pages

### DIFF
--- a/src/app/organisations/views/search.ejs
+++ b/src/app/organisations/views/search.ejs
@@ -206,4 +206,15 @@ const organisationStatusesQuery = locals.organisationStatuses.filter(x => x.isSe
             </div>
         <% } %>
     </div>
-</div>    
+</div>
+<script>
+    document.querySelectorAll('form').forEach(function (form) {
+        var hidden = form.querySelector('input[type="hidden"][name="criteria"]');
+        if (hidden) {
+            form.addEventListener('submit', function () {
+                hidden.value = document.getElementById('criteria').value;
+            });
+        }
+    });
+</script>
+

--- a/src/app/users/views/search.ejs
+++ b/src/app/users/views/search.ejs
@@ -304,3 +304,14 @@ if (services && services.length > 0) {
     <% } %>
   </div>
 </div>
+
+<script>
+    document.querySelectorAll('form').forEach(function (form) {
+        var hidden = form.querySelector('input[type="hidden"][name="criteria"]');
+        if (hidden) {
+            form.addEventListener('submit', function () {
+                hidden.value = document.getElementById('criteria').value;
+            });
+        }
+    });
+</script>


### PR DESCRIPTION
## Summary
- Fixes a bug where clearing the search field on the Users or Organisations pages and then clicking "Show filters" or "Apply filter" caused the old search term to reappear.
- Root cause: the "show filters" and "apply filter" forms carry a server-rendered hidden `criteria` field that goes stale once the user clears the visible input client-side. Submitting either form resubmitted the stale value.
- Adds an inline sync script (identical pattern already verified in production via NSA-9846) to `src/app/users/views/search.ejs` and `src/app/organisations/views/search.ejs` that copies the live visible input value into the hidden `criteria` field on submit.

## Test Plan
- [x] Full test suite passes: 106 suites / 706 tests, 0 failures
- [x] Manual verification on `/users`: search, clear, click "Show filters" - field stays empty
- [x] Manual verification on `/users`: search, clear, check a filter, click "Apply filter" - field stays empty
- [x] Manual verification on `/organisations`: repeat both checks above
- [x] Regression check: search, click "Show filters" WITHOUT clearing - term persists (fix doesn't break existing behaviour)

Ticket: https://dfe-secureaccess.atlassian.net/browse/NSA-9922
